### PR TITLE
Add initial, basic vxlan-policy-agent for Windows 

### DIFF
--- a/src/lib/policy_client/internal_policy_client.go
+++ b/src/lib/policy_client/internal_policy_client.go
@@ -23,20 +23,21 @@ func NewInternal(logger lager.Logger, httpClient json_client.HttpClient, baseURL
 	}
 }
 
-func (c *InternalClient) GetPolicies() ([]Policy, error) {
+func (c *InternalClient) GetPolicies() ([]Policy, []EgressPolicy, error) {
 	var policies struct {
-		Policies []Policy `json:"policies"`
+		Policies       []Policy       `json:"policies"`
+		EgressPolicies []EgressPolicy `json:"egress_policies"`
 	}
 	err := c.JsonClient.Do("GET", "/networking/v1/internal/policies", nil, &policies, "")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return policies.Policies, nil
+	return policies.Policies, policies.EgressPolicies, nil
 }
 
 func (c *InternalClient) GetPoliciesByID(ids ...string) ([]Policy, []EgressPolicy, error) {
 	var policies struct {
-		Policies []Policy `json:"policies"`
+		Policies       []Policy       `json:"policies"`
 		EgressPolicies []EgressPolicy `json:"egress_policies"`
 	}
 	if len(ids) == 0 {

--- a/src/vxlan-policy-agent/cmd/vxlan-policy-agent-windows/main.go
+++ b/src/vxlan-policy-agent/cmd/vxlan-policy-agent-windows/main.go
@@ -64,10 +64,11 @@ func main() {
 		conf.PolicyServerURL,
 	)
 
-	policies, err := policyClient.GetPolicies()
+	policies, egressPolicies, err := policyClient.GetPolicies()
 	if err != nil {
 		die(logger, "policy-client-get-policies", err)
 	}
 
 	logger.Info("policies", lager.Data{"policies": policies})
+	logger.Info("policies", lager.Data{"egress_policies": egressPolicies})
 }

--- a/src/vxlan-policy-agent/cmd/vxlan-policy-agent-windows/main.go
+++ b/src/vxlan-policy-agent/cmd/vxlan-policy-agent-windows/main.go
@@ -4,11 +4,16 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
+	"os"
+	"time"
 
 	"lib/common"
+	"lib/policy_client"
 
 	"vxlan-policy-agent/config"
 
+	"code.cloudfoundry.org/cf-networking-helpers/mutualtls"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagerflags"
 )
@@ -21,11 +26,10 @@ var (
 	logPrefix = "cfnetworking"
 )
 
-//
-// func die(logger lager.Logger, action string, err error) {
-// 	logger.Error(action, err)
-// 	os.Exit(1)
-// }
+func die(logger lager.Logger, action string, err error) {
+	logger.Error(action, err)
+	os.Exit(1)
+}
 
 func main() {
 	configFilePath := flag.String("config-file", "", "path to config file")
@@ -35,189 +39,35 @@ func main() {
 	if err != nil {
 		log.Fatalf("%s: could not read config file %s", logPrefix, err)
 	}
-	//
-	// if conf.LogPrefix != "" {
-	// 	logPrefix = conf.LogPrefix
-	// }
-	//
+
 	logger, _ := lagerflags.NewFromConfig(fmt.Sprintf("%s.%s", logPrefix, jobPrefix), common.GetLagerConfig())
 
 	logger.Info("parsed-config", lager.Data{"config": conf})
-	//
-	// pollInterval := time.Duration(conf.PollInterval) * time.Second
-	// if pollInterval == 0 {
-	// 	pollInterval = time.Second
-	// }
-	//
-	// clientTLSConfig, err := mutualtls.NewClientTLSConfig(conf.ClientCertFile, conf.ClientKeyFile, conf.ServerCACertFile)
-	// if err != nil {
-	// 	die(logger, "mutual tls config", err)
-	// }
-	//
-	// httpClient := &http.Client{
-	// 	Transport: &http.Transport{
-	// 		TLSClientConfig: clientTLSConfig,
-	// 	},
-	// 	Timeout: time.Duration(conf.ClientTimeoutSeconds) * time.Second,
-	// }
-	//
-	// policyClient := policy_client.NewInternal(
-	// 	logger.Session("policy-client"),
-	// 	httpClient,
-	// 	conf.PolicyServerURL,
-	// )
-	//
-	// _, err = policyClient.GetPolicies()
-	//
-	// if err != nil {
-	// 	die(logger, "policy-client-get-policies", err)
-	// }
-	//
-	// store := &datastore.Store{
-	// 	Serializer: &serial.Serial{},
-	// 	Locker: &filelock.Locker{
-	// 		FileLocker: filelock.NewLocker(conf.Datastore + "_lock"),
-	// 		Mutex:      new(sync.Mutex),
-	// 	},
-	// 	DataFilePath:    conf.Datastore,
-	// 	VersionFilePath: conf.Datastore + "_version",
-	// 	LockedFilePath:  conf.Datastore + "_lock",
-	// 	CacheMutex:      new(sync.RWMutex),
-	// }
-	//
-	// ipt, err := iptables.New()
-	// if err != nil {
-	// 	die(logger, "iptables-new", err)
-	// }
-	//
-	// iptLocker := &filelock.Locker{
-	// 	FileLocker: filelock.NewLocker(conf.IPTablesLockFile),
-	// 	Mutex:      &sync.Mutex{},
-	// }
-	// restorer := &rules.Restorer{}
-	// lockedIPTables := &rules.LockedIPTables{
-	// 	IPTables: ipt,
-	// 	Locker:   iptLocker,
-	// 	Restorer: restorer,
-	// }
-	//
-	// metricsSender := &metrics.MetricsSender{
-	// 	Logger: logger.Session("time-metric-emitter"),
-	// }
-	//
-	// iptablesLoggingState := &planner.LoggingState{}
-	// if conf.IPTablesLogging {
-	// 	iptablesLoggingState.Enable()
-	// }
-	//
-	// dynamicPlanner := &planner.VxlanPolicyPlanner{
-	// 	Datastore:     store,
-	// 	PolicyClient:  policyClient,
-	// 	Logger:        logger.Session("rules-updater"),
-	// 	VNI:           conf.VNI,
-	// 	MetricsSender: metricsSender,
-	// 	Chain: enforcer.Chain{
-	// 		Table:       "filter",
-	// 		ParentChain: "FORWARD",
-	// 		Prefix:      "vpa--",
-	// 	},
-	// 	LoggingState:                  iptablesLoggingState,
-	// 	IPTablesAcceptedUDPLogsPerSec: conf.IPTablesAcceptedUDPLogsPerSec,
-	// 	EnableOverlayIngressRules:     conf.EnableOverlayIngressRules,
-	// }
-	//
-	// timestamper := &enforcer.Timestamper{}
-	// ruleEnforcer := enforcer.NewEnforcer(
-	// 	logger.Session("rules-enforcer"),
-	// 	timestamper,
-	// 	lockedIPTables,
-	// 	enforcer.EnforcerConfig{
-	// 		DisableContainerNetworkPolicy: conf.DisableContainerNetworkPolicy,
-	// 		OverlayNetwork:                conf.OverlayNetwork,
-	// 	},
-	// )
-	//
-	// err = dropsonde.Initialize(conf.MetronAddress, dropsondeOrigin)
-	// if err != nil {
-	// 	log.Fatalf("%s: initializing dropsonde: %s", logPrefix, err)
-	// }
-	//
-	// uptimeSource := metrics.NewUptimeSource()
-	// metricsEmitter := metrics.NewMetricsEmitter(logger, emitInterval, uptimeSource)
-	//
-	// pollCycleFunc := (&converger.SinglePollCycle{
-	// 	Planners: []converger.Planner{
-	// 		dynamicPlanner,
-	// 	},
-	// 	Enforcer:      ruleEnforcer,
-	// 	MetricsSender: metricsSender,
-	// 	Logger:        logger,
-	// 	Mutex:         new(sync.Mutex),
-	// }).DoCycle
-	//
-	// policyPoller := &poller.Poller{
-	// 	Logger:          logger,
-	// 	PollInterval:    pollInterval,
-	// 	SingleCycleFunc: pollCycleFunc,
-	// }
-	//
-	// forcePolicyPollCycleServerAddress := fmt.Sprintf("%s:%d", conf.ForcePolicyPollCycleHost, conf.ForcePolicyPollCyclePort)
-	// forcePolicyPollCycleServer := createForcePolicyPollCycleServer(forcePolicyPollCycleServerAddress, pollCycleFunc)
-	//
-	// debugServerAddress := fmt.Sprintf("%s:%d", conf.DebugServerHost, conf.DebugServerPort)
-	// debugServer := createCustomDebugServer(debugServerAddress, reconfigurableSink, iptablesLoggingState)
-	// members := grouper.Members{
-	// 	{"metrics_emitter", metricsEmitter},
-	// 	{"policy_poller", policyPoller},
-	// 	{"debug-server", debugServer},
-	// 	{"force-policy-poll-cycle-server", forcePolicyPollCycleServer},
-	// }
-	//
-	// monitor := ifrit.Invoke(sigmon.New(grouper.NewOrdered(os.Interrupt, members)))
-	logger.Info("starting")
-	// err = <-monitor.Wait()
-	// if err != nil {
-	// 	die(logger, "ifrit monitor", err)
-	// }
-}
 
-// const (
-// 	DEBUG = "debug"
-// 	INFO  = "info"
-// 	ERROR = "error"
-// 	FATAL = "fatal"
-// )
-//
-// func initLoggerSink(logger lager.Logger, level string) *lager.ReconfigurableSink {
-// 	var logLevel lager.LogLevel
-// 	switch strings.ToLower(level) {
-// 	case DEBUG:
-// 		logLevel = lager.DEBUG
-// 	case INFO:
-// 		logLevel = lager.INFO
-// 	case ERROR:
-// 		logLevel = lager.ERROR
-// 	case FATAL:
-// 		logLevel = lager.FATAL
-// 	default:
-// 		logLevel = lager.INFO
-// 	}
-// 	w := lager.NewWriterSink(os.Stdout, lager.DEBUG)
-// 	return lager.NewReconfigurableSink(w, logLevel)
-// }
-//
-// func createCustomDebugServer(listenAddress string, sink *lager.ReconfigurableSink, iptablesLoggingState *planner.LoggingState) ifrit.Runner {
-// 	mux := debugserver.Handler(sink).(*http.ServeMux)
-// 	mux.Handle("/iptables-c2c-logging", &handlers.IPTablesLogging{
-// 		LoggingState: iptablesLoggingState,
-// 	})
-// 	return http_server.New(listenAddress, mux)
-// }
-//
-// func createForcePolicyPollCycleServer(listenAddress string, pollCycleFunc func() error) ifrit.Runner {
-// 	mux := http.NewServeMux()
-// 	mux.Handle("/force-policy-poll-cycle", &handlers.ForcePolicyPollCycle{
-// 		PollCycleFunc: pollCycleFunc,
-// 	})
-// 	return http_server.New(listenAddress, mux)
-// }
+	logger.Info("starting")
+
+	clientTLSConfig, err := mutualtls.NewClientTLSConfig(conf.ClientCertFile, conf.ClientKeyFile, conf.ServerCACertFile)
+	if err != nil {
+		die(logger, "mutual tls config", err)
+	}
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: clientTLSConfig,
+		},
+		Timeout: time.Duration(conf.ClientTimeoutSeconds) * time.Second,
+	}
+
+	policyClient := policy_client.NewInternal(
+		logger.Session("policy-client"),
+		httpClient,
+		conf.PolicyServerURL,
+	)
+
+	policies, err := policyClient.GetPolicies()
+	if err != nil {
+		die(logger, "policy-client-get-policies", err)
+	}
+
+	logger.Info("policies", lager.Data{"policies": policies})
+}

--- a/src/vxlan-policy-agent/cmd/vxlan-policy-agent-windows/main.go
+++ b/src/vxlan-policy-agent/cmd/vxlan-policy-agent-windows/main.go
@@ -70,5 +70,5 @@ func main() {
 	}
 
 	logger.Info("policies", lager.Data{"policies": policies})
-	logger.Info("policies", lager.Data{"egress_policies": egressPolicies})
+	logger.Info("egress_policies", lager.Data{"egress_policies": egressPolicies})
 }

--- a/src/vxlan-policy-agent/cmd/vxlan-policy-agent-windows/main.go
+++ b/src/vxlan-policy-agent/cmd/vxlan-policy-agent-windows/main.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	"lib/common"
+
+	"vxlan-policy-agent/config"
+
+	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/lager/lagerflags"
+)
+
+const (
+	jobPrefix = "vxlan-policy-agent"
+)
+
+var (
+	logPrefix = "cfnetworking"
+)
+
+//
+// func die(logger lager.Logger, action string, err error) {
+// 	logger.Error(action, err)
+// 	os.Exit(1)
+// }
+
+func main() {
+	configFilePath := flag.String("config-file", "", "path to config file")
+	flag.Parse()
+
+	conf, err := config.New(*configFilePath)
+	if err != nil {
+		log.Fatalf("%s: could not read config file %s", logPrefix, err)
+	}
+	//
+	// if conf.LogPrefix != "" {
+	// 	logPrefix = conf.LogPrefix
+	// }
+	//
+	logger, _ := lagerflags.NewFromConfig(fmt.Sprintf("%s.%s", logPrefix, jobPrefix), common.GetLagerConfig())
+
+	logger.Info("parsed-config", lager.Data{"config": conf})
+	//
+	// pollInterval := time.Duration(conf.PollInterval) * time.Second
+	// if pollInterval == 0 {
+	// 	pollInterval = time.Second
+	// }
+	//
+	// clientTLSConfig, err := mutualtls.NewClientTLSConfig(conf.ClientCertFile, conf.ClientKeyFile, conf.ServerCACertFile)
+	// if err != nil {
+	// 	die(logger, "mutual tls config", err)
+	// }
+	//
+	// httpClient := &http.Client{
+	// 	Transport: &http.Transport{
+	// 		TLSClientConfig: clientTLSConfig,
+	// 	},
+	// 	Timeout: time.Duration(conf.ClientTimeoutSeconds) * time.Second,
+	// }
+	//
+	// policyClient := policy_client.NewInternal(
+	// 	logger.Session("policy-client"),
+	// 	httpClient,
+	// 	conf.PolicyServerURL,
+	// )
+	//
+	// _, err = policyClient.GetPolicies()
+	//
+	// if err != nil {
+	// 	die(logger, "policy-client-get-policies", err)
+	// }
+	//
+	// store := &datastore.Store{
+	// 	Serializer: &serial.Serial{},
+	// 	Locker: &filelock.Locker{
+	// 		FileLocker: filelock.NewLocker(conf.Datastore + "_lock"),
+	// 		Mutex:      new(sync.Mutex),
+	// 	},
+	// 	DataFilePath:    conf.Datastore,
+	// 	VersionFilePath: conf.Datastore + "_version",
+	// 	LockedFilePath:  conf.Datastore + "_lock",
+	// 	CacheMutex:      new(sync.RWMutex),
+	// }
+	//
+	// ipt, err := iptables.New()
+	// if err != nil {
+	// 	die(logger, "iptables-new", err)
+	// }
+	//
+	// iptLocker := &filelock.Locker{
+	// 	FileLocker: filelock.NewLocker(conf.IPTablesLockFile),
+	// 	Mutex:      &sync.Mutex{},
+	// }
+	// restorer := &rules.Restorer{}
+	// lockedIPTables := &rules.LockedIPTables{
+	// 	IPTables: ipt,
+	// 	Locker:   iptLocker,
+	// 	Restorer: restorer,
+	// }
+	//
+	// metricsSender := &metrics.MetricsSender{
+	// 	Logger: logger.Session("time-metric-emitter"),
+	// }
+	//
+	// iptablesLoggingState := &planner.LoggingState{}
+	// if conf.IPTablesLogging {
+	// 	iptablesLoggingState.Enable()
+	// }
+	//
+	// dynamicPlanner := &planner.VxlanPolicyPlanner{
+	// 	Datastore:     store,
+	// 	PolicyClient:  policyClient,
+	// 	Logger:        logger.Session("rules-updater"),
+	// 	VNI:           conf.VNI,
+	// 	MetricsSender: metricsSender,
+	// 	Chain: enforcer.Chain{
+	// 		Table:       "filter",
+	// 		ParentChain: "FORWARD",
+	// 		Prefix:      "vpa--",
+	// 	},
+	// 	LoggingState:                  iptablesLoggingState,
+	// 	IPTablesAcceptedUDPLogsPerSec: conf.IPTablesAcceptedUDPLogsPerSec,
+	// 	EnableOverlayIngressRules:     conf.EnableOverlayIngressRules,
+	// }
+	//
+	// timestamper := &enforcer.Timestamper{}
+	// ruleEnforcer := enforcer.NewEnforcer(
+	// 	logger.Session("rules-enforcer"),
+	// 	timestamper,
+	// 	lockedIPTables,
+	// 	enforcer.EnforcerConfig{
+	// 		DisableContainerNetworkPolicy: conf.DisableContainerNetworkPolicy,
+	// 		OverlayNetwork:                conf.OverlayNetwork,
+	// 	},
+	// )
+	//
+	// err = dropsonde.Initialize(conf.MetronAddress, dropsondeOrigin)
+	// if err != nil {
+	// 	log.Fatalf("%s: initializing dropsonde: %s", logPrefix, err)
+	// }
+	//
+	// uptimeSource := metrics.NewUptimeSource()
+	// metricsEmitter := metrics.NewMetricsEmitter(logger, emitInterval, uptimeSource)
+	//
+	// pollCycleFunc := (&converger.SinglePollCycle{
+	// 	Planners: []converger.Planner{
+	// 		dynamicPlanner,
+	// 	},
+	// 	Enforcer:      ruleEnforcer,
+	// 	MetricsSender: metricsSender,
+	// 	Logger:        logger,
+	// 	Mutex:         new(sync.Mutex),
+	// }).DoCycle
+	//
+	// policyPoller := &poller.Poller{
+	// 	Logger:          logger,
+	// 	PollInterval:    pollInterval,
+	// 	SingleCycleFunc: pollCycleFunc,
+	// }
+	//
+	// forcePolicyPollCycleServerAddress := fmt.Sprintf("%s:%d", conf.ForcePolicyPollCycleHost, conf.ForcePolicyPollCyclePort)
+	// forcePolicyPollCycleServer := createForcePolicyPollCycleServer(forcePolicyPollCycleServerAddress, pollCycleFunc)
+	//
+	// debugServerAddress := fmt.Sprintf("%s:%d", conf.DebugServerHost, conf.DebugServerPort)
+	// debugServer := createCustomDebugServer(debugServerAddress, reconfigurableSink, iptablesLoggingState)
+	// members := grouper.Members{
+	// 	{"metrics_emitter", metricsEmitter},
+	// 	{"policy_poller", policyPoller},
+	// 	{"debug-server", debugServer},
+	// 	{"force-policy-poll-cycle-server", forcePolicyPollCycleServer},
+	// }
+	//
+	// monitor := ifrit.Invoke(sigmon.New(grouper.NewOrdered(os.Interrupt, members)))
+	logger.Info("starting")
+	// err = <-monitor.Wait()
+	// if err != nil {
+	// 	die(logger, "ifrit monitor", err)
+	// }
+}
+
+// const (
+// 	DEBUG = "debug"
+// 	INFO  = "info"
+// 	ERROR = "error"
+// 	FATAL = "fatal"
+// )
+//
+// func initLoggerSink(logger lager.Logger, level string) *lager.ReconfigurableSink {
+// 	var logLevel lager.LogLevel
+// 	switch strings.ToLower(level) {
+// 	case DEBUG:
+// 		logLevel = lager.DEBUG
+// 	case INFO:
+// 		logLevel = lager.INFO
+// 	case ERROR:
+// 		logLevel = lager.ERROR
+// 	case FATAL:
+// 		logLevel = lager.FATAL
+// 	default:
+// 		logLevel = lager.INFO
+// 	}
+// 	w := lager.NewWriterSink(os.Stdout, lager.DEBUG)
+// 	return lager.NewReconfigurableSink(w, logLevel)
+// }
+//
+// func createCustomDebugServer(listenAddress string, sink *lager.ReconfigurableSink, iptablesLoggingState *planner.LoggingState) ifrit.Runner {
+// 	mux := debugserver.Handler(sink).(*http.ServeMux)
+// 	mux.Handle("/iptables-c2c-logging", &handlers.IPTablesLogging{
+// 		LoggingState: iptablesLoggingState,
+// 	})
+// 	return http_server.New(listenAddress, mux)
+// }
+//
+// func createForcePolicyPollCycleServer(listenAddress string, pollCycleFunc func() error) ifrit.Runner {
+// 	mux := http.NewServeMux()
+// 	mux.Handle("/force-policy-poll-cycle", &handlers.ForcePolicyPollCycle{
+// 		PollCycleFunc: pollCycleFunc,
+// 	})
+// 	return http_server.New(listenAddress, mux)
+// }

--- a/src/vxlan-policy-agent/cmd/vxlan-policy-agent/main.go
+++ b/src/vxlan-policy-agent/cmd/vxlan-policy-agent/main.go
@@ -90,7 +90,7 @@ func main() {
 		conf.PolicyServerURL,
 	)
 
-	_, err = policyClient.GetPolicies()
+	_, _, err = policyClient.GetPolicies()
 
 	if err != nil {
 		die(logger, "policy-client-get-policies", err)

--- a/src/vxlan-policy-agent/integration/linux/linux_suite_test.go
+++ b/src/vxlan-policy-agent/integration/linux/linux_suite_test.go
@@ -1,0 +1,94 @@
+package linux_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"vxlan-policy-agent/config"
+
+	"code.cloudfoundry.org/cf-networking-helpers/testsupport"
+
+	. "github.com/onsi/ginkgo"
+	ginkgoConfig "github.com/onsi/ginkgo/config"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+
+	"testing"
+)
+
+var DEFAULT_TIMEOUT = "5s"
+
+const GlobalIPTablesLockFile = "/tmp/netman/iptables.lock"
+
+var (
+	certDir string
+	paths   testPaths
+)
+
+type testPaths struct {
+	ServerCACertFile     string
+	ClientCACertFile     string
+	ServerCertFile       string
+	ServerKeyFile        string
+	ClientCertFile       string
+	ClientKeyFile        string
+	VxlanPolicyAgentPath string
+}
+
+func TestIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Integration Suite")
+}
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	var err error
+	certDir, err = ioutil.TempDir("", "netman-certs")
+	Expect(err).NotTo(HaveOccurred())
+
+	certWriter, err := testsupport.NewCertWriter(certDir)
+	Expect(err).NotTo(HaveOccurred())
+
+	paths.ServerCACertFile, err = certWriter.WriteCA("server-ca")
+	Expect(err).NotTo(HaveOccurred())
+	paths.ServerCertFile, paths.ServerKeyFile, err = certWriter.WriteAndSign("server", "server-ca")
+	Expect(err).NotTo(HaveOccurred())
+
+	paths.ClientCACertFile, err = certWriter.WriteCA("client-ca")
+	Expect(err).NotTo(HaveOccurred())
+	paths.ClientCertFile, paths.ClientKeyFile, err = certWriter.WriteAndSign("client", "client-ca")
+	Expect(err).NotTo(HaveOccurred())
+
+	fmt.Fprintf(GinkgoWriter, "building binary...")
+	paths.VxlanPolicyAgentPath, err = gexec.Build("vxlan-policy-agent/cmd/vxlan-policy-agent", "-race")
+	fmt.Fprintf(GinkgoWriter, "done")
+	Expect(err).NotTo(HaveOccurred())
+
+	data, err := json.Marshal(paths)
+	Expect(err).NotTo(HaveOccurred())
+
+	return data
+}, func(data []byte) {
+	Expect(json.Unmarshal(data, &paths)).To(Succeed())
+
+	rand.Seed(ginkgoConfig.GinkgoConfig.RandomSeed + int64(GinkgoParallelNode()))
+})
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	gexec.CleanupBuildArtifacts()
+	os.Remove(certDir)
+})
+
+func WriteConfigFile(Config config.VxlanPolicyAgent) string {
+	configFile, err := ioutil.TempFile("", "test-config")
+	Expect(err).NotTo(HaveOccurred())
+
+	configBytes, err := json.Marshal(Config)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = ioutil.WriteFile(configFile.Name(), configBytes, os.ModePerm)
+	Expect(err).NotTo(HaveOccurred())
+
+	return configFile.Name()
+}

--- a/src/vxlan-policy-agent/integration/linux/linux_suite_test.go
+++ b/src/vxlan-policy-agent/integration/linux/linux_suite_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package linux_test
 
 import (

--- a/src/vxlan-policy-agent/integration/linux/linux_test.go
+++ b/src/vxlan-policy-agent/integration/linux/linux_test.go
@@ -1,4 +1,4 @@
-package integration_test
+package linux_test
 
 import (
 	"crypto/tls"

--- a/src/vxlan-policy-agent/integration/linux/linux_test.go
+++ b/src/vxlan-policy-agent/integration/linux/linux_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package linux_test
 
 import (

--- a/src/vxlan-policy-agent/integration/windows/windows_suite_test.go
+++ b/src/vxlan-policy-agent/integration/windows/windows_suite_test.go
@@ -1,4 +1,4 @@
-package integration_test
+package windows_test
 
 import (
 	"encoding/json"
@@ -61,7 +61,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(err).NotTo(HaveOccurred())
 
 	fmt.Fprintf(GinkgoWriter, "building binary...")
-	paths.VxlanPolicyAgentPath, err = gexec.Build("vxlan-policy-agent/cmd/vxlan-policy-agent", "-race")
+	paths.VxlanPolicyAgentPath, err = gexec.Build("vxlan-policy-agent/cmd/vxlan-policy-agent-windows", "-race")
 	fmt.Fprintf(GinkgoWriter, "done")
 	Expect(err).NotTo(HaveOccurred())
 

--- a/src/vxlan-policy-agent/integration/windows/windows_suite_test.go
+++ b/src/vxlan-policy-agent/integration/windows/windows_suite_test.go
@@ -20,8 +20,6 @@ import (
 
 var DEFAULT_TIMEOUT = "5s"
 
-const GlobalIPTablesLockFile = "/tmp/netman/iptables.lock"
-
 var (
 	certDir string
 	paths   testPaths

--- a/src/vxlan-policy-agent/integration/windows/windows_suite_test.go
+++ b/src/vxlan-policy-agent/integration/windows/windows_suite_test.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package windows_test
 
 import (

--- a/src/vxlan-policy-agent/integration/windows/windows_test.go
+++ b/src/vxlan-policy-agent/integration/windows/windows_test.go
@@ -81,7 +81,7 @@ var _ = Describe("VXLAN Policy Agent Windows", func() {
 			ServerCACertFile:              paths.ServerCACertFile,
 			ClientCertFile:                paths.ClientCertFile,
 			ClientKeyFile:                 paths.ClientKeyFile,
-			IPTablesLockFile:              GlobalIPTablesLockFile,
+			IPTablesLockFile:              "REMOVE", // TODO: Remove this property
 			ForcePolicyPollCycleHost:      "127.0.0.1",
 			ForcePolicyPollCyclePort:      ports.PickAPort(),
 			DebugServerHost:               "127.0.0.1",
@@ -91,7 +91,6 @@ var _ = Describe("VXLAN Policy Agent Windows", func() {
 			IPTablesAcceptedUDPLogsPerSec: 7,
 			EnableOverlayIngressRules:     true,
 		}
-
 	})
 
 	JustBeforeEach(func() {
@@ -121,6 +120,7 @@ var _ = Describe("VXLAN Policy Agent Windows", func() {
 				Eventually(session.Out, "2s").Should(Say("cfnetworking.vxlan-policy-agent.parsed-config"))
 				Eventually(session.Out, "2s").Should(Say(conf.PolicyServerURL))
 				Eventually(session.Out, "2s").Should(Say("cfnetworking.vxlan-policy-agent.starting"))
+				Eventually(session.Out, "3s").Should(Say("cfnetworking.vxlan-policy-agent.policies"))
 			})
 		})
 	})

--- a/src/vxlan-policy-agent/integration/windows/windows_test.go
+++ b/src/vxlan-policy-agent/integration/windows/windows_test.go
@@ -121,6 +121,7 @@ var _ = Describe("VXLAN Policy Agent Windows", func() {
 				Eventually(session.Out, "2s").Should(Say(conf.PolicyServerURL))
 				Eventually(session.Out, "2s").Should(Say("cfnetworking.vxlan-policy-agent.starting"))
 				Eventually(session.Out, "3s").Should(Say("cfnetworking.vxlan-policy-agent.policies"))
+				Eventually(session.Out, "3s").Should(Say("cfnetworking.vxlan-policy-agent.egress_policies"))
 			})
 		})
 	})

--- a/src/vxlan-policy-agent/integration/windows/windows_test.go
+++ b/src/vxlan-policy-agent/integration/windows/windows_test.go
@@ -1,0 +1,244 @@
+package windows_test
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"vxlan-policy-agent/config"
+
+	"code.cloudfoundry.org/cf-networking-helpers/mutualtls"
+	"code.cloudfoundry.org/cf-networking-helpers/testsupport/metrics"
+	"code.cloudfoundry.org/cf-networking-helpers/testsupport/ports"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+
+	"github.com/tedsuo/ifrit"
+	"github.com/tedsuo/ifrit/grouper"
+	"github.com/tedsuo/ifrit/http_server"
+	"github.com/tedsuo/ifrit/sigmon"
+)
+
+var _ = Describe("VXLAN Policy Agent Windows", func() {
+	var (
+		session          *gexec.Session
+		datastorePath    string
+		conf             config.VxlanPolicyAgent
+		configFilePath   string
+		fakeMetron       metrics.FakeMetron
+		mockPolicyServer ifrit.Process
+		serverListenPort int
+		serverListenAddr string
+		serverTLSConfig  *tls.Config
+	)
+
+	BeforeEach(func() {
+		var err error
+		fakeMetron = metrics.NewFakeMetron()
+
+		serverTLSConfig, err = mutualtls.NewServerTLSConfig(paths.ServerCertFile, paths.ServerKeyFile, paths.ClientCACertFile)
+		Expect(err).NotTo(HaveOccurred())
+
+		serverListenPort = ports.PickAPort()
+		serverListenAddr = fmt.Sprintf("127.0.0.1:%d", serverListenPort)
+
+		containerMetadata := `{
+			"some-handle": {
+				"handle":"some-handle",
+				"ip":"10.255.100.21",
+				"metadata": {
+					"policy_group_id":"some-very-very-long-app-guid",
+					"space_id": "some-space",
+					"ports": "8080, 9090",
+					"container_workload": "app"
+				}
+			},
+			"some-other-handle": {
+				"handle":"some-other-handle",
+				"ip":"10.255.100.21",
+				"metadata": {
+					"policy_group_id":"some-app-guid-no-ports",
+					"ports": "8080, 9090"
+				}
+			}
+		}`
+		containerMetadataFile, err := ioutil.TempFile("", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ioutil.WriteFile(containerMetadataFile.Name(), []byte(containerMetadata), os.ModePerm))
+		datastorePath = containerMetadataFile.Name()
+
+		conf = config.VxlanPolicyAgent{
+			PollInterval:                  1,
+			PolicyServerURL:               fmt.Sprintf("https://%s", serverListenAddr),
+			Datastore:                     datastorePath,
+			VNI:                           42,
+			MetronAddress:                 fakeMetron.Address(),
+			ServerCACertFile:              paths.ServerCACertFile,
+			ClientCertFile:                paths.ClientCertFile,
+			ClientKeyFile:                 paths.ClientKeyFile,
+			IPTablesLockFile:              GlobalIPTablesLockFile,
+			ForcePolicyPollCycleHost:      "127.0.0.1",
+			ForcePolicyPollCyclePort:      ports.PickAPort(),
+			DebugServerHost:               "127.0.0.1",
+			DebugServerPort:               ports.PickAPort(),
+			LogPrefix:                     "testprefix",
+			ClientTimeoutSeconds:          5,
+			IPTablesAcceptedUDPLogsPerSec: 7,
+			EnableOverlayIngressRules:     true,
+		}
+
+	})
+
+	JustBeforeEach(func() {
+		configFilePath = WriteConfigFile(conf)
+	})
+
+	AfterEach(func() {
+		stopServer(mockPolicyServer)
+		session.Interrupt()
+		Eventually(session, DEFAULT_TIMEOUT).Should(gexec.Exit())
+	})
+
+	Describe("policy agent", func() {
+		Context("when the policy server is up and running", func() {
+			JustBeforeEach(func() {
+				mockPolicyServer = startServer(serverListenAddr, serverTLSConfig)
+				session = startAgent(paths.VxlanPolicyAgentPath, configFilePath)
+			})
+
+			It("should boot and gracefully terminate", func() {
+				Consistently(session).ShouldNot(gexec.Exit())
+				session.Interrupt()
+				Eventually(session, DEFAULT_TIMEOUT).Should(gexec.Exit())
+			})
+
+			It("should parse the config file", func() {
+				Eventually(session.Out, "2s").Should(Say("cfnetworking.vxlan-policy-agent.parsed-config"))
+				Eventually(session.Out, "2s").Should(Say(conf.PolicyServerURL))
+				Eventually(session.Out, "2s").Should(Say("cfnetworking.vxlan-policy-agent.starting"))
+			})
+		})
+	})
+})
+
+func startAgent(binaryPath, configPath string) *gexec.Session {
+	cmd := exec.Command(binaryPath, "-config-file", configPath)
+	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+	Expect(err).NotTo(HaveOccurred())
+	return session
+}
+
+func startServer(serverListenAddr string, tlsConfig *tls.Config) ifrit.Process {
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/networking/v1/internal/policies" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"total_policies": 4,
+				"policies": [
+					{
+						"source": {"id":"some-very-very-long-app-guid", "tag":"A"},
+						"destination": {"id": "some-other-app-guid", "tag":"B", "protocol":"tcp", "ports":{"start":3333, "end":3333}}
+					},
+					{
+						"source": {"id":"some-very-very-long-app-guid", "tag":"A"},
+						"destination": {"id": "some-other-app-guid", "tag":"B", "protocol":"tcp", "ports":{"start":3334, "end":3334}}
+					},
+					{
+						"source": {"id":"another-app-guid", "tag":"C"},
+						"destination": {"id": "some-very-very-long-app-guid", "tag":"A", "protocol":"tcp", "ports":{"start":9999, "end":9999}}
+					},
+					{
+						"source": {"id":"yet-another-app-guid", "tag":"D"},
+						"destination": {"id": "some-very-very-long-app-guid", "tag":"A", "protocol":"udp", "ports":{"start":7000, "end":8000}}
+					}
+				],
+				"total_egress_policies": 7,
+				"egress_policies": [
+					{
+						"source": {"id": "some-space", "type": "space" },
+						"destination": {"ips": [{"start": "10.27.2.1", "end": "10.27.2.2"}], "protocol": "tcp"},
+						"app_lifecycle": "running"
+					},
+					{
+						"source": {"id": "some-very-very-long-app-guid" },
+						"destination": {"ips": [{"start": "10.27.1.1", "end": "10.27.1.2"}], "protocol": "icmp", "icmp_type": 3, "icmp_code": 4},
+						"app_lifecycle": "running"
+					},
+					{
+						"source": {"id": "some-very-very-long-app-guid" },
+						"destination": {"ips": [{"start": "1.1.1.1", "end": "2.9.9.9"}], "ports": [{"start": 8080, "end": 8081}], "protocol": "tcp"},
+						"app_lifecycle": "staging"
+					},
+					{
+						"source": {"id": "some-very-very-long-app-guid" },
+						"destination": {"ips": [{"start": "10.27.1.1", "end": "10.27.1.2"}], "protocol": "icmp", "icmp_type": -1, "icmp_code": -1},
+						"app_lifecycle": "all"
+					},
+					{
+						"source": {"id": "some-very-very-long-app-guid" },
+						"destination": {"ips": [{"start": "10.27.1.1", "end": "10.27.1.2"}], "protocol": "icmp", "icmp_type": 8, "icmp_code": -1},
+						"app_lifecycle": "all"
+					},
+					{
+						"source": {"id": "some-very-very-long-app-guid" },
+						"destination": {"ips": [{"start": "10.27.1.1", "end": "10.27.1.2"}], "ports": [{"start": 8080, "end": 8081}], "protocol": "tcp"},
+						"app_lifecycle": "all"
+					},
+					{
+						"source": {"id": "some-app-guid-no-ports" },
+						"destination": {"ips": [{"start": "10.27.1.3", "end": "10.27.1.4"}], "protocol": "tcp"},
+						"app_lifecycle": "all"
+					},
+					{
+						"source": {"id": "not-deployed-on-this-cell-why-did-you-query-for-this-id" },
+						"destination": {"ips": [{"start": "10.27.2.3", "end": "10.27.2.5"}], "protocol": "udp"},
+						"app_lifecycle": "all"
+					},
+					{
+						"source": {"id": "", "type": "default" },
+						"destination": {"ips": [{"start": "10.28.2.3", "end": "10.28.2.5"}], "protocol": "tcp"},
+						"app_lifecycle": "all"
+					}
+				]
+			}`))
+			return
+		}
+
+		if r.URL.Path == "/networking/v1/internal/tags" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte((`{
+					"id": "some-id",
+					"type": "some-type",
+					"tag": "6"
+				}`)))
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+		return
+	})
+	someServer := http_server.NewTLSServer(serverListenAddr, testHandler, tlsConfig)
+
+	members := grouper.Members{{
+		Name:   "http_server",
+		Runner: someServer,
+	}}
+	group := grouper.NewOrdered(os.Interrupt, members)
+	monitor := ifrit.Invoke(sigmon.New(group))
+
+	Eventually(monitor.Ready()).Should(BeClosed())
+	return monitor
+}
+
+func stopServer(server ifrit.Process) {
+	if server == nil {
+		return
+	}
+	server.Signal(os.Interrupt)
+	Eventually(server.Wait()).Should(Receive())
+}

--- a/src/vxlan-policy-agent/planner/planner.go
+++ b/src/vxlan-policy-agent/planner/planner.go
@@ -3,39 +3,18 @@ package planner
 import (
 	"lib/datastore"
 	"lib/policy_client"
-	"lib/rules"
-	"strings"
 	"time"
 	"vxlan-policy-agent/enforcer"
-
-	"fmt"
-	"strconv"
-
-	"encoding/json"
-	"sort"
 
 	"code.cloudfoundry.org/lager"
 )
 
-//go:generate counterfeiter -o fakes/policy_client.go --fake-name PolicyClient . policyClient
-type policyClient interface {
-	GetPoliciesByID(ids ...string) ([]policy_client.Policy, []policy_client.EgressPolicy, error)
-	CreateOrGetTag(id, groupType string) (string, error)
-}
-
-//go:generate counterfeiter -o fakes/dstore.go --fake-name Dstore . dstore
-type dstore interface {
-	ReadAll() (map[string]datastore.Container, error)
-}
-
-//go:generate counterfeiter -o fakes/metrics_sender.go --fake-name MetricsSender . metricsSender
-type metricsSender interface {
-	SendDuration(string, time.Duration)
-}
-
-//go:generate counterfeiter -o fakes/loggingStateGetter.go --fake-name LoggingStateGetter . loggingStateGetter
-type loggingStateGetter interface {
-	IsEnabled() bool
+type container struct {
+	AppID   string
+	SpaceID string
+	Ports   string
+	IP      string
+	Purpose string
 }
 
 type VxlanPolicyPlanner struct {
@@ -50,178 +29,29 @@ type VxlanPolicyPlanner struct {
 	EnableOverlayIngressRules     bool
 }
 
-type container struct {
-	AppID   string
-	SpaceID string
-	Ports   string
-	IP      string
-	Purpose string
+//go:generate counterfeiter -o fakes/dstore.go --fake-name Dstore . dstore
+type dstore interface {
+	ReadAll() (map[string]datastore.Container, error)
 }
 
-type containerPolicySet struct {
-	Source      sourceSlice
-	Destination destinationSlice
-	Ingress     ingressSlice
-	Egress      egressSlice
+//go:generate counterfeiter -o fakes/policy_client.go --fake-name PolicyClient . policyClient
+type policyClient interface {
+	GetPoliciesByID(ids ...string) ([]policy_client.Policy, []policy_client.EgressPolicy, error)
+	CreateOrGetTag(id, groupType string) (string, error)
 }
 
-type source struct {
-	IP   string
-	Tag  string
-	GUID string
+//go:generate counterfeiter -o fakes/metrics_sender.go --fake-name MetricsSender . metricsSender
+type metricsSender interface {
+	SendDuration(string, time.Duration)
 }
 
-type sourceSlice []source
-
-func (s sourceSlice) Len() int {
-	return len(s)
-}
-
-func (s sourceSlice) Less(i, j int) bool {
-	a, err := json.Marshal(s[i])
-	if err != nil {
-		panic(err)
-	}
-
-	b, err := json.Marshal(s[j])
-	if err != nil {
-		panic(err)
-	}
-
-	return strings.Compare(string(a), string(b)) < 0
-}
-
-func (s sourceSlice) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-type destination struct {
-	IP                 string
-	StartPort, EndPort int
-	GUID               string
-	SourceGUID         string
-	Protocol           string
-	SourceTag          string
-}
-
-type destinationSlice []destination
-
-func (s destinationSlice) Len() int {
-	return len(s)
-}
-
-func (s destinationSlice) Less(i, j int) bool {
-	a, err := json.Marshal(s[i])
-	if err != nil {
-		panic(err)
-	}
-
-	b, err := json.Marshal(s[j])
-	if err != nil {
-		panic(err)
-	}
-
-	return strings.Compare(string(a), string(b)) < 0
-}
-
-func (s destinationSlice) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-type egress struct {
-	SourceIP  string
-	Protocol  string
-	IpStart   string
-	IpEnd     string
-	IcmpType  int
-	IcmpCode  int
-	PortStart int
-	PortEnd   int
-}
-
-type egressSlice []egress
-
-func (s egressSlice) Len() int {
-	return len(s)
-}
-
-func (s egressSlice) Less(i, j int) bool {
-	a, err := json.Marshal(s[i])
-	if err != nil {
-		panic(err)
-	}
-
-	b, err := json.Marshal(s[j])
-	if err != nil {
-		panic(err)
-	}
-
-	return strings.Compare(string(a), string(b)) < 0
-}
-
-func (s egressSlice) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-type ingress struct {
-	IngressTag string
-	IP         string
-	Protocol   string
-	Port       int
-}
-
-type ingressSlice []ingress
-
-func (s ingressSlice) Len() int {
-	return len(s)
-}
-
-func (s ingressSlice) Less(i, j int) bool {
-	a, err := json.Marshal(s[i])
-	if err != nil {
-		panic(err)
-	}
-
-	b, err := json.Marshal(s[j])
-	if err != nil {
-		panic(err)
-	}
-
-	return strings.Compare(string(a), string(b)) < 0
-}
-
-func (s ingressSlice) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
+//go:generate counterfeiter -o fakes/loggingStateGetter.go --fake-name LoggingStateGetter . loggingStateGetter
+type loggingStateGetter interface {
+	IsEnabled() bool
 }
 
 const metricContainerMetadata = "containerMetadataTime"
 const metricPolicyServerPoll = "policyServerPollTime"
-
-func (p *VxlanPolicyPlanner) GetRulesAndChain() (enforcer.RulesWithChain, error) {
-	allContainers, err := p.readFile()
-	if err != nil {
-		p.Logger.Error("datastore", err)
-		return enforcer.RulesWithChain{}, err
-	}
-	policy, egressPolicy, ingressTag, err := p.queryPolicyServer(allContainers)
-	if err != nil {
-		p.Logger.Error("policy-client-query", err)
-		return enforcer.RulesWithChain{}, err
-	}
-
-	containerPolicySet, err := p.getContainerPolicies(policy, egressPolicy, ingressTag, allContainers)
-	if err != nil {
-		p.Logger.Error("policy-client-get-container-policies", err)
-		return enforcer.RulesWithChain{}, err
-	}
-	ruleset := p.planIPTableRules(containerPolicySet)
-
-	p.Logger.Debug("generated-rules", lager.Data{"rules": ruleset})
-	return enforcer.RulesWithChain{
-		Chain: p.Chain,
-		Rules: ruleset,
-	}, nil
-}
 
 func (p *VxlanPolicyPlanner) readFile() ([]container, error) {
 	containerMetadataStartTime := time.Now()
@@ -270,9 +100,7 @@ func (p *VxlanPolicyPlanner) readFile() ([]container, error) {
 	return allContainers, nil
 }
 
-func (p *VxlanPolicyPlanner) queryPolicyServer(allContainers []container) ([]policy_client.Policy, []policy_client.EgressPolicy, string, error) {
-	policyServerStartRequestTime := time.Now()
-
+func extractGUIDs(allContainers []container) []string {
 	allGUIDs := make(map[string]interface{})
 	for _, container := range allContainers {
 		if container.AppID != "" {
@@ -289,177 +117,5 @@ func (p *VxlanPolicyPlanner) queryPolicyServer(allContainers []container) ([]pol
 		guids[i] = key
 		i++
 	}
-
-	var policies []policy_client.Policy
-	var egressPolicies []policy_client.EgressPolicy
-	if len(guids) > 0 {
-		var err error
-		policies, egressPolicies, err = p.PolicyClient.GetPoliciesByID(guids...)
-		if err != nil {
-			err = fmt.Errorf("failed to get policies: %s", err)
-			return nil, nil, "", err
-		}
-	}
-
-	var ingressTag string
-	if p.EnableOverlayIngressRules {
-		var err error
-		ingressTag, err = p.PolicyClient.CreateOrGetTag("INGRESS_ROUTER", "router")
-		if err != nil {
-			err = fmt.Errorf("failed to get ingress tags: %s", err)
-			return nil, nil, "", err
-		}
-	}
-
-	policyServerPollDuration := time.Now().Sub(policyServerStartRequestTime)
-	p.MetricsSender.SendDuration(metricPolicyServerPoll, policyServerPollDuration)
-	return policies, egressPolicies, ingressTag, nil
-}
-
-func (p *VxlanPolicyPlanner) getContainerPolicies(policies []policy_client.Policy, egressPolicies []policy_client.EgressPolicy, ingressTag string, allContainers []container) (containerPolicySet, error) {
-	visited := make(map[string]bool)
-	var containerPolicySet containerPolicySet
-	for _, container := range allContainers {
-		for _, policy := range policies {
-			if container.AppID == policy.Source.ID {
-				if _, ok := visited[container.IP]; !ok {
-					containerPolicy := source{
-						Tag:  policy.Source.Tag,
-						GUID: policy.Source.ID,
-						IP:   container.IP,
-					}
-					containerPolicySet.Source = append(containerPolicySet.Source, containerPolicy)
-					visited[container.IP] = true
-				}
-			}
-
-			if container.AppID == policy.Destination.ID {
-				containerPolicy := destination{
-					IP:         container.IP,
-					StartPort:  policy.Destination.Ports.Start,
-					EndPort:    policy.Destination.Ports.End,
-					Protocol:   policy.Destination.Protocol,
-					SourceTag:  policy.Source.Tag,
-					GUID:       policy.Destination.ID,
-					SourceGUID: policy.Source.ID,
-				}
-				containerPolicySet.Destination = append(containerPolicySet.Destination, containerPolicy)
-			}
-		}
-
-		for _, egressPolicy := range egressPolicies {
-			if (egressPolicy.Source.ID == container.AppID) ||
-				(egressPolicy.Source.ID == container.SpaceID && egressPolicy.Source.Type == "space") ||
-				egressPolicy.Source.Type == "default" {
-				if containerPurposeMatchesAppLifecycle(container.Purpose, egressPolicy.AppLifecycle) {
-					var startPort, endPort int
-
-					if len(egressPolicy.Destination.Ports) > 0 {
-						startPort = egressPolicy.Destination.Ports[0].Start
-						endPort = egressPolicy.Destination.Ports[0].End
-					}
-
-					containerPolicy := egress{
-						SourceIP:  container.IP,
-						Protocol:  egressPolicy.Destination.Protocol,
-						IpStart:   egressPolicy.Destination.IPRanges[0].Start,
-						IpEnd:     egressPolicy.Destination.IPRanges[0].End,
-						IcmpType:  egressPolicy.Destination.ICMPType,
-						IcmpCode:  egressPolicy.Destination.ICMPCode,
-						PortStart: startPort,
-						PortEnd:   endPort,
-					}
-					containerPolicySet.Egress = append(containerPolicySet.Egress, containerPolicy)
-				}
-			}
-		}
-
-		if p.EnableOverlayIngressRules {
-			if container.Ports != "" {
-				for _, port := range strings.Split(container.Ports, ",") {
-					convPort, err := strconv.Atoi(strings.TrimSpace(port))
-					if err != nil {
-						return containerPolicySet, fmt.Errorf("converting container metadata port to int: %s", err)
-					}
-					containerPolicySet.Ingress = append(containerPolicySet.Ingress, ingress{
-						IngressTag: ingressTag,
-						IP:         container.IP,
-						Protocol:   "tcp",
-						Port:       convPort,
-					})
-				}
-			}
-		}
-	}
-
-	sort.Sort(containerPolicySet.Source)
-	sort.Sort(containerPolicySet.Destination)
-	sort.Sort(containerPolicySet.Egress)
-	sort.Sort(containerPolicySet.Ingress)
-
-	return containerPolicySet, nil
-}
-
-func (p *VxlanPolicyPlanner) planIPTableRules(containerPolicySet containerPolicySet) []rules.IPTablesRule {
-	var ruleset []rules.IPTablesRule
-	for _, c2cSource := range containerPolicySet.Source {
-		ruleset = append(ruleset, rules.NewMarkSetRule(
-			c2cSource.IP,
-			c2cSource.Tag,
-			c2cSource.GUID))
-	}
-
-	for _, c2cDestination := range containerPolicySet.Destination {
-		if p.LoggingState.IsEnabled() {
-			ruleset = append(ruleset, rules.NewMarkAllowLogRule(
-				c2cDestination.IP,
-				c2cDestination.Protocol,
-				c2cDestination.StartPort,
-				c2cDestination.EndPort,
-				c2cDestination.SourceTag,
-				c2cDestination.GUID,
-				p.IPTablesAcceptedUDPLogsPerSec,
-			))
-		}
-		ruleset = append(ruleset, rules.NewMarkAllowRule(
-			c2cDestination.IP,
-			c2cDestination.Protocol,
-			c2cDestination.StartPort,
-			c2cDestination.EndPort,
-			c2cDestination.SourceTag,
-			c2cDestination.SourceGUID,
-			c2cDestination.GUID,
-		))
-	}
-
-	for _, egressSource := range containerPolicySet.Egress {
-		ruleset = append(ruleset, rules.NewEgress(
-			egressSource.SourceIP,
-			egressSource.Protocol,
-			egressSource.IpStart,
-			egressSource.IpEnd,
-			egressSource.IcmpType,
-			egressSource.IcmpCode,
-			egressSource.PortStart,
-			egressSource.PortEnd))
-	}
-
-	for _, ingressSource := range containerPolicySet.Ingress {
-		ruleset = append(ruleset, rules.NewMarkAllowRuleNoComment(
-			ingressSource.IP,
-			ingressSource.Protocol,
-			ingressSource.Port,
-			ingressSource.IngressTag,
-		))
-	}
-
-	return ruleset
-}
-
-func containerPurposeMatchesAppLifecycle(containerPurpose, appLifecycle string) bool {
-	return appLifecycle == "all" ||
-		containerPurpose == "" ||
-		(appLifecycle == "running" && (containerPurpose == "task" || containerPurpose == "app")) ||
-		appLifecycle == "staging" && containerPurpose == "staging"
-
+	return guids
 }

--- a/src/vxlan-policy-agent/planner/planner_linux.go
+++ b/src/vxlan-policy-agent/planner/planner_linux.go
@@ -1,0 +1,359 @@
+// +build !windows
+
+package planner
+
+import (
+	"lib/policy_client"
+	"lib/rules"
+	"strings"
+	"time"
+	"vxlan-policy-agent/enforcer"
+
+	"fmt"
+	"strconv"
+
+	"encoding/json"
+	"sort"
+
+	"code.cloudfoundry.org/lager"
+)
+
+type containerPolicySet struct {
+	Source      sourceSlice
+	Destination destinationSlice
+	Ingress     ingressSlice
+	Egress      egressSlice
+}
+
+type source struct {
+	IP   string
+	Tag  string
+	GUID string
+}
+
+type sourceSlice []source
+
+func (s sourceSlice) Len() int {
+	return len(s)
+}
+
+func (s sourceSlice) Less(i, j int) bool {
+	a, err := json.Marshal(s[i])
+	if err != nil {
+		panic(err)
+	}
+
+	b, err := json.Marshal(s[j])
+	if err != nil {
+		panic(err)
+	}
+
+	return strings.Compare(string(a), string(b)) < 0
+}
+
+func (s sourceSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+type destination struct {
+	IP                 string
+	StartPort, EndPort int
+	GUID               string
+	SourceGUID         string
+	Protocol           string
+	SourceTag          string
+}
+
+type destinationSlice []destination
+
+func (s destinationSlice) Len() int {
+	return len(s)
+}
+
+func (s destinationSlice) Less(i, j int) bool {
+	a, err := json.Marshal(s[i])
+	if err != nil {
+		panic(err)
+	}
+
+	b, err := json.Marshal(s[j])
+	if err != nil {
+		panic(err)
+	}
+
+	return strings.Compare(string(a), string(b)) < 0
+}
+
+func (s destinationSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+type egress struct {
+	SourceIP  string
+	Protocol  string
+	IpStart   string
+	IpEnd     string
+	IcmpType  int
+	IcmpCode  int
+	PortStart int
+	PortEnd   int
+}
+
+type egressSlice []egress
+
+func (s egressSlice) Len() int {
+	return len(s)
+}
+
+func (s egressSlice) Less(i, j int) bool {
+	a, err := json.Marshal(s[i])
+	if err != nil {
+		panic(err)
+	}
+
+	b, err := json.Marshal(s[j])
+	if err != nil {
+		panic(err)
+	}
+
+	return strings.Compare(string(a), string(b)) < 0
+}
+
+func (s egressSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+type ingress struct {
+	IngressTag string
+	IP         string
+	Protocol   string
+	Port       int
+}
+
+type ingressSlice []ingress
+
+func (s ingressSlice) Len() int {
+	return len(s)
+}
+
+func (s ingressSlice) Less(i, j int) bool {
+	a, err := json.Marshal(s[i])
+	if err != nil {
+		panic(err)
+	}
+
+	b, err := json.Marshal(s[j])
+	if err != nil {
+		panic(err)
+	}
+
+	return strings.Compare(string(a), string(b)) < 0
+}
+
+func (s ingressSlice) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (p *VxlanPolicyPlanner) GetRulesAndChain() (enforcer.RulesWithChain, error) {
+	allContainers, err := p.readFile()
+	if err != nil {
+		p.Logger.Error("datastore", err)
+		return enforcer.RulesWithChain{}, err
+	}
+	policy, egressPolicy, ingressTag, err := p.queryPolicyServer(allContainers)
+	if err != nil {
+		p.Logger.Error("policy-client-query", err)
+		return enforcer.RulesWithChain{}, err
+	}
+
+	containerPolicySet, err := p.getContainerPolicies(policy, egressPolicy, ingressTag, allContainers)
+	if err != nil {
+		p.Logger.Error("policy-client-get-container-policies", err)
+		return enforcer.RulesWithChain{}, err
+	}
+	ruleset := p.planIPTableRules(containerPolicySet)
+
+	p.Logger.Debug("generated-rules", lager.Data{"rules": ruleset})
+	return enforcer.RulesWithChain{
+		Chain: p.Chain,
+		Rules: ruleset,
+	}, nil
+}
+
+func (p *VxlanPolicyPlanner) queryPolicyServer(allContainers []container) ([]policy_client.Policy, []policy_client.EgressPolicy, string, error) {
+	policyServerStartRequestTime := time.Now()
+	guids := extractGUIDs(allContainers)
+
+	var policies []policy_client.Policy
+	var egressPolicies []policy_client.EgressPolicy
+	if len(guids) > 0 {
+		var err error
+		policies, egressPolicies, err = p.PolicyClient.GetPoliciesByID(guids...)
+		if err != nil {
+			err = fmt.Errorf("failed to get policies: %s", err)
+			return nil, nil, "", err
+		}
+	}
+
+	var ingressTag string
+	if p.EnableOverlayIngressRules {
+		var err error
+		ingressTag, err = p.PolicyClient.CreateOrGetTag("INGRESS_ROUTER", "router")
+		if err != nil {
+			err = fmt.Errorf("failed to get ingress tags: %s", err)
+			return nil, nil, "", err
+		}
+	}
+
+	policyServerPollDuration := time.Now().Sub(policyServerStartRequestTime)
+	p.MetricsSender.SendDuration(metricPolicyServerPoll, policyServerPollDuration)
+	return policies, egressPolicies, ingressTag, nil
+}
+
+func (p *VxlanPolicyPlanner) getContainerPolicies(policies []policy_client.Policy, egressPolicies []policy_client.EgressPolicy, ingressTag string, allContainers []container) (containerPolicySet, error) {
+	visited := make(map[string]bool)
+	var containerPolicySet containerPolicySet
+	for _, container := range allContainers {
+		for _, policy := range policies {
+			if container.AppID == policy.Source.ID {
+				if _, ok := visited[container.IP]; !ok {
+					containerPolicy := source{
+						Tag:  policy.Source.Tag,
+						GUID: policy.Source.ID,
+						IP:   container.IP,
+					}
+					containerPolicySet.Source = append(containerPolicySet.Source, containerPolicy)
+					visited[container.IP] = true
+				}
+			}
+
+			if container.AppID == policy.Destination.ID {
+				containerPolicy := destination{
+					IP:         container.IP,
+					StartPort:  policy.Destination.Ports.Start,
+					EndPort:    policy.Destination.Ports.End,
+					Protocol:   policy.Destination.Protocol,
+					SourceTag:  policy.Source.Tag,
+					GUID:       policy.Destination.ID,
+					SourceGUID: policy.Source.ID,
+				}
+				containerPolicySet.Destination = append(containerPolicySet.Destination, containerPolicy)
+			}
+		}
+
+		for _, egressPolicy := range egressPolicies {
+			if (egressPolicy.Source.ID == container.AppID) ||
+				(egressPolicy.Source.ID == container.SpaceID && egressPolicy.Source.Type == "space") ||
+				egressPolicy.Source.Type == "default" {
+				if containerPurposeMatchesAppLifecycle(container.Purpose, egressPolicy.AppLifecycle) {
+					var startPort, endPort int
+
+					if len(egressPolicy.Destination.Ports) > 0 {
+						startPort = egressPolicy.Destination.Ports[0].Start
+						endPort = egressPolicy.Destination.Ports[0].End
+					}
+
+					containerPolicy := egress{
+						SourceIP:  container.IP,
+						Protocol:  egressPolicy.Destination.Protocol,
+						IpStart:   egressPolicy.Destination.IPRanges[0].Start,
+						IpEnd:     egressPolicy.Destination.IPRanges[0].End,
+						IcmpType:  egressPolicy.Destination.ICMPType,
+						IcmpCode:  egressPolicy.Destination.ICMPCode,
+						PortStart: startPort,
+						PortEnd:   endPort,
+					}
+					containerPolicySet.Egress = append(containerPolicySet.Egress, containerPolicy)
+				}
+			}
+		}
+
+		if p.EnableOverlayIngressRules {
+			if container.Ports != "" {
+				for _, port := range strings.Split(container.Ports, ",") {
+					convPort, err := strconv.Atoi(strings.TrimSpace(port))
+					if err != nil {
+						return containerPolicySet, fmt.Errorf("converting container metadata port to int: %s", err)
+					}
+					containerPolicySet.Ingress = append(containerPolicySet.Ingress, ingress{
+						IngressTag: ingressTag,
+						IP:         container.IP,
+						Protocol:   "tcp",
+						Port:       convPort,
+					})
+				}
+			}
+		}
+	}
+
+	sort.Sort(containerPolicySet.Source)
+	sort.Sort(containerPolicySet.Destination)
+	sort.Sort(containerPolicySet.Egress)
+	sort.Sort(containerPolicySet.Ingress)
+
+	return containerPolicySet, nil
+}
+
+func (p *VxlanPolicyPlanner) planIPTableRules(containerPolicySet containerPolicySet) []rules.IPTablesRule {
+	var ruleset []rules.IPTablesRule
+	for _, c2cSource := range containerPolicySet.Source {
+		ruleset = append(ruleset, rules.NewMarkSetRule(
+			c2cSource.IP,
+			c2cSource.Tag,
+			c2cSource.GUID))
+	}
+
+	for _, c2cDestination := range containerPolicySet.Destination {
+		if p.LoggingState.IsEnabled() {
+			ruleset = append(ruleset, rules.NewMarkAllowLogRule(
+				c2cDestination.IP,
+				c2cDestination.Protocol,
+				c2cDestination.StartPort,
+				c2cDestination.EndPort,
+				c2cDestination.SourceTag,
+				c2cDestination.GUID,
+				p.IPTablesAcceptedUDPLogsPerSec,
+			))
+		}
+		ruleset = append(ruleset, rules.NewMarkAllowRule(
+			c2cDestination.IP,
+			c2cDestination.Protocol,
+			c2cDestination.StartPort,
+			c2cDestination.EndPort,
+			c2cDestination.SourceTag,
+			c2cDestination.SourceGUID,
+			c2cDestination.GUID,
+		))
+	}
+
+	for _, egressSource := range containerPolicySet.Egress {
+		ruleset = append(ruleset, rules.NewEgress(
+			egressSource.SourceIP,
+			egressSource.Protocol,
+			egressSource.IpStart,
+			egressSource.IpEnd,
+			egressSource.IcmpType,
+			egressSource.IcmpCode,
+			egressSource.PortStart,
+			egressSource.PortEnd))
+	}
+
+	for _, ingressSource := range containerPolicySet.Ingress {
+		ruleset = append(ruleset, rules.NewMarkAllowRuleNoComment(
+			ingressSource.IP,
+			ingressSource.Protocol,
+			ingressSource.Port,
+			ingressSource.IngressTag,
+		))
+	}
+
+	return ruleset
+}
+
+func containerPurposeMatchesAppLifecycle(containerPurpose, appLifecycle string) bool {
+	return appLifecycle == "all" ||
+		containerPurpose == "" ||
+		(appLifecycle == "running" && (containerPurpose == "task" || containerPurpose == "app")) ||
+		appLifecycle == "staging" && containerPurpose == "staging"
+
+}

--- a/src/vxlan-policy-agent/planner/planner_linux_test.go
+++ b/src/vxlan-policy-agent/planner/planner_linux_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package planner_test
 
 import (
@@ -45,9 +47,9 @@ var _ = Describe("Planner", func() {
 			Handle: "container-id-1",
 			IP:     "10.255.1.2",
 			Metadata: map[string]interface{}{
-				"policy_group_id":   "some-app-guid",
-				"space_id":          "some-space-guid",
-				"ports":             "8080",
+				"policy_group_id":    "some-app-guid",
+				"space_id":           "some-space-guid",
+				"ports":              "8080",
 				"container_workload": "task",
 			},
 		}
@@ -55,8 +57,8 @@ var _ = Describe("Planner", func() {
 			Handle: "container-id-2",
 			IP:     "10.255.1.3",
 			Metadata: map[string]interface{}{
-				"policy_group_id":   "some-other-app-guid",
-				"ports":             " 8181 , 9090",
+				"policy_group_id":    "some-other-app-guid",
+				"ports":              " 8181 , 9090",
 				"container_workload": "staging",
 			},
 		}
@@ -836,8 +838,8 @@ var _ = Describe("Planner", func() {
 						Handle: "container-id-1",
 						IP:     "10.255.1.2",
 						Metadata: map[string]interface{}{
-							"policy_group_id":   "some-app-guid",
-							"ports":             "8080",
+							"policy_group_id":    "some-app-guid",
+							"ports":              "8080",
 							"container_workload": "app",
 						},
 					}
@@ -865,8 +867,8 @@ var _ = Describe("Planner", func() {
 						Handle: "container-id-1",
 						IP:     "10.255.1.2",
 						Metadata: map[string]interface{}{
-							"policy_group_id":   "some-app-guid",
-							"ports":             "8080",
+							"policy_group_id":    "some-app-guid",
+							"ports":              "8080",
 							"container_workload": "task",
 						},
 					}
@@ -894,8 +896,8 @@ var _ = Describe("Planner", func() {
 						Handle: "container-id-1",
 						IP:     "10.255.1.2",
 						Metadata: map[string]interface{}{
-							"policy_group_id":   "some-app-guid",
-							"ports":             "8080",
+							"policy_group_id":    "some-app-guid",
+							"ports":              "8080",
 							"container_workload": "staging",
 						},
 					}
@@ -923,8 +925,8 @@ var _ = Describe("Planner", func() {
 						Handle: "container-id-1",
 						IP:     "10.255.1.2",
 						Metadata: map[string]interface{}{
-							"policy_group_id":   "some-app-guid",
-							"ports":             "8080",
+							"policy_group_id": "some-app-guid",
+							"ports":           "8080",
 						},
 					}
 					store.ReadAllReturns(data, nil)

--- a/src/vxlan-policy-agent/planner/planner_windows.go
+++ b/src/vxlan-policy-agent/planner/planner_windows.go
@@ -1,0 +1,44 @@
+// +build windows
+
+package planner
+
+import (
+	"fmt"
+	"lib/policy_client"
+	"time"
+)
+
+func (p *VxlanPolicyPlanner) GetRules() ([]policy_client.EgressPolicy, error) {
+	allContainers, err := p.readFile()
+	if err != nil {
+		p.Logger.Error("datastore", err)
+		return []policy_client.EgressPolicy{}, err
+	}
+
+	egressPolicies, err := p.queryPolicyServer(allContainers)
+	if err != nil {
+		p.Logger.Error("policy-client-query", err)
+		return []policy_client.EgressPolicy{}, err
+	}
+
+	return egressPolicies, nil
+}
+
+func (p *VxlanPolicyPlanner) queryPolicyServer(allContainers []container) ([]policy_client.EgressPolicy, error) {
+	policyServerStartRequestTime := time.Now()
+	guids := extractGUIDs(allContainers)
+
+	var egressPolicies []policy_client.EgressPolicy
+	if len(guids) > 0 {
+		var err error
+		_, egressPolicies, err = p.PolicyClient.GetPoliciesByID(guids...)
+		if err != nil {
+			err = fmt.Errorf("failed to get policies: %s", err)
+			return egressPolicies, err
+		}
+	}
+
+	policyServerPollDuration := time.Now().Sub(policyServerStartRequestTime)
+	p.MetricsSender.SendDuration(metricPolicyServerPoll, policyServerPollDuration)
+	return egressPolicies, nil
+}

--- a/src/vxlan-policy-agent/planner/planner_windows_test.go
+++ b/src/vxlan-policy-agent/planner/planner_windows_test.go
@@ -1,0 +1,309 @@
+// +build windows
+
+package planner_test
+
+import (
+	"errors"
+	"lib/datastore"
+	libfakes "lib/fakes"
+	"lib/policy_client"
+	"vxlan-policy-agent/enforcer"
+	"vxlan-policy-agent/planner/fakes"
+
+	"vxlan-policy-agent/planner"
+
+	"code.cloudfoundry.org/lager/lagertest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Planner", func() {
+	var (
+		policyPlanner              *planner.VxlanPolicyPlanner
+		policyClient               *fakes.PolicyClient
+		policyServerResponse       []policy_client.Policy
+		egressPolicyServerResponse []policy_client.EgressPolicy
+		store                      *libfakes.Datastore
+		metricsSender              *fakes.MetricsSender
+		logger                     *lagertest.TestLogger
+		chain                      enforcer.Chain
+		data                       map[string]datastore.Container
+		loggingStateGetter         *fakes.LoggingStateGetter
+	)
+
+	BeforeEach(func() {
+		logger = lagertest.NewTestLogger("test")
+		policyClient = &fakes.PolicyClient{}
+		metricsSender = &fakes.MetricsSender{}
+		loggingStateGetter = &fakes.LoggingStateGetter{}
+
+		store = &libfakes.Datastore{}
+
+		data = make(map[string]datastore.Container)
+		data["container-id-1"] = datastore.Container{
+			Handle: "container-id-1",
+			IP:     "10.255.1.2",
+			Metadata: map[string]interface{}{
+				"policy_group_id":    "some-app-guid",
+				"space_id":           "some-space-guid",
+				"ports":              "8080",
+				"container_workload": "task",
+			},
+		}
+		data["container-id-2"] = datastore.Container{
+			Handle: "container-id-2",
+			IP:     "10.255.1.3",
+			Metadata: map[string]interface{}{
+				"policy_group_id":    "some-other-app-guid",
+				"ports":              " 8181 , 9090",
+				"container_workload": "staging",
+			},
+		}
+		data["container-id-3"] = datastore.Container{
+			Handle: "container-id-3",
+			IP:     "10.255.1.4",
+		}
+
+		store.ReadAllReturns(data, nil)
+
+		policyServerResponse = []policy_client.Policy{
+			{
+				Source: policy_client.Source{
+					ID:  "some-app-guid",
+					Tag: "AA",
+				},
+				Destination: policy_client.Destination{
+					ID: "some-other-app-guid",
+					Ports: policy_client.Ports{
+						Start: 1234,
+						End:   1234,
+					},
+					Protocol: "tcp",
+				},
+			},
+			{
+				Source: policy_client.Source{
+					ID:  "another-app-guid",
+					Tag: "BB",
+				},
+				Destination: policy_client.Destination{
+					ID: "some-other-app-guid",
+					Ports: policy_client.Ports{
+						Start: 5555,
+						End:   5555,
+					},
+					Protocol: "udp",
+				},
+			},
+			{
+				Source: policy_client.Source{
+					ID:  "some-other-app-guid",
+					Tag: "CC",
+				},
+				Destination: policy_client.Destination{
+					ID: "yet-another-app-guid",
+					Ports: policy_client.Ports{
+						Start: 6534,
+						End:   6534,
+					},
+					Protocol: "udp",
+				},
+			},
+			{
+				Source: policy_client.Source{
+					ID:  "some-app-guid",
+					Tag: "AA",
+				},
+				Destination: policy_client.Destination{
+					ID: "some-app-guid",
+					Ports: policy_client.Ports{
+						Start: 8080,
+						End:   8080,
+					},
+					Protocol: "tcp",
+				},
+			},
+		}
+
+		egressPolicyServerResponse = []policy_client.EgressPolicy{
+			{
+				Source: &policy_client.EgressSource{
+					ID: "some-app-guid",
+				},
+				Destination: &policy_client.EgressDestination{
+					Protocol: "tcp",
+					Ports: []policy_client.Ports{
+						{Start: 8080, End: 8081},
+					},
+					IPRanges: []policy_client.IPRange{
+						{Start: "1.2.3.4", End: "1.2.3.5"},
+					},
+				},
+				AppLifecycle: "all",
+			},
+			{
+				Source: &policy_client.EgressSource{
+					ID: "some-app-guid",
+				},
+				Destination: &policy_client.EgressDestination{
+					Protocol: "udp",
+					Ports: []policy_client.Ports{
+						{Start: 8080, End: 8081},
+					},
+					IPRanges: []policy_client.IPRange{
+						{Start: "1.2.3.4", End: "1.2.3.5"},
+					},
+				},
+				AppLifecycle: "all",
+			},
+			{
+				Source: &policy_client.EgressSource{
+					ID: "some-other-app-guid",
+				},
+				Destination: &policy_client.EgressDestination{
+					Protocol: "icmp",
+					ICMPType: 2,
+					ICMPCode: 3,
+					IPRanges: []policy_client.IPRange{
+						{Start: "1.2.3.6", End: "1.2.3.7"},
+					},
+				},
+				AppLifecycle: "all",
+			},
+			{
+				Source: &policy_client.EgressSource{
+					ID: "some-other-app-guid",
+				},
+				Destination: &policy_client.EgressDestination{
+					Protocol: "icmp",
+					ICMPType: 8,
+					ICMPCode: -1,
+					IPRanges: []policy_client.IPRange{
+						{Start: "1.2.3.6", End: "1.2.3.7"},
+					},
+				},
+				AppLifecycle: "all",
+			},
+			{
+				Source: &policy_client.EgressSource{
+					ID: "some-other-app-guid",
+				},
+				Destination: &policy_client.EgressDestination{
+					Protocol: "icmp",
+					ICMPType: -1,
+					ICMPCode: -1,
+					IPRanges: []policy_client.IPRange{
+						{Start: "1.2.3.6", End: "1.2.3.7"},
+					},
+				},
+				AppLifecycle: "all",
+			},
+			{
+				Source: &policy_client.EgressSource{
+					ID: "some-other-app-guid",
+				},
+				Destination: &policy_client.EgressDestination{
+					Protocol: "tcp",
+					IPRanges: []policy_client.IPRange{
+						{Start: "1.2.3.6", End: "1.2.3.7"},
+					},
+				},
+				AppLifecycle: "all",
+			},
+			{
+				Source: &policy_client.EgressSource{
+					ID:   "some-space-guid",
+					Type: "space",
+				},
+				Destination: &policy_client.EgressDestination{
+					Protocol: "udp",
+					IPRanges: []policy_client.IPRange{
+						{Start: "2.3.4.5", End: "3.3.3.3"},
+					},
+				},
+				AppLifecycle: "all",
+			},
+			{
+				Source: &policy_client.EgressSource{
+					ID:   "",
+					Type: "default",
+				},
+				Destination: &policy_client.EgressDestination{
+					Protocol: "udp",
+					IPRanges: []policy_client.IPRange{
+						{Start: "8.7.6.5", End: "4.3.2.1"},
+					},
+				},
+				AppLifecycle: "all",
+			},
+			{
+				Source: &policy_client.EgressSource{
+					ID: "some-other-app-guid",
+				},
+				Destination: &policy_client.EgressDestination{
+					Protocol: "all",
+					IPRanges: []policy_client.IPRange{
+						{Start: "8.8.4.4", End: "8.8.8.8"},
+					},
+					Ports: []policy_client.Ports{
+						{Start: 8080, End: 8081},
+					},
+				},
+				AppLifecycle: "all",
+			},
+		}
+
+		policyClient.GetPoliciesByIDReturns(policyServerResponse, egressPolicyServerResponse, nil)
+
+		policyPlanner = &planner.VxlanPolicyPlanner{
+			Logger:        logger,
+			Datastore:     store,
+			PolicyClient:  policyClient,
+			VNI:           42,
+			MetricsSender: metricsSender,
+			Chain:         chain, // TODO: consider removing this property
+			LoggingState:  loggingStateGetter,
+		}
+	})
+
+	Describe("GetRules", func() {
+		It("gets every container's properties from the datastore", func() {
+			_, err := policyPlanner.GetRules()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(store.ReadAllCallCount()).To(Equal(1))
+		})
+
+		It("gets policies from the policy server", func() {
+			_, err := policyPlanner.GetRules()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("filtering by ID when calling the internal policy server")
+			Expect(policyClient.GetPoliciesByIDCallCount()).To(Equal(1))
+			Expect(policyClient.GetPoliciesByIDArgsForCall(0)).To(ConsistOf([]interface{}{"some-app-guid", "some-other-app-guid", "some-space-guid"}))
+		})
+
+		Context("when the file can't be read", func() {
+			BeforeEach(func() {
+				store.ReadAllReturns(nil, errors.New("ohno!"))
+			})
+
+			It("returns an error", func() {
+				_, err := policyPlanner.GetRules()
+				Expect(err).To(MatchError("ohno!"))
+				Expect(policyClient.GetPoliciesByIDCallCount()).To(Equal(0))
+			})
+		})
+
+		Context("when the policy server returns an error", func() {
+			BeforeEach(func() {
+				policyClient.GetPoliciesByIDReturns(nil, nil, errors.New("ohno!"))
+			})
+
+			It("returns an error", func() {
+				_, err := policyPlanner.GetRules()
+				Expect(err).To(MatchError("failed to get policies: ohno!"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
This PR adds a very basic vxlan-policy-agent that compiles on Windows. Currently, all it does is connect to the policy server and print out policies.

To facilitate this, we pulled out os-specific functionality of `planner` into separate files for each os. Common functionality remains in `planner.go`.

Tracker: https://www.pivotaltracker.com/story/show/160927901