### PR TITLE
Use correct job name for silk-cni in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The components in this release used to be a part of CF Networking Release. To us
 This release contains the following jobs:
 - `silk-controller`
 - `silk-daemon`
-- `cni`
+- `silk-cni`
 - `netmon`
 - `vxlan-policy-agent`
 - `iptables-logger`


### PR DESCRIPTION
The `cni` job is called `silk-cni` in the job template.