### PR TITLE
Add deny_networks property to silk-cni

### DIFF
--- a/jobs/silk-cni/spec
+++ b/jobs/silk-cni/spec
@@ -75,7 +75,13 @@ properties:
 
   deny_networks:
     description: "List of CIDR blocks to which containers will be denied access"
-    default: []
+    default: {}
     example: |
-      - 172.16.0.0/12
-      - 192.168.0.0/16
+      all:
+        - 172.16.0.0/12
+      app:
+        - 192.161.0.0/16
+      staging:
+        - 192.162.0.0/16
+      task:
+        - 192.163.0.0/16

--- a/jobs/silk-cni/spec
+++ b/jobs/silk-cni/spec
@@ -72,3 +72,10 @@ properties:
     example: |
       - 169.254.0.2:9001
       - 169.254.0.2:9002
+
+  deny_networks:
+    description: "List of CIDR blocks to which containers will be denied access"
+    default: []
+    example: |
+      - 172.16.0.0/12
+      - 192.168.0.0/16

--- a/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
+++ b/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
@@ -47,6 +47,7 @@
       'dns_servers' => p('dns_servers'),
       'host_tcp_services' => p('host_tcp_services'),
       'host_udp_services' => p('host_udp_services'),
+      'deny_networks' => p('deny_networks'),
       'delegate' => {
         'cniVersion' => '0.3.1',
         'name' => 'silk',

--- a/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
+++ b/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
@@ -31,7 +31,10 @@ module Bosh::Template::Test
         'iptables_accepted_udp_logs_per_sec' => 3,
         'host_tcp_services' => ['169.254.0.2:9001', '169.254.0.2:9002'],
         'host_udp_services' => ['169.254.0.2:9003', '169.254.0.2:9004'],
-        'deny_networks' => ['172.16.0.0/12', '192.168.0.0/16']
+        'deny_networks' => {
+          'app' => ['172.16.0.0/12', '192.168.0.0/16'],
+          'task' => ['172.16.0.0/12', '192.168.0.0/16'],
+        }
       }
     end
     let(:job) {release.job('silk-cni')}
@@ -69,7 +72,10 @@ module Bosh::Template::Test
             'policy_agent_force_poll_address' => '127.0.0.1:5555',
             'host_tcp_services' => ['169.254.0.2:9001', '169.254.0.2:9002'],
             'host_udp_services' => ['169.254.0.2:9003', '169.254.0.2:9004'],
-            'deny_networks' => ['172.16.0.0/12', '192.168.0.0/16'],
+            'deny_networks' => {
+              'app' => ['172.16.0.0/12', '192.168.0.0/16'],
+              'task' => ['172.16.0.0/12', '192.168.0.0/16'],
+            },
             'delegate' => {
               'cniVersion' => '0.3.1',
               'name' => 'silk',

--- a/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
+++ b/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
@@ -30,7 +30,8 @@ module Bosh::Template::Test
         'iptables_denied_logs_per_sec' => 2,
         'iptables_accepted_udp_logs_per_sec' => 3,
         'host_tcp_services' => ['169.254.0.2:9001', '169.254.0.2:9002'],
-        'host_udp_services' => ['169.254.0.2:9003', '169.254.0.2:9004']
+        'host_udp_services' => ['169.254.0.2:9003', '169.254.0.2:9004'],
+        'deny_networks' => ['172.16.0.0/12', '192.168.0.0/16']
       }
     end
     let(:job) {release.job('silk-cni')}
@@ -68,6 +69,7 @@ module Bosh::Template::Test
             'policy_agent_force_poll_address' => '127.0.0.1:5555',
             'host_tcp_services' => ['169.254.0.2:9001', '169.254.0.2:9002'],
             'host_udp_services' => ['169.254.0.2:9003', '169.254.0.2:9004'],
+            'deny_networks' => ['172.16.0.0/12', '192.168.0.0/16'],
             'delegate' => {
               'cniVersion' => '0.3.1',
               'name' => 'silk',

--- a/src/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
+++ b/src/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
@@ -867,7 +867,11 @@ var _ = Describe("CniWrapperPlugin", func() {
 
 			Context("when deny networks are configured", func() {
 				BeforeEach(func() {
-					inputStruct.DenyNetworks = []string{"172.16.0.0/12", "192.168.0.0/16"}
+					inputStruct.Metadata["container_workload"] = "app"
+					inputStruct.DenyNetworks = map[string][]string{
+						"all": []string{"172.16.0.0/12"},
+						"app": []string{"192.168.0.0/16"},
+					}
 					input = GetInput(inputStruct)
 
 					cmd = cniCommand("ADD", input)

--- a/src/cni-wrapper-plugin/legacynet/netout_test.go
+++ b/src/cni-wrapper-plugin/legacynet/netout_test.go
@@ -269,14 +269,14 @@ var _ = Describe("Netout", func() {
 				Expect(table).To(Equal("filter"))
 				Expect(chain).To(Equal("input-some-container-handle"))
 				Expect(rulespec).To(Equal([]rules.IPTablesRule{
-					{"-m", "state", "--state", "RELATED,ESTABLISHED",
-						"--jump", "ACCEPT"},
+					{"-m", "state", "--state", "RELATED,ESTABLISHED", "--jump", "ACCEPT"},
+
 					{"-p", "tcp", "-d", "8.8.4.4", "--destination-port", "53", "--jump", "ACCEPT"},
 					{"-p", "udp", "-d", "8.8.4.4", "--destination-port", "53", "--jump", "ACCEPT"},
 					{"-p", "tcp", "-d", "1.2.3.4", "--destination-port", "53", "--jump", "ACCEPT"},
 					{"-p", "udp", "-d", "1.2.3.4", "--destination-port", "53", "--jump", "ACCEPT"},
-					{"--jump", "REJECT",
-						"--reject-with", "icmp-port-unreachable"},
+
+					{"--jump", "REJECT", "--reject-with", "icmp-port-unreachable"},
 				}))
 			})
 
@@ -383,12 +383,12 @@ var _ = Describe("Netout", func() {
 				Expect(table).To(Equal("filter"))
 				Expect(chain).To(Equal("input-some-container-handle"))
 				Expect(rulespec).To(Equal([]rules.IPTablesRule{
-					{"-m", "state", "--state", "RELATED,ESTABLISHED",
-						"--jump", "ACCEPT"},
+					{"-m", "state", "--state", "RELATED,ESTABLISHED", "--jump", "ACCEPT"},
+
 					{"-p", "tcp", "-d", "169.125.0.4", "--destination-port", "9001", "--jump", "ACCEPT"},
 					{"-p", "tcp", "-d", "169.125.0.9", "--destination-port", "8080", "--jump", "ACCEPT"},
-					{"--jump", "REJECT",
-						"--reject-with", "icmp-port-unreachable"},
+
+					{"--jump", "REJECT", "--reject-with", "icmp-port-unreachable"},
 				}))
 			})
 
@@ -417,12 +417,12 @@ var _ = Describe("Netout", func() {
 				Expect(table).To(Equal("filter"))
 				Expect(chain).To(Equal("input-some-container-handle"))
 				Expect(rulespec).To(Equal([]rules.IPTablesRule{
-					{"-m", "state", "--state", "RELATED,ESTABLISHED",
-						"--jump", "ACCEPT"},
+					{"-m", "state", "--state", "RELATED,ESTABLISHED", "--jump", "ACCEPT"},
+
 					{"-p", "udp", "-d", "169.125.0.4", "--destination-port", "9001", "--jump", "ACCEPT"},
 					{"-p", "udp", "-d", "169.125.0.9", "--destination-port", "8080", "--jump", "ACCEPT"},
-					{"--jump", "REJECT",
-						"--reject-with", "icmp-port-unreachable"},
+
+					{"--jump", "REJECT", "--reject-with", "icmp-port-unreachable"},
 				}))
 			})
 

--- a/src/cni-wrapper-plugin/lib/lib.go
+++ b/src/cni-wrapper-plugin/lib/lib.go
@@ -28,6 +28,7 @@ type WrapperConfig struct {
 	DNSServers                      []string               `json:"dns_servers"`
 	HostTCPServices                 []string               `json:"host_tcp_services"`
 	HostUDPServices                 []string               `json:"host_udp_services"`
+	DenyNetworks                    []string               `json:"deny_networks"`
 	UnderlayIPs                     []string               `json:"underlay_ips"`
 	TemporaryUnderlayInterfaceNames []string               `json:"temporary_underlay_interface_names"`
 	IPTablesASGLogging              bool                   `json:"iptables_asg_logging"`

--- a/src/cni-wrapper-plugin/lib/lib.go
+++ b/src/cni-wrapper-plugin/lib/lib.go
@@ -28,7 +28,7 @@ type WrapperConfig struct {
 	DNSServers                      []string               `json:"dns_servers"`
 	HostTCPServices                 []string               `json:"host_tcp_services"`
 	HostUDPServices                 []string               `json:"host_udp_services"`
-	DenyNetworks                    []string               `json:"deny_networks"`
+	DenyNetworks                    map[string][]string    `json:"deny_networks"`
 	UnderlayIPs                     []string               `json:"underlay_ips"`
 	TemporaryUnderlayInterfaceNames []string               `json:"temporary_underlay_interface_names"`
 	IPTablesASGLogging              bool                   `json:"iptables_asg_logging"`

--- a/src/cni-wrapper-plugin/main.go
+++ b/src/cni-wrapper-plugin/main.go
@@ -134,6 +134,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		ContainerIP:           containerIP.String(),
 		HostTCPServices:       cfg.HostTCPServices,
 		HostUDPServices:       cfg.HostUDPServices,
+		DenyNetworks:          cfg.DenyNetworks,
 		DNSServers:            localDNSServers,
 	}
 	if err := netOutProvider.Initialize(); err != nil {

--- a/src/cni-wrapper-plugin/main.go
+++ b/src/cni-wrapper-plugin/main.go
@@ -49,6 +49,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 
 	containerIP := result030.IPs[0].Address.IP
+	var containerWorkload string
 
 	// Add container metadata info
 	store := &datastore.Store{
@@ -70,6 +71,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 	if err := json.Unmarshal(args.StdinData, &cniAddData); err != nil {
 		return err // not tested, this should be impossible
+	}
+	if workload, present := cniAddData.Metadata["container_workload"]; present {
+		containerWorkload, _ = workload.(string)
 	}
 
 	if err := store.Add(args.ContainerID, containerIP.String(), cniAddData.Metadata); err != nil {
@@ -136,6 +140,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		HostUDPServices:       cfg.HostUDPServices,
 		DenyNetworks:          cfg.DenyNetworks,
 		DNSServers:            localDNSServers,
+		ContainerWorkload:     containerWorkload,
 	}
 	if err := netOutProvider.Initialize(); err != nil {
 		return fmt.Errorf("initialize net out: %s", err)

--- a/src/lib/rules/rules.go
+++ b/src/lib/rules/rules.go
@@ -253,6 +253,14 @@ func NewInputAllowRule(protocol, destination string, destPort int) IPTablesRule 
 	}
 }
 
+func NewInputRejectRule(destinationIP string) IPTablesRule {
+	return IPTablesRule{
+		"-d", destinationIP,
+		"--jump", "REJECT",
+		"--reject-with", "icmp-port-unreachable",
+	}
+}
+
 func NewInputDefaultRejectRule() IPTablesRule {
 	return IPTablesRule{
 		"--jump", "REJECT",


### PR DESCRIPTION
_:pencil: This is a work-in-progress pull request, there are probably details to think about. Input from the networking team would be appreciated :smile:_

### Context

As a platform operator, restrict certain isolation segments from accessing certain networks.

It is infeasible to use dynamic egress policies, or application security groups (native CF features), if the platform has a default security group which allows access to these networks: ASGs and egress policies do not allow you to deny destinations, only allow.

Allowing ASGs and/or egress policies to do both allow/deny is quite an involved change. Exposing this inside silk is probably fine (IMO)

### Changes

This pull request allows a platform operator to specify a list of CIDR ranges which an app container should not be able to talk to.

This is similar to the [garden property (from the garden-runc release) called `deny_networks`](https://bosh.io/jobs/garden?source=github.com/cloudfoundry/garden-runc-release&version=1.19.10#p%3dgarden.deny_networks), but is controlled via silk instead of garden.

This pull request

- Exposes a new property `deny_networks` in the `silk-cni` job
- Any destinations in the `deny_networks` property is added to a container's `netout` chain, before any of the ASG/dynamic egress policy rules
- Reformats some IPTables expectations to make them easier to read
- Updates the BOSH job spec conflist spec test

### Checklist

- [x] Updated the relevant BOSH job spec
- [x] Run all the tests locally `/scripts/docker-test`
- [x] Deployed to my development environment
  - 🙈 https://github.com/cloudfoundry/silk-release/pull/21
  - 🛫 https://github.com/alphagov/paas-silk-release/pull/1 (see appendix)
- [x] Signed the CLA

### Things I'm unsure about

Is this a feature the networking team want?

Is adding an IPTables rule to the regular FORWARD chain a better solution? (using source `10.255/16`)

Is chaining CNIs a better idea, for instance using the `firewall` CNI from the CNI project, similar to how `bandwidth` is currently used. However this has other disadvantages.

### Contact

@tlwr in Cloud Foundry slack

### Appendix

I've deployed this to my development environment, to an isolation segment.

With silk-cni having the following `deny_networks`

- 0.0.0.0/5
- 8.0.0.0/7
- 11.0.0.0/8
- 12.0.0.0/6
- 16.0.0.0/4
- 32.0.0.0/3
- 64.0.0.0/2
- 128.0.0.0/1

When I create an app, it gets the rules correctly:

```
Chain netout--13e80c9e-5fd1-485f-7 (1 references)
target     prot opt source               destination
ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0            state RELATED,ESTABLISHED
DROP       tcp  --  0.0.0.0/0            0.0.0.0/0            state INVALID
REJECT     all  --  0.0.0.0/0            128.0.0.0/1          reject-with icmp-port-unreachable
REJECT     all  --  0.0.0.0/0            64.0.0.0/2           reject-with icmp-port-unreachable
REJECT     all  --  0.0.0.0/0            32.0.0.0/3           reject-with icmp-port-unreachable
REJECT     all  --  0.0.0.0/0            16.0.0.0/4           reject-with icmp-port-unreachable
REJECT     all  --  0.0.0.0/0            12.0.0.0/6           reject-with icmp-port-unreachable
REJECT     all  --  0.0.0.0/0            11.0.0.0/8           reject-with icmp-port-unreachable
REJECT     all  --  0.0.0.0/0            8.0.0.0/7            reject-with icmp-port-unreachable
REJECT     all  --  0.0.0.0/0            0.0.0.0/5            reject-with icmp-port-unreachable
ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0            destination IP range 10.0.52.0-10.0.55.255 tcp dpt:6379
ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0            destination IP range 10.0.52.0-10.0.55.255 tcp dpt:3306
ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0            destination IP range 10.0.52.0-10.0.55.255 tcp dpt:5432
ACCEPT     udp  --  0.0.0.0/0            0.0.0.0/0            destination IP range 0.0.0.0-255.255.255.255 udp dpt:53
ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0            destination IP range 0.0.0.0-255.255.255.255 tcp dpt:53
ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0            destination IP range 192.169.0.0-255.255.255.255
ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0            destination IP range 172.32.0.0-192.167.255.255
ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0            destination IP range 169.255.0.0-172.15.255.255
ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0            destination IP range 11.0.0.0-169.253.255.255
ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0            destination IP range 0.0.0.0-9.255.255.255
REJECT     all  --  0.0.0.0/0            0.0.0.0/0            reject-with icmp-port-unreachable
```

which restricts egress to the internet correctly, but container to container networking is not impacted, neither is DNS resolution.