### PR TITLE
Can specify UDP services running on the host

### DIFF
--- a/jobs/silk-cni/spec
+++ b/jobs/silk-cni/spec
@@ -65,3 +65,10 @@ properties:
     example: |
       - 169.254.0.2:9001
       - 169.254.0.2:9002
+
+  host_udp_services:
+    description: "List of UDP addresses running on the BOSH VM that should be accessible from containers.  The address must not be in the 127.0.0.0/8 range.  The network plugin will install an iptables INPUT rule for each service."
+    default: []
+    example: |
+      - 169.254.0.2:9001
+      - 169.254.0.2:9002

--- a/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
+++ b/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
@@ -46,6 +46,7 @@
       'policy_agent_force_poll_address' => '127.0.0.1:' + link('vpa').p('force_policy_poll_cycle_port').to_s,
       'dns_servers' => p('dns_servers'),
       'host_tcp_services' => p('host_tcp_services'),
+      'host_udp_services' => p('host_udp_services'),
       'delegate' => {
         'cniVersion' => '0.3.1',
         'name' => 'silk',

--- a/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
+++ b/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
@@ -29,7 +29,8 @@ module Bosh::Template::Test
         'burst' => 200,
         'iptables_denied_logs_per_sec' => 2,
         'iptables_accepted_udp_logs_per_sec' => 3,
-        'host_tcp_services' => ['169.254.0.2:9001', '169.254.0.2:9002']
+        'host_tcp_services' => ['169.254.0.2:9001', '169.254.0.2:9002'],
+        'host_udp_services' => ['169.254.0.2:9003', '169.254.0.2:9004']
       }
     end
     let(:job) {release.job('silk-cni')}
@@ -66,6 +67,7 @@ module Bosh::Template::Test
             'dns_servers' => ['8.8.8.8'],
             'policy_agent_force_poll_address' => '127.0.0.1:5555',
             'host_tcp_services' => ['169.254.0.2:9001', '169.254.0.2:9002'],
+            'host_udp_services' => ['169.254.0.2:9003', '169.254.0.2:9004'],
             'delegate' => {
               'cniVersion' => '0.3.1',
               'name' => 'silk',

--- a/src/cni-wrapper-plugin/lib/lib.go
+++ b/src/cni-wrapper-plugin/lib/lib.go
@@ -27,6 +27,7 @@ type WrapperConfig struct {
 	NoMasqueradeCIDRRange           string                 `json:"no_masquerade_cidr_range"`
 	DNSServers                      []string               `json:"dns_servers"`
 	HostTCPServices                 []string               `json:"host_tcp_services"`
+	HostUDPServices                 []string               `json:"host_udp_services"`
 	UnderlayIPs                     []string               `json:"underlay_ips"`
 	TemporaryUnderlayInterfaceNames []string               `json:"temporary_underlay_interface_names"`
 	IPTablesASGLogging              bool                   `json:"iptables_asg_logging"`

--- a/src/cni-wrapper-plugin/main.go
+++ b/src/cni-wrapper-plugin/main.go
@@ -133,6 +133,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		ContainerHandle:       args.ContainerID,
 		ContainerIP:           containerIP.String(),
 		HostTCPServices:       cfg.HostTCPServices,
+		HostUDPServices:       cfg.HostUDPServices,
 		DNSServers:            localDNSServers,
 	}
 	if err := netOutProvider.Initialize(); err != nil {


### PR DESCRIPTION
### Context

As a platform operator, I want to expose services running on the host, to messages sent from applications, via UDP. _e.g. metrics via statsd_

### Changes

This PR exposes a new property `host_udp_services` in the `silk-cni` job, which behaves similarly to `host_tcp_services`, except it adds UDP rules instead of TCP.

- Adds a new `cni-wrapper-plugin` integration test for host UDP services
- Adds a new test for `legacynet` test for UDP host services
- Moves the DNS + host TCP services test within a "when dns servers are specified content"
  - (the diff looks weird, it will be easier to read the entire file)
  - `src/cni-wrapper-plugin/legacynet/netout_test.go`
- Adds a new test for DNS + host UDP services within the "when dns servers are specified"` context
- Updates the BOSH job spec conflist spec test

### Checklist

- [x] Updated the relevant BOSH job spec
- [x] Run all the tests locally `/scripts/docker-test`
- [ ] Deployed to my development environment
- [x] Signed the CLA

### Contact

@tlwr in Cloud Foundry slack