### PR TITLE
Add deny_networks to silk-cni job

### DIFF
--- a/jobs/silk-cni/spec
+++ b/jobs/silk-cni/spec
@@ -72,3 +72,27 @@ properties:
     example: |
       - 169.254.0.2:9001
       - 169.254.0.2:9002
+
+  deny_networks.always:
+    default: []
+    description: |
+      List of CIDR blocks to which all containers will be denied access, regardless of security groups.
+      This can severely impact the network connectivity of applications.
+      Use with extreme caution and at your own risk.
+      These rules apply to all containers.
+
+  deny_networks.running:
+    default: []
+    description: |
+      List of CIDR blocks to which all containers will be denied access, regardless of security groups.
+      This can severely impact the network connectivity of applications.
+      Use with extreme caution and at your own risk.
+      These rules apply to running scheduled containers: apps and tasks.
+
+  deny_networks.staging:
+    default: []
+    description: |
+      List of CIDR blocks to which all containers will be denied access, regardless of security groups.
+      This can severely impact the network connectivity of applications.
+      Use with extreme caution and at your own risk.
+      These rules apply during the staging process.

--- a/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
+++ b/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
@@ -1,5 +1,6 @@
 <% unless p('disable') %>
 <%=
+  require 'ipaddr'
   require 'json'
 
   def compute_mtu
@@ -21,6 +22,22 @@
       end
 
       return no_masquerade_cidr_range
+    end
+  end
+
+  if_p('deny_networks') do |deny_networks|
+    deny_networks.each do |network, destinations|
+      destinations.each do |dest|
+        begin
+          validated_dest = IPAddr.new(dest)
+
+          unless validated_dest.ipv4?
+            raise "Invalid deny_networks.#{network} entry #{dest} not an IPv4 address"
+          end
+        rescue IPAddr::Error => e
+          raise "Invalid deny_networks.#{network} entry #{dest} #{e}"
+        end
+      end
     end
   end
 
@@ -47,6 +64,11 @@
       'dns_servers' => p('dns_servers'),
       'host_tcp_services' => p('host_tcp_services'),
       'host_udp_services' => p('host_udp_services'),
+      'deny_networks' => {
+        'always' => p('deny_networks.always'),
+        'running' => p('deny_networks.running'),
+        'staging' => p('deny_networks.staging'),
+      },
       'delegate' => {
         'cniVersion' => '0.3.1',
         'name' => 'silk',

--- a/src/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
+++ b/src/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
@@ -864,6 +864,46 @@ var _ = Describe("CniWrapperPlugin", func() {
 
 				})
 			})
+
+			Context("when deny networks are configured", func() {
+				BeforeEach(func() {
+					inputStruct.Metadata["container_workload"] = "app"
+					inputStruct.DenyNetworks = lib.DenyNetworksConfig{
+						Always:  []string{"172.16.0.0/12"},
+						Running: []string{"192.168.0.0/16"},
+					}
+					input = GetInput(inputStruct)
+
+					cmd = cniCommand("ADD", input)
+				})
+				It("writes input chain rules for deny networks", func() {
+					session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(session).Should(gexec.Exit(0))
+
+					By("checking that the default filter rules are installed before the deny")
+					Expect(AllIPTablesRules("filter")).To(gomegamatchers.ContainSequence([]string{
+						`-A ` + netoutChainName + ` -m state --state RELATED,ESTABLISHED -j ACCEPT`,
+						`-A ` + netoutChainName + ` -p tcp -m state --state INVALID -j DROP`,
+
+						`-A ` + netoutChainName + ` -d 192.168.0.0/16 -j REJECT --reject-with icmp-port-unreachable`,
+						`-A ` + netoutChainName + ` -d 172.16.0.0/12 -j REJECT --reject-with icmp-port-unreachable`,
+					}))
+
+					By("checking that the default filter rules are installed before the container rules")
+					Expect(AllIPTablesRules("filter")).To(gomegamatchers.ContainSequence([]string{
+						`-A ` + netoutChainName + ` -d 192.168.0.0/16 -j REJECT --reject-with icmp-port-unreachable`,
+						`-A ` + netoutChainName + ` -d 172.16.0.0/12 -j REJECT --reject-with icmp-port-unreachable`,
+
+						`-A ` + netoutChainName + ` -p icmp -m iprange --dst-range 5.5.5.5-6.6.6.6 -m icmp --icmp-type 8/0 -j ACCEPT`,
+						`-A ` + netoutChainName + ` -p udp -m iprange --dst-range 11.11.11.11-22.22.22.22 -m udp --dport 53:54 -j ACCEPT`,
+						`-A ` + netoutChainName + ` -p tcp -m iprange --dst-range 8.8.8.8-9.9.9.9 -m tcp --dport 53:54 -j ACCEPT`,
+						`-A ` + netoutChainName + ` -m iprange --dst-range 3.3.3.3-4.4.4.4 -j ACCEPT`,
+
+						`-A ` + netoutChainName + ` -j REJECT --reject-with icmp-port-unreachable`,
+					}))
+				})
+			})
 		})
 
 		Context("When the delegate plugin returns an error", func() {

--- a/src/cni-wrapper-plugin/legacynet/deny_networks.go
+++ b/src/cni-wrapper-plugin/legacynet/deny_networks.go
@@ -1,0 +1,7 @@
+package legacynet
+
+type DenyNetworks struct {
+	Always  []string
+	Running []string
+	Staging []string
+}

--- a/src/cni-wrapper-plugin/legacynet/netout.go
+++ b/src/cni-wrapper-plugin/legacynet/netout.go
@@ -36,7 +36,9 @@ type NetOut struct {
 	ContainerIP           string
 	HostTCPServices       []string
 	HostUDPServices       []string
+	DenyNetworks          DenyNetworks
 	DNSServers            []string
+	ContainerWorkload     string
 }
 
 func (m *NetOut) Initialize() error {
@@ -45,7 +47,17 @@ func (m *NetOut) Initialize() error {
 		return err
 	}
 
-	args, err = m.appendInputRules(args, m.DNSServers, m.HostTCPServices, m.HostUDPServices)
+	err = m.validateDenyNetworks()
+	if err != nil {
+		return err
+	}
+
+	args, err = m.appendInputRules(
+		args,
+		m.DNSServers,
+		m.HostTCPServices,
+		m.HostUDPServices,
+	)
 	if err != nil {
 		return fmt.Errorf("input rules: %s", err)
 	}
@@ -76,6 +88,7 @@ func (m *NetOut) BulkInsertRules(netOutRules []garden.NetOutRule) error {
 	}
 
 	ruleSpec := m.Converter.BulkConvert(netOutRules, logChain, m.ASGLogging)
+	ruleSpec = append(ruleSpec, m.denyNetworksRules()...)
 	ruleSpec = append(ruleSpec, []rules.IPTablesRule{
 		{"-p", "tcp", "-m", "state", "--state", "INVALID", "-j", "DROP"},
 		{"-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"},
@@ -225,4 +238,48 @@ func (m *NetOut) appendInputRules(
 	args[0].Rules = append(args[0].Rules, rules.NewInputDefaultRejectRule())
 
 	return args, nil
+}
+
+func (m *NetOut) validateDenyNetworks() error {
+	allDenyNetworkRules := [][]string{
+		m.DenyNetworks.Always,
+		m.DenyNetworks.Running,
+		m.DenyNetworks.Staging,
+	}
+
+	for _, denyNetworks := range allDenyNetworkRules {
+		for destinationIndex, destination := range denyNetworks {
+			_, validatedDestination, err := net.ParseCIDR(destination)
+
+			if err != nil {
+				return fmt.Errorf("deny networks: %s", err)
+			}
+
+			denyNetworks[destinationIndex] = fmt.Sprintf("%s", validatedDestination)
+		}
+	}
+
+	return nil
+}
+
+func (m *NetOut) denyNetworksRules() []rules.IPTablesRule {
+	denyRules := []rules.IPTablesRule{}
+
+	for _, denyNetwork := range m.DenyNetworks.Always {
+		denyRules = append(denyRules, rules.NewInputRejectRule(denyNetwork))
+	}
+
+	if m.ContainerWorkload == "app" || m.ContainerWorkload == "task" {
+		for _, denyNetwork := range m.DenyNetworks.Running {
+			denyRules = append(denyRules, rules.NewInputRejectRule(denyNetwork))
+		}
+	}
+
+	if m.ContainerWorkload == "staging" {
+		for _, denyNetwork := range m.DenyNetworks.Staging {
+			denyRules = append(denyRules, rules.NewInputRejectRule(denyNetwork))
+		}
+	}
+
+	return denyRules
 }

--- a/src/cni-wrapper-plugin/legacynet/netout_test.go
+++ b/src/cni-wrapper-plugin/legacynet/netout_test.go
@@ -269,14 +269,14 @@ var _ = Describe("Netout", func() {
 				Expect(table).To(Equal("filter"))
 				Expect(chain).To(Equal("input-some-container-handle"))
 				Expect(rulespec).To(Equal([]rules.IPTablesRule{
-					{"-m", "state", "--state", "RELATED,ESTABLISHED",
-						"--jump", "ACCEPT"},
+					{"-m", "state", "--state", "RELATED,ESTABLISHED", "--jump", "ACCEPT"},
+
 					{"-p", "tcp", "-d", "8.8.4.4", "--destination-port", "53", "--jump", "ACCEPT"},
 					{"-p", "udp", "-d", "8.8.4.4", "--destination-port", "53", "--jump", "ACCEPT"},
 					{"-p", "tcp", "-d", "1.2.3.4", "--destination-port", "53", "--jump", "ACCEPT"},
 					{"-p", "udp", "-d", "1.2.3.4", "--destination-port", "53", "--jump", "ACCEPT"},
-					{"--jump", "REJECT",
-						"--reject-with", "icmp-port-unreachable"},
+
+					{"--jump", "REJECT", "--reject-with", "icmp-port-unreachable"},
 				}))
 			})
 
@@ -383,12 +383,12 @@ var _ = Describe("Netout", func() {
 				Expect(table).To(Equal("filter"))
 				Expect(chain).To(Equal("input-some-container-handle"))
 				Expect(rulespec).To(Equal([]rules.IPTablesRule{
-					{"-m", "state", "--state", "RELATED,ESTABLISHED",
-						"--jump", "ACCEPT"},
+					{"-m", "state", "--state", "RELATED,ESTABLISHED", "--jump", "ACCEPT"},
+
 					{"-p", "tcp", "-d", "169.125.0.4", "--destination-port", "9001", "--jump", "ACCEPT"},
 					{"-p", "tcp", "-d", "169.125.0.9", "--destination-port", "8080", "--jump", "ACCEPT"},
-					{"--jump", "REJECT",
-						"--reject-with", "icmp-port-unreachable"},
+
+					{"--jump", "REJECT", "--reject-with", "icmp-port-unreachable"},
 				}))
 			})
 
@@ -417,12 +417,12 @@ var _ = Describe("Netout", func() {
 				Expect(table).To(Equal("filter"))
 				Expect(chain).To(Equal("input-some-container-handle"))
 				Expect(rulespec).To(Equal([]rules.IPTablesRule{
-					{"-m", "state", "--state", "RELATED,ESTABLISHED",
-						"--jump", "ACCEPT"},
+					{"-m", "state", "--state", "RELATED,ESTABLISHED", "--jump", "ACCEPT"},
+
 					{"-p", "udp", "-d", "169.125.0.4", "--destination-port", "9001", "--jump", "ACCEPT"},
 					{"-p", "udp", "-d", "169.125.0.9", "--destination-port", "8080", "--jump", "ACCEPT"},
-					{"--jump", "REJECT",
-						"--reject-with", "icmp-port-unreachable"},
+
+					{"--jump", "REJECT", "--reject-with", "icmp-port-unreachable"},
 				}))
 			})
 

--- a/src/cni-wrapper-plugin/legacynet/netout_test.go
+++ b/src/cni-wrapper-plugin/legacynet/netout_test.go
@@ -11,6 +11,7 @@ import (
 	"lib/rules"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -436,6 +437,37 @@ var _ = Describe("Netout", func() {
 				Expect(err).To(MatchError(MatchRegexp("host udp services.*parsing")))
 			})
 		})
+
+		Context("when deny networks are specified", func() {
+			It("returns an error for an incorrectly formatted deny network", func() {
+				netOut.DenyNetworks = legacynet.DenyNetworks{
+					Always: []string{"a.b.c.d", "192.168.0.0/16"},
+				}
+
+				err := netOut.Initialize()
+				Expect(err).To(MatchError(MatchRegexp("deny networks: invalid CIDR address: a.b.c.d")))
+
+				netOut.DenyNetworks = legacynet.DenyNetworks{
+					Always: []string{"1.2.3.4/abc", "192.168.0.0/16"},
+				}
+				err = netOut.Initialize()
+				Expect(err).To(MatchError(MatchRegexp("deny networks: invalid CIDR address: 1.2.3.4/abc")))
+			})
+
+			It("returns an error for an improperly bounded deny network", func() {
+				netOut.DenyNetworks = legacynet.DenyNetworks{
+					Running: []string{"256.256.256.1024/24", "192.168.0.0/16"},
+				}
+				err := netOut.Initialize()
+				Expect(err).To(MatchError(MatchRegexp("deny networks: invalid CIDR address: 256.256.256.1024/24")))
+
+				netOut.DenyNetworks = legacynet.DenyNetworks{
+					Running: []string{"172.16.0.0/35", "192.168.0.0/16"},
+				}
+				err = netOut.Initialize()
+				Expect(err).To(MatchError(MatchRegexp("deny networks: invalid CIDR address: 172.16.0.0/35")))
+			})
+		})
 	})
 
 	Describe("Cleanup", func() {
@@ -669,6 +701,73 @@ var _ = Describe("Netout", func() {
 				Expect(logChainName).To(Equal("some-other-chain-name"))
 				Expect(logging).To(Equal(true))
 			})
+		})
+
+		Context("when deny networks are specified", func() {
+			BeforeEach(func() {
+				netOut.DenyNetworks = legacynet.DenyNetworks{}
+			})
+
+			DescribeTable(
+				"it should deny the workload networks and the 'all' networks",
+				func(workload string, denyNetworks legacynet.DenyNetworks) {
+					netOut.ContainerWorkload = workload
+					netOut.DenyNetworks = denyNetworks
+					netOut.DenyNetworks.Always = []string{"172.16.0.0/12"}
+
+					err := netOut.BulkInsertRules(netOutRules)
+					Expect(err).NotTo(HaveOccurred())
+
+					_, _, _, rulespec := ipTables.BulkInsertArgsForCall(0)
+
+					rulesWithDenyNetworksAndDefaults := append(
+						genericRules,
+						[]rules.IPTablesRule{
+							{"-d", "172.16.0.0/12", "--jump", "REJECT", "--reject-with", "icmp-port-unreachable"},
+							{"-d", "192.168.0.0/16", "--jump", "REJECT", "--reject-with", "icmp-port-unreachable"},
+							{"-p", "tcp", "-m", "state", "--state", "INVALID", "-j", "DROP"},
+							{"-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"},
+						}...,
+					)
+
+					Expect(rulespec).To(Equal(rulesWithDenyNetworksAndDefaults))
+				},
+				Entry("when the workload is an app", "app", legacynet.DenyNetworks{Running: []string{"192.168.0.0/16"}}),
+				Entry("when the workload is a task", "task", legacynet.DenyNetworks{Running: []string{"192.168.0.0/16"}}),
+				Entry("when the workload is staging", "staging", legacynet.DenyNetworks{Staging: []string{"192.168.0.0/16"}}),
+			)
+
+			DescribeTable(
+				"it should only deny the workload networks and the 'all' networks",
+				func(workload string, expectedDenyNetwork string) {
+					netOut.ContainerWorkload = workload
+					netOut.DenyNetworks = legacynet.DenyNetworks{
+						Always:  []string{"1.1.1.1/32"},
+						Running: []string{"2.2.2.2/32"},
+						Staging: []string{"3.3.3.3/32"},
+					}
+
+					err := netOut.BulkInsertRules(netOutRules)
+					Expect(err).NotTo(HaveOccurred())
+
+					_, _, _, rulespec := ipTables.BulkInsertArgsForCall(0)
+
+					rulesWithDenyNetworksAndDefaults := append(
+						genericRules,
+						[]rules.IPTablesRule{
+							{"-d", "1.1.1.1/32", "--jump", "REJECT", "--reject-with", "icmp-port-unreachable"},
+							{"-d", expectedDenyNetwork, "--jump", "REJECT", "--reject-with", "icmp-port-unreachable"},
+							{"-p", "tcp", "-m", "state", "--state", "INVALID", "-j", "DROP"},
+							{"-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"},
+						}...,
+					)
+
+					Expect(rulespec).To(Equal(rulesWithDenyNetworksAndDefaults))
+				},
+				Entry("when the workload is an app", "app", "2.2.2.2/32"),
+				Entry("when the workload is a task", "task", "2.2.2.2/32"),
+				Entry("when the workload is staging", "staging", "3.3.3.3/32"),
+			)
 		})
 	})
 })

--- a/src/cni-wrapper-plugin/lib/lib.go
+++ b/src/cni-wrapper-plugin/lib/lib.go
@@ -17,6 +17,12 @@ type RuntimeConfig struct {
 	NetOutRules  []garden.NetOutRule `json:"netOutRules"`
 }
 
+type DenyNetworksConfig struct {
+	Always  []string `json:"always"`
+	Running []string `json:"running"`
+	Staging []string `json:"staging"`
+}
+
 type WrapperConfig struct {
 	Datastore                       string                 `json:"datastore"`
 	DatastoreFileOwner              string                 `json:"datastore_file_owner"`
@@ -28,6 +34,7 @@ type WrapperConfig struct {
 	DNSServers                      []string               `json:"dns_servers"`
 	HostTCPServices                 []string               `json:"host_tcp_services"`
 	HostUDPServices                 []string               `json:"host_udp_services"`
+	DenyNetworks                    DenyNetworksConfig     `json:"deny_networks"`
 	UnderlayIPs                     []string               `json:"underlay_ips"`
 	TemporaryUnderlayInterfaceNames []string               `json:"temporary_underlay_interface_names"`
 	IPTablesASGLogging              bool                   `json:"iptables_asg_logging"`

--- a/src/cni-wrapper-plugin/main.go
+++ b/src/cni-wrapper-plugin/main.go
@@ -49,6 +49,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 
 	containerIP := result030.IPs[0].Address.IP
+	var containerWorkload string
 
 	// Add container metadata info
 	store := &datastore.Store{
@@ -70,6 +71,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 	if err := json.Unmarshal(args.StdinData, &cniAddData); err != nil {
 		return err // not tested, this should be impossible
+	}
+	if workload, present := cniAddData.Metadata["container_workload"]; present {
+		containerWorkload, _ = workload.(string)
 	}
 
 	if err := store.Add(args.ContainerID, containerIP.String(), cniAddData.Metadata); err != nil {
@@ -134,7 +138,13 @@ func cmdAdd(args *skel.CmdArgs) error {
 		ContainerIP:           containerIP.String(),
 		HostTCPServices:       cfg.HostTCPServices,
 		HostUDPServices:       cfg.HostUDPServices,
-		DNSServers:            localDNSServers,
+		DenyNetworks: legacynet.DenyNetworks{
+			Always:  cfg.DenyNetworks.Always,
+			Running: cfg.DenyNetworks.Running,
+			Staging: cfg.DenyNetworks.Staging,
+		},
+		DNSServers:        localDNSServers,
+		ContainerWorkload: containerWorkload,
 	}
 	if err := netOutProvider.Initialize(); err != nil {
 		return fmt.Errorf("initialize net out: %s", err)

--- a/src/lib/rules/rules.go
+++ b/src/lib/rules/rules.go
@@ -253,6 +253,14 @@ func NewInputAllowRule(protocol, destination string, destPort int) IPTablesRule 
 	}
 }
 
+func NewInputRejectRule(destinationIP string) IPTablesRule {
+	return IPTablesRule{
+		"-d", destinationIP,
+		"--jump", "REJECT",
+		"--reject-with", "icmp-port-unreachable",
+	}
+}
+
 func NewInputDefaultRejectRule() IPTablesRule {
 	return IPTablesRule{
 		"--jump", "REJECT",


### PR DESCRIPTION
See #20

### Context

As a platform operator, restrict certain isolation segments from accessing certain networks.

It is infeasible to use dynamic egress policies, or application security groups (native CF features), if the platform has a default security group which allows access to these networks: ASGs and egress policies do not allow you to deny destinations, only allow.

Allowing ASGs and/or egress policies to do both allow/deny is quite an involved change. Exposing this inside silk is probably fine (IMO)

### Changes

This pull request allows a platform operator to specify a list of CIDR ranges which an app container should not be able to talk to.

This is similar to the [garden property (from the garden-runc release) called `deny_networks`](https://bosh.io/jobs/garden?source=github.com/cloudfoundry/garden-runc-release&version=1.19.10#p%3dgarden.deny_networks), but is controlled via silk instead of garden.

This pull request

- Exposes a new property `deny_networks` in the `silk-cni` job
- Any destinations in the `deny_networks` property is added to a container's `netout` chain, before any of the ASG/dynamic egress policy rules
- Reformats some IPTables expectations to make them easier to read
- Updates the BOSH job spec conflist spec test

### How to use the feature

Consider the following `silk-cni` job running on a diego-cell:

```
consumes:
  vpa:
    from: vpa-dev-1
name: silk-cni
properties:
  deny_networks:
    always:
    - 172.16.0.0/12
    staging: []
    running:
    - 192.168.0.0/16
release: silk
```

Will cause prevent applications from accessing `172.16.0.0/12` all the time, and `192.168.0.0/16` after the application has been staged.

These rules are added before ASGs and dynamic egress policies, but after DNS requests.

### How to test this against a live environment

1. Deploy against a live environment

2. Play around with `/var/vcap/jobs/silk-cni/config/cni/cni-wrapper-plugin.conflist`
  1. Deny `0.0.0.0/0` when `staging` and try to deploy an app
  2. Deny `93.184.216.34/32` when `running` and try to `curl example.com` from an app
  3. Deny the subnet for `dig buildpacks.cloudfoundry.org` and try pushing an app

### Checklist

- [x] Updated the relevant BOSH job spec
- [x] Run all the tests locally `/scripts/docker-test`
- [x] Deployed to my development environment
- [x] Signed the CLA

### Contact

@tlwr in Cloud Foundry slack

### Appendix

I've deployed this, after rebasing and changing the job interface

Let me know if you want me to fix up the commits to make things more atomic