### PR TITLE
Use exiter.ps1

### DIFF
--- a/packages/vxlan-policy-agent-windows/packaging
+++ b/packages/vxlan-policy-agent-windows/packaging
@@ -1,3 +1,5 @@
+. ./exiter.ps1
+
 $Enabled=[bool]"True"
 
 Start-Sleep 5

--- a/packages/vxlan-policy-agent-windows/spec
+++ b/packages/vxlan-policy-agent-windows/spec
@@ -34,3 +34,4 @@ files:
   - vxlan-policy-agent/config/*.go # gosub
   - vxlan-policy-agent/enforcer/*.go # gosub
   - vxlan-policy-agent/planner/*.go # gosub
+  - exiter.ps1


### PR DESCRIPTION
- it avoids a compilation error when exporting release
error:
```
Task 27689 | 20:20:08 | Error: Action Failed get_task: Task d89462d8-dd82-4743-45e3-b6f656395244 result: Compiling package vxlan-policy-agent-windows: Running packaging script: Running packaging script: Command exited with 2; Stdout: , Stderr: packaging: line 1: =[bool]True: command not found
+ Start-Sleep 5
packaging: line 3: Start-Sleep: command not found
packaging: line 5: syntax error near unexpected token `{'
packaging: line 5: `if (-not $Enabled) {'
```