### PR TITLE
Introduce container outbound connection count rate limiting

### DIFF
--- a/jobs/silk-cni/spec
+++ b/jobs/silk-cni/spec
@@ -101,10 +101,6 @@ properties:
     default: false
     description: "Enables outbound connections count limiting per destination host per container."
 
-  outbound_connections.max:
-    default: 1000
-    description: "Hard limit of outbound connections count per destination host allowed per container. Has no effect when `outbound_connections.limit` is false."
-
   outbound_connections.burst:
     default: 1000
     description: "Maximum number of outbound connections per destination host allowed to be opened at once per container. Has no effect when `outbound_connections.limit` is false."

--- a/jobs/silk-cni/spec
+++ b/jobs/silk-cni/spec
@@ -99,14 +99,14 @@ properties:
 
   outbound_connections.limit:
     default: false
-    description: "Enables outbound connections count limiting per destination host per container."
+    description: "EXPERIMENTAL: Enables outbound connections count limiting per destination host per container."
 
   outbound_connections.burst:
     default: 1000
-    description: "Maximum number of outbound connections per destination host allowed to be opened at once per container. Has no effect when `outbound_connections.limit` is false."
+    description: "EXPERIMENTAL: Maximum number of outbound connections per destination host allowed to be opened at once per container. Has no effect when `outbound_connections.limit` is false."
 
   outbound_connections.rate_per_sec:
     default: 100
     description: |
-      Maximum number of outbound connections to be opened per second per destination host per container given that the burst is exhausted.
+      EXPERIMENTAL: Maximum number of outbound connections to be opened per second per destination host per container given that the burst is exhausted.
       Has no effect when `outbound_connections.limit` is false.

--- a/jobs/silk-cni/spec
+++ b/jobs/silk-cni/spec
@@ -99,14 +99,16 @@ properties:
 
   outbound_connections.limit:
     default: false
-    description: "EXPERIMENTAL: Enables outbound connections count limiting per destination host per container."
+    description: "EXPERIMENTAL: Enables outbound connections count limiting per port on destination host per container."
 
   outbound_connections.burst:
     default: 1000
-    description: "EXPERIMENTAL: Maximum number of outbound connections per destination host allowed to be opened at once per container. Has no effect when `outbound_connections.limit` is false."
+    description: |
+      EXPERIMENTAL: Maximum number of outbound connections per port on destination host allowed to be opened at once per container.
+      Has no effect when `outbound_connections.limit` is false.
 
   outbound_connections.rate_per_sec:
     default: 100
     description: |
-      EXPERIMENTAL: Maximum number of outbound connections to be opened per second per destination host per container given that the burst is exhausted.
+      EXPERIMENTAL: Maximum number of outbound connections to be opened per second per port on destination host per container given that the burst is exhausted.
       Has no effect when `outbound_connections.limit` is false.

--- a/jobs/silk-cni/spec
+++ b/jobs/silk-cni/spec
@@ -96,3 +96,21 @@ properties:
       This can severely impact the network connectivity of applications.
       Use with extreme caution and at your own risk.
       These rules apply during the staging process.
+
+  outbound_connections.limit:
+    default: false
+    description: "Enables outbound connections count limiting per destination host per container."
+
+  outbound_connections.max:
+    default: 1000
+    description: "Hard limit of outbound connections count per destination host allowed per container. Has no effect when `outbound_connections.limit` is false."
+
+  outbound_connections.burst:
+    default: 1000
+    description: "Maximum number of outbound connections per destination host allowed to be opened at once per container. Has no effect when `outbound_connections.limit` is false."
+
+  outbound_connections.rate_per_sec:
+    default: 100
+    description: |
+      Maximum number of outbound connections to be opened per second per destination host per container given that the burst is exhausted.
+      Has no effect when `outbound_connections.limit` is false.

--- a/jobs/silk-cni/spec
+++ b/jobs/silk-cni/spec
@@ -28,7 +28,7 @@ properties:
     description: "Silk CNI plugin connects to the silk daemon on this port."
     default: 23954
   iptables_logging:
-    description: "Enables iptables logging for overlay network policies and Application Security Groups.  Logs to the kernel log."
+    description: "Enables iptables logging for overlay network policies, Application Security Groups and outbound container connection limits.  Logs to the kernel log."
     default: false
 
   dns_servers:

--- a/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
+++ b/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
@@ -80,6 +80,7 @@
       },
       'outbound_connections' => {
         'limit' => p('outbound_connections.limit'),
+        'logging' => p('iptables_logging'),
         'max' => p('outbound_connections.max'),
         'burst' => p('outbound_connections.burst'),
         'rate_per_sec' => p('outbound_connections.rate_per_sec'),

--- a/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
+++ b/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
@@ -77,7 +77,13 @@
         'dataDir' => '/var/vcap/data/host-local',
         'datastore' => '/var/vcap/data/silk/store.json',
         'mtu' => compute_mtu,
-       }
+      },
+      'outbound_connections' => {
+        'limit' => p('outbound_connections.limit'),
+        'max' => p('outbound_connections.max'),
+        'burst' => p('outbound_connections.burst'),
+        'rate_per_sec' => p('outbound_connections.rate_per_sec'),
+      }
     }, {
       'name' => 'bandwidth-limit',
       'type' => 'bandwidth',

--- a/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
+++ b/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
@@ -81,7 +81,6 @@
       'outbound_connections' => {
         'limit' => p('outbound_connections.limit'),
         'logging' => p('iptables_logging'),
-        'max' => p('outbound_connections.max'),
         'burst' => p('outbound_connections.burst'),
         'rate_per_sec' => p('outbound_connections.rate_per_sec'),
       }

--- a/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
+++ b/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
@@ -93,7 +93,6 @@ module Bosh::Template::Test
             'outbound_connections' => {
               'limit' => true,
               'logging' => true,
-              'max' => 1000,
               'burst' => 1000,
               'rate_per_sec' => 100,
             }

--- a/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
+++ b/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
@@ -35,6 +35,9 @@ module Bosh::Template::Test
           'always' => ['1.1.1.1/32'],
           'running' => ['2.2.2.2/32'],
           'staging' => ['3.3.3.3/32'],
+        },
+        'outbound_connections' => {
+          'limit' => true,
         }
       }
     end
@@ -86,6 +89,12 @@ module Bosh::Template::Test
               'dataDir' => '/var/vcap/data/host-local',
               'datastore' => '/var/vcap/data/silk/store.json',
               'mtu' => 0
+            },
+            'outbound_connections' => {
+              'limit' => true,
+              'max' => 1000,
+              'burst' => 1000,
+              'rate_per_sec' => 100,
             }
           }, {
             'name' => 'bandwidth-limit',

--- a/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
+++ b/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
@@ -92,6 +92,7 @@ module Bosh::Template::Test
             },
             'outbound_connections' => {
               'limit' => true,
+              'logging' => true,
               'max' => 1000,
               'burst' => 1000,
               'rate_per_sec' => 100,

--- a/src/cni-wrapper-plugin/legacynet/conn.go
+++ b/src/cni-wrapper-plugin/legacynet/conn.go
@@ -1,0 +1,8 @@
+package legacynet
+
+type Conn struct {
+	Limit bool
+	Max   string
+	Burst string
+	Rate  string
+}

--- a/src/cni-wrapper-plugin/legacynet/conn.go
+++ b/src/cni-wrapper-plugin/legacynet/conn.go
@@ -1,8 +1,0 @@
-package legacynet
-
-type Conn struct {
-	Limit bool
-	Max   string
-	Burst string
-	Rate  string
-}

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
@@ -235,6 +235,12 @@ var _ = Describe("CniWrapperPlugin", func() {
 						},
 					},
 				},
+				OutConn: lib.OutConnConfig{
+					Limit:      false,
+					Max:        1000,
+					Burst:      999,
+					RatePerSec: 100,
+				},
 			},
 		}
 

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
@@ -802,9 +802,10 @@ var _ = Describe("CniWrapperPlugin", func() {
 				})
 			})
 
-			Context("when outbound container connection limiting is enabled", func() {
+			Context("when outbound container connection limiting with logging is enabled", func() {
 				BeforeEach(func() {
 					inputStruct.WrapperConfig.OutConn.Limit = true
+					inputStruct.WrapperConfig.OutConn.Logging = true
 					input = GetInput(inputStruct)
 				})
 

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
@@ -819,13 +819,13 @@ var _ = Describe("CniWrapperPlugin", func() {
 
 					By("writing the default forwarding and outbound connection rate limit rule for that container")
 
-					expectedRateLimitCfg := "-m hashlimit --hashlimit-above 100/sec --hashlimit-burst 999 --hashlimit-mode dstip"
+					expectedRateLimitCfg := "-m hashlimit --hashlimit-above 100/sec --hashlimit-burst 999 --hashlimit-mode dstip,dstport"
 					expectedRateLimitCfg += " --hashlimit-name " + containerID + " --hashlimit-htable-expire 10000"
 
 					Expect(AllIPTablesRules("filter")).To(gomegamatchers.ContainSequence([]string{
 						`-A ` + netoutChainName + ` -m state --state RELATED,ESTABLISHED -j ACCEPT`,
 						`-A ` + netoutChainName + ` -p tcp -m state --state INVALID -j DROP`,
-						`-A ` + netoutChainName + ` -m conntrack --ctstate NEW ` + expectedRateLimitCfg + ` -j netout--some-contain--rl-log`,
+						`-A ` + netoutChainName + ` -p tcp -m conntrack --ctstate NEW ` + expectedRateLimitCfg + ` -j netout--some-contain--rl-log`,
 						`-A ` + netoutChainName + ` -p icmp -m iprange --dst-range 5.5.5.5-6.6.6.6 -m icmp --icmp-type 8/0 -j ACCEPT`,
 						`-A ` + netoutChainName + ` -p udp -m iprange --dst-range 11.11.11.11-22.22.22.22 -m udp --dport 53:54 -j ACCEPT`,
 						`-A ` + netoutChainName + ` -p tcp -m iprange --dst-range 8.8.8.8-9.9.9.9 -m tcp --dport 53:54 -j ACCEPT`,

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
@@ -821,7 +821,9 @@ var _ = Describe("CniWrapperPlugin", func() {
 					By("writing the default forwarding and outbound connection limit rules for that container")
 
 					expectedHardLimitCfg := "-m connlimit --connlimit-above 1000 --connlimit-mask 32 --connlimit-daddr"
-					expectedRateLimitCfg := "-m hashlimit --hashlimit-above 100/sec --hashlimit-burst 999 --hashlimit-mode dstip --hashlimit-name " + containerID
+					expectedRateLimitCfg := "-m hashlimit --hashlimit-above 100/sec --hashlimit-burst 999 --hashlimit-mode dstip"
+					expectedRateLimitCfg += " --hashlimit-name " + containerID + " --hashlimit-htable-expire 10000"
+
 					Expect(AllIPTablesRules("filter")).To(gomegamatchers.ContainSequence([]string{
 						`-A ` + netoutChainName + ` -m state --state RELATED,ESTABLISHED -j ACCEPT`,
 						`-A ` + netoutChainName + ` -p tcp -m state --state INVALID -j DROP`,

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/legacynet/netout_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/legacynet/netout_test.go
@@ -894,9 +894,9 @@ var _ = Describe("Netout", func() {
 		Context("when outbound container connection limiting is enabled", func() {
 			BeforeEach(func() {
 				netOut.Conn.Limit = true
-				netOut.Conn.Max = "500"
-				netOut.Conn.Burst = "400"
-				netOut.Conn.Rate = "100/sec"
+				netOut.Conn.Max = 500
+				netOut.Conn.Burst = 400
+				netOut.Conn.RatePerSec = 99
 
 				chainNamer.PostfixReturnsOnCall(1, "netout-some-container-handle-rl-log", nil)
 				chainNamer.PostfixReturnsOnCall(2, "netout-some-container-handle-hl-log", nil)
@@ -917,8 +917,9 @@ var _ = Describe("Netout", func() {
 
 				expectedRateLimitRule := rules.IPTablesRule{
 					"-m", "conntrack", "--ctstate", "NEW",
-					"-m", "hashlimit", "--hashlimit-above", "100/sec", "--hashlimit-burst", "400",
-					"--hashlimit-mode", "dstip", "--hashlimit-name", "some-container-handle", "-j", "netout-some-container-handle-rl-log",
+					"-m", "hashlimit", "--hashlimit-above", "99/sec", "--hashlimit-burst", "400",
+					"--hashlimit-mode", "dstip", "--hashlimit-name", "some-container-handle",
+					"--hashlimit-htable-expire", "5000", "-j", "netout-some-container-handle-rl-log",
 				}
 				expectedHardLimitRule := rules.IPTablesRule{
 					"-m", "conntrack", "--ctstate", "NEW",

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/legacynet/netout_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/legacynet/netout_test.go
@@ -481,74 +481,94 @@ var _ = Describe("Netout", func() {
 				chainNamer.PostfixReturnsOnCall(2, "netout-some-container-handle-rl-log", nil)
 			})
 
-			It("additionally creates the hard and rate limit logging chains", func() {
-				err := netOut.Initialize()
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(chainNamer.PostfixCallCount()).To(Equal(3))
-				body, suffix := chainNamer.PostfixArgsForCall(1)
-				Expect(body).To(Equal("netout-some-container-handle"))
-				Expect(suffix).To(Equal("hl-log"))
-
-				body, suffix = chainNamer.PostfixArgsForCall(2)
-				Expect(body).To(Equal("netout-some-container-handle"))
-				Expect(suffix).To(Equal("rl-log"))
-
-				Expect(ipTables.NewChainCallCount()).To(Equal(6))
-				table, chain := ipTables.NewChainArgsForCall(4)
-				Expect(table).To(Equal("filter"))
-				Expect(chain).To(Equal("netout-some-container-handle-hl-log"))
-
-				table, chain = ipTables.NewChainArgsForCall(5)
-				Expect(table).To(Equal("filter"))
-				Expect(chain).To(Equal("netout-some-container-handle-rl-log"))
-			})
-
-			It("additionally writes the hard and rate limit logging rules", func() {
-				err := netOut.Initialize()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(ipTables.BulkAppendCallCount()).To(Equal(9))
-
-				table, chain, rulespec := ipTables.BulkAppendArgsForCall(7)
-				Expect(table).To(Equal("filter"))
-				Expect(chain).To(Equal("netout-some-container-handle-hl-log"))
-				Expect(rulespec).To(Equal([]rules.IPTablesRule{
-					{"-m", "limit", "--limit", "3/s", "--limit-burst", "3",
-						"--jump", "LOG", "--log-prefix", `"DENY_OHL_some-container-hand "`},
-					{"--jump", "REJECT", "--reject-with", "icmp-port-unreachable"},
-				}))
-
-				table, chain, rulespec = ipTables.BulkAppendArgsForCall(8)
-				Expect(table).To(Equal("filter"))
-				Expect(chain).To(Equal("netout-some-container-handle-rl-log"))
-				Expect(rulespec).To(Equal([]rules.IPTablesRule{
-					{"-m", "limit", "--limit", "3/s", "--limit-burst", "3",
-						"--jump", "LOG", "--log-prefix", `"DENY_ORL_some-container-hand "`},
-					{"--jump", "REJECT", "--reject-with", "icmp-port-unreachable"},
-				}))
-			})
-
-			Context("when the chain namer fails", func() {
-				Context("when naming the hard limit chain", func() {
-					BeforeEach(func() {
-						chainNamer.PostfixReturnsOnCall(1, "", errors.New("pineapple"))
-					})
-
-					It("returns the error", func() {
-						err := netOut.Initialize()
-						Expect(err).To(MatchError("getting chain name: pineapple"))
-					})
+			Context("when denied outbound container connections logging is enabled", func() {
+				BeforeEach(func() {
+					netOut.Conn.Logging = true
 				})
 
-				Context("when naming the rate limit chain", func() {
-					BeforeEach(func() {
-						chainNamer.PostfixReturnsOnCall(2, "", errors.New("mango"))
+				It("additionally creates the hard and rate limit logging chains", func() {
+					err := netOut.Initialize()
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(chainNamer.PostfixCallCount()).To(Equal(3))
+					body, suffix := chainNamer.PostfixArgsForCall(1)
+					Expect(body).To(Equal("netout-some-container-handle"))
+					Expect(suffix).To(Equal("hl-log"))
+
+					body, suffix = chainNamer.PostfixArgsForCall(2)
+					Expect(body).To(Equal("netout-some-container-handle"))
+					Expect(suffix).To(Equal("rl-log"))
+
+					Expect(ipTables.NewChainCallCount()).To(Equal(6))
+					table, chain := ipTables.NewChainArgsForCall(4)
+					Expect(table).To(Equal("filter"))
+					Expect(chain).To(Equal("netout-some-container-handle-hl-log"))
+
+					table, chain = ipTables.NewChainArgsForCall(5)
+					Expect(table).To(Equal("filter"))
+					Expect(chain).To(Equal("netout-some-container-handle-rl-log"))
+				})
+
+				It("additionally writes the hard and rate limit logging rules", func() {
+					err := netOut.Initialize()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ipTables.BulkAppendCallCount()).To(Equal(9))
+
+					table, chain, rulespec := ipTables.BulkAppendArgsForCall(7)
+					Expect(table).To(Equal("filter"))
+					Expect(chain).To(Equal("netout-some-container-handle-hl-log"))
+					Expect(rulespec).To(Equal([]rules.IPTablesRule{
+						{"-m", "limit", "--limit", "3/s", "--limit-burst", "3",
+							"--jump", "LOG", "--log-prefix", `"DENY_OHL_some-container-hand "`},
+						{"--jump", "REJECT", "--reject-with", "icmp-port-unreachable"},
+					}))
+
+					table, chain, rulespec = ipTables.BulkAppendArgsForCall(8)
+					Expect(table).To(Equal("filter"))
+					Expect(chain).To(Equal("netout-some-container-handle-rl-log"))
+					Expect(rulespec).To(Equal([]rules.IPTablesRule{
+						{"-m", "limit", "--limit", "3/s", "--limit-burst", "3",
+							"--jump", "LOG", "--log-prefix", `"DENY_ORL_some-container-hand "`},
+						{"--jump", "REJECT", "--reject-with", "icmp-port-unreachable"},
+					}))
+				})
+
+				Context("when the chain namer fails", func() {
+					Context("when naming the hard limit chain", func() {
+						BeforeEach(func() {
+							chainNamer.PostfixReturnsOnCall(1, "", errors.New("pineapple"))
+						})
+
+						It("returns the error", func() {
+							err := netOut.Initialize()
+							Expect(err).To(MatchError("getting chain name: pineapple"))
+						})
 					})
 
-					It("returns the error", func() {
-						err := netOut.Initialize()
-						Expect(err).To(MatchError("getting chain name: mango"))
+					Context("when naming the rate limit chain", func() {
+						BeforeEach(func() {
+							chainNamer.PostfixReturnsOnCall(2, "", errors.New("mango"))
+						})
+
+						It("returns the error", func() {
+							err := netOut.Initialize()
+							Expect(err).To(MatchError("getting chain name: mango"))
+						})
 					})
+				})
+			})
+
+			Context("when denied outbound container connections logging is disabled", func() {
+				BeforeEach(func() {
+					netOut.Conn.Logging = false
+				})
+
+				It("doesn't add the hard and rate limit logging chains", func() {
+					err := netOut.Initialize()
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(chainNamer.PostfixCallCount()).To(Equal(1))
+					Expect(ipTables.NewChainCallCount()).To(Equal(4))
 				})
 			})
 		})
@@ -707,32 +727,52 @@ var _ = Describe("Netout", func() {
 				chainNamer.PostfixReturnsOnCall(2, "netout-some-container-handle-rl-log", nil)
 			})
 
-			It("additionally clears the connection limit logging chains", func() {
-				err := netOut.Cleanup()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(ipTables.DeleteChainCallCount()).To(Equal(6))
+			Context("when denied outbound container connections logging is enabled", func() {
+				BeforeEach(func() {
+					netOut.Conn.Logging = true
+				})
 
-				table, chain := ipTables.DeleteChainArgsForCall(4)
-				Expect(table).To(Equal("filter"))
-				Expect(chain).To(Equal("netout-some-container-handle-hl-log"))
+				It("additionally clears the connection limit logging chains", func() {
+					err := netOut.Cleanup()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ipTables.ClearChainCallCount()).To(Equal(6))
 
-				table, chain = ipTables.DeleteChainArgsForCall(5)
-				Expect(table).To(Equal("filter"))
-				Expect(chain).To(Equal("netout-some-container-handle-rl-log"))
+					table, chain := ipTables.ClearChainArgsForCall(4)
+					Expect(table).To(Equal("filter"))
+					Expect(chain).To(Equal("netout-some-container-handle-hl-log"))
+
+					table, chain = ipTables.ClearChainArgsForCall(5)
+					Expect(table).To(Equal("filter"))
+					Expect(chain).To(Equal("netout-some-container-handle-rl-log"))
+				})
+
+				It("additionally deletes the connection limit logging chains", func() {
+					err := netOut.Cleanup()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ipTables.DeleteChainCallCount()).To(Equal(6))
+
+					table, chain := ipTables.DeleteChainArgsForCall(4)
+					Expect(table).To(Equal("filter"))
+					Expect(chain).To(Equal("netout-some-container-handle-hl-log"))
+
+					table, chain = ipTables.DeleteChainArgsForCall(5)
+					Expect(table).To(Equal("filter"))
+					Expect(chain).To(Equal("netout-some-container-handle-rl-log"))
+				})
 			})
 
-			It("additionally deletes the connection limit logging chains", func() {
-				err := netOut.Cleanup()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(ipTables.DeleteChainCallCount()).To(Equal(6))
+			Context("when denied outbound container connections logging is disabled", func() {
+				BeforeEach(func() {
+					netOut.Conn.Logging = false
+				})
 
-				table, chain := ipTables.DeleteChainArgsForCall(4)
-				Expect(table).To(Equal("filter"))
-				Expect(chain).To(Equal("netout-some-container-handle-hl-log"))
+				It("doesn't clean up the hard and rate limit logging chains", func() {
+					err := netOut.Cleanup()
+					Expect(err).NotTo(HaveOccurred())
 
-				table, chain = ipTables.DeleteChainArgsForCall(5)
-				Expect(table).To(Equal("filter"))
-				Expect(chain).To(Equal("netout-some-container-handle-rl-log"))
+					Expect(ipTables.ClearChainCallCount()).To(Equal(4))
+					Expect(ipTables.DeleteChainCallCount()).To(Equal(4))
+				})
 			})
 		})
 	})
@@ -902,61 +942,111 @@ var _ = Describe("Netout", func() {
 				chainNamer.PostfixReturnsOnCall(2, "netout-some-container-handle-hl-log", nil)
 			})
 
-			It("inserts hard and rate limit rules", func() {
-				err := netOut.BulkInsertRules(netOutRules)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(ipTables.BulkInsertCallCount()).To(Equal(1))
-				table, chain, pos, rulespec := ipTables.BulkInsertArgsForCall(0)
-
-				Expect(table).To(Equal("filter"))
-				Expect(chain).To(Equal("netout-some-container-handle"))
-				Expect(pos).To(Equal(1))
-
-				Expect(chainNamer.PostfixCallCount()).To(Equal(3))
-
-				expectedRateLimitRule := rules.IPTablesRule{
-					"-m", "conntrack", "--ctstate", "NEW",
-					"-m", "hashlimit", "--hashlimit-above", "99/sec", "--hashlimit-burst", "400",
-					"--hashlimit-mode", "dstip", "--hashlimit-name", "some-container-handle",
-					"--hashlimit-htable-expire", "5000", "-j", "netout-some-container-handle-rl-log",
-				}
-				expectedHardLimitRule := rules.IPTablesRule{
-					"-m", "conntrack", "--ctstate", "NEW",
-					"-m", "connlimit", "--connlimit-above", "500", "--connlimit-mask", "32", "--connlimit-daddr",
-					"-j", "netout-some-container-handle-hl-log",
-				}
-				expectedRules := append(genericRules, []rules.IPTablesRule{
-					expectedRateLimitRule,
-					expectedHardLimitRule,
-					{"-p", "tcp", "-m", "state", "--state", "INVALID", "-j", "DROP"},
-					{"-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"},
-				}...)
-
-				Expect(rulespec).To(Equal(expectedRules))
-			})
-
-			Context("when the chain namer fails", func() {
-				Context("when naming the rate limit chain", func() {
-					BeforeEach(func() {
-						chainNamer.PostfixReturnsOnCall(1, "", errors.New("guacamole"))
-					})
-
-					It("returns the error", func() {
-						err := netOut.BulkInsertRules(netOutRules)
-						Expect(err).To(MatchError("getting chain name: guacamole"))
-					})
+			Context("when denied outbound container connections logging is enabled", func() {
+				BeforeEach(func() {
+					netOut.Conn.Logging = true
 				})
 
-				Context("when naming the rate limit chain", func() {
-					BeforeEach(func() {
-						chainNamer.PostfixReturnsOnCall(2, "", errors.New("papaya"))
+				It("inserts hard and rate limit rules", func() {
+					err := netOut.BulkInsertRules(netOutRules)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(ipTables.BulkInsertCallCount()).To(Equal(1))
+					table, chain, pos, rulespec := ipTables.BulkInsertArgsForCall(0)
+
+					Expect(table).To(Equal("filter"))
+					Expect(chain).To(Equal("netout-some-container-handle"))
+					Expect(pos).To(Equal(1))
+
+					Expect(chainNamer.PostfixCallCount()).To(Equal(3))
+
+					By("specifying a jump condition to the respective logging chains")
+
+					expectedRateLimitRule := rules.IPTablesRule{
+						"-m", "conntrack", "--ctstate", "NEW",
+						"-m", "hashlimit", "--hashlimit-above", "99/sec", "--hashlimit-burst", "400",
+						"--hashlimit-mode", "dstip", "--hashlimit-name", "some-container-handle",
+						"--hashlimit-htable-expire", "5000", "-j", "netout-some-container-handle-rl-log",
+					}
+					expectedHardLimitRule := rules.IPTablesRule{
+						"-m", "conntrack", "--ctstate", "NEW",
+						"-m", "connlimit", "--connlimit-above", "500", "--connlimit-mask", "32", "--connlimit-daddr",
+						"-j", "netout-some-container-handle-hl-log",
+					}
+					expectedRules := append(genericRules, []rules.IPTablesRule{
+						expectedRateLimitRule,
+						expectedHardLimitRule,
+						{"-p", "tcp", "-m", "state", "--state", "INVALID", "-j", "DROP"},
+						{"-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"},
+					}...)
+
+					Expect(rulespec).To(Equal(expectedRules))
+				})
+
+				Context("when the chain namer fails", func() {
+					Context("when naming the rate limit chain", func() {
+						BeforeEach(func() {
+							chainNamer.PostfixReturnsOnCall(1, "", errors.New("guacamole"))
+						})
+
+						It("returns the error", func() {
+							err := netOut.BulkInsertRules(netOutRules)
+							Expect(err).To(MatchError("getting chain name: guacamole"))
+						})
 					})
 
-					It("returns the error", func() {
-						err := netOut.BulkInsertRules(netOutRules)
-						Expect(err).To(MatchError("getting chain name: papaya"))
+					Context("when naming the rate limit chain", func() {
+						BeforeEach(func() {
+							chainNamer.PostfixReturnsOnCall(2, "", errors.New("papaya"))
+						})
+
+						It("returns the error", func() {
+							err := netOut.BulkInsertRules(netOutRules)
+							Expect(err).To(MatchError("getting chain name: papaya"))
+						})
 					})
+				})
+			})
+
+			Context("when denied outbound container connections logging is disabled", func() {
+				BeforeEach(func() {
+					netOut.Conn.Logging = false
+				})
+
+				It("inserts hard and rate limit rules", func() {
+					err := netOut.BulkInsertRules(netOutRules)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(ipTables.BulkInsertCallCount()).To(Equal(1))
+					table, chain, pos, rulespec := ipTables.BulkInsertArgsForCall(0)
+
+					Expect(table).To(Equal("filter"))
+					Expect(chain).To(Equal("netout-some-container-handle"))
+					Expect(pos).To(Equal(1))
+
+					Expect(chainNamer.PostfixCallCount()).To(Equal(1))
+
+					By("specifying a REJECT jump condition")
+
+					expectedRateLimitRule := rules.IPTablesRule{
+						"-m", "conntrack", "--ctstate", "NEW",
+						"-m", "hashlimit", "--hashlimit-above", "99/sec", "--hashlimit-burst", "400",
+						"--hashlimit-mode", "dstip", "--hashlimit-name", "some-container-handle",
+						"--hashlimit-htable-expire", "5000", "-j", "REJECT",
+					}
+					expectedHardLimitRule := rules.IPTablesRule{
+						"-m", "conntrack", "--ctstate", "NEW",
+						"-m", "connlimit", "--connlimit-above", "500", "--connlimit-mask", "32", "--connlimit-daddr",
+						"-j", "REJECT",
+					}
+					expectedRules := append(genericRules, []rules.IPTablesRule{
+						expectedRateLimitRule,
+						expectedHardLimitRule,
+						{"-p", "tcp", "-m", "state", "--state", "INVALID", "-j", "DROP"},
+						{"-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"},
+					}...)
+
+					Expect(rulespec).To(Equal(expectedRules))
 				})
 			})
 		})

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/legacynet/netout_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/legacynet/netout_test.go
@@ -921,9 +921,10 @@ var _ = Describe("Netout", func() {
 					By("specifying a jump condition to the respective logging chains")
 
 					expectedRateLimitRule := rules.IPTablesRule{
+						"-p", "tcp",
 						"-m", "conntrack", "--ctstate", "NEW",
 						"-m", "hashlimit", "--hashlimit-above", "99/sec", "--hashlimit-burst", "400",
-						"--hashlimit-mode", "dstip", "--hashlimit-name", "some-container-handle",
+						"--hashlimit-mode", "dstip,dstport", "--hashlimit-name", "some-container-handle",
 						"--hashlimit-htable-expire", "5000", "-j", "netout-some-container-handle-rl-log",
 					}
 					expectedRules := append(genericRules, []rules.IPTablesRule{
@@ -970,9 +971,10 @@ var _ = Describe("Netout", func() {
 					By("specifying a REJECT jump condition")
 
 					expectedRateLimitRule := rules.IPTablesRule{
+						"-p", "tcp",
 						"-m", "conntrack", "--ctstate", "NEW",
 						"-m", "hashlimit", "--hashlimit-above", "99/sec", "--hashlimit-burst", "400",
-						"--hashlimit-mode", "dstip", "--hashlimit-name", "some-container-handle",
+						"--hashlimit-mode", "dstip,dstport", "--hashlimit-name", "some-container-handle",
 						"--hashlimit-htable-expire", "5000", "-j", "REJECT",
 					}
 					expectedRules := append(genericRules, []rules.IPTablesRule{

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib.go
@@ -23,6 +23,13 @@ type DenyNetworksConfig struct {
 	Staging []string `json:"staging"`
 }
 
+type OutConnConfig struct {
+	Limit      bool `json:"limit"`
+	Max        int  `json:"max" validate:"min=1"`
+	Burst      int  `json:"burst" validate:"min=1"`
+	RatePerSec int  `json:"rate_per_sec" validate:"min=1"`
+}
+
 type WrapperConfig struct {
 	Datastore                       string                 `json:"datastore"`
 	DatastoreFileOwner              string                 `json:"datastore_file_owner"`
@@ -45,6 +52,7 @@ type WrapperConfig struct {
 	VTEPName                        string                 `json:"vtep_name"`
 	RuntimeConfig                   RuntimeConfig          `json:"runtimeConfig,omitempty"`
 	PolicyAgentForcePollAddress     string                 `json:"policy_agent_force_poll_address" validate:"nonzero"`
+	OutConn                         OutConnConfig          `json:"outbound_connections"`
 }
 
 func LoadWrapperConfig(bytes []byte) (*WrapperConfig, error) {
@@ -87,6 +95,18 @@ func LoadWrapperConfig(bytes []byte) (*WrapperConfig, error) {
 
 	if _, ok := n.Delegate["cniVersion"]; !ok {
 		n.Delegate["cniVersion"] = version.Current()
+	}
+
+	if n.OutConn.Max <= 0 {
+		return nil, fmt.Errorf("invalid outbound connection max")
+	}
+
+	if n.OutConn.Burst <= 0 {
+		return nil, fmt.Errorf("invalid outbound connection burst")
+	}
+
+	if n.OutConn.RatePerSec <= 0 {
+		return nil, fmt.Errorf("invalid outbound connection rate")
 	}
 
 	validator.Validate(n)

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib.go
@@ -26,7 +26,6 @@ type DenyNetworksConfig struct {
 type OutConnConfig struct {
 	Limit      bool `json:"limit"`
 	Logging    bool `json:"logging"`
-	Max        int  `json:"max" validate:"min=1"`
 	Burst      int  `json:"burst" validate:"min=1"`
 	RatePerSec int  `json:"rate_per_sec" validate:"min=1"`
 }
@@ -96,10 +95,6 @@ func LoadWrapperConfig(bytes []byte) (*WrapperConfig, error) {
 
 	if _, ok := n.Delegate["cniVersion"]; !ok {
 		n.Delegate["cniVersion"] = version.Current()
-	}
-
-	if n.OutConn.Max <= 0 {
-		return nil, fmt.Errorf("invalid outbound connection max")
 	}
 
 	if n.OutConn.Burst <= 0 {

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib.go
@@ -25,6 +25,7 @@ type DenyNetworksConfig struct {
 
 type OutConnConfig struct {
 	Limit      bool `json:"limit"`
+	Logging    bool `json:"logging"`
 	Max        int  `json:"max" validate:"min=1"`
 	Burst      int  `json:"burst" validate:"min=1"`
 	RatePerSec int  `json:"rate_per_sec" validate:"min=1"`

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib_test.go
@@ -40,6 +40,7 @@ var _ = Describe("LoadWrapperConfig", func() {
 			"iptables_accepted_udp_logs_per_sec": 4,
 			"outbound_connections": {
 				"limit": true,
+				"logging": true,
 				"max": 1000,
 				"burst": 900,
 				"rate_per_sec": 100
@@ -70,6 +71,7 @@ var _ = Describe("LoadWrapperConfig", func() {
 			IPTablesAcceptedUDPLogsPerSec: 4,
 			OutConn: lib.OutConnConfig{
 				Limit:      true,
+				Logging:    true,
 				Max:        1000,
 				Burst:      900,
 				RatePerSec: 100,

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib_test.go
@@ -41,7 +41,6 @@ var _ = Describe("LoadWrapperConfig", func() {
 			"outbound_connections": {
 				"limit": true,
 				"logging": true,
-				"max": 1000,
 				"burst": 900,
 				"rate_per_sec": 100
 			}
@@ -72,7 +71,6 @@ var _ = Describe("LoadWrapperConfig", func() {
 			OutConn: lib.OutConnConfig{
 				Limit:      true,
 				Logging:    true,
-				Max:        1000,
 				Burst:      900,
 				RatePerSec: 100,
 			},
@@ -157,9 +155,8 @@ var _ = Describe("LoadWrapperConfig", func() {
 	},
 		Entry("denied logs per sec", "iptables_denied_logs_per_sec", -1, "invalid denied logs per sec"),
 		Entry("accepted udp logs per sec", "iptables_accepted_udp_logs_per_sec", -1, "invalid accepted udp logs per sec"),
-		Entry("out conn max", "outbound_connections", map[string]interface{}{"max": 0}, "invalid outbound connection max"),
-		Entry("out conn burst", "outbound_connections", map[string]interface{}{"max": 1, "burst": -1}, "invalid outbound connection burst"),
-		Entry("out conn rate", "outbound_connections", map[string]interface{}{"max": 1, "burst": 1, "rate_per_sec": -1}, "invalid outbound connection rate"),
+		Entry("out conn burst", "outbound_connections", map[string]interface{}{"burst": -1}, "invalid outbound connection burst"),
+		Entry("out conn rate", "outbound_connections", map[string]interface{}{"burst": 1, "rate_per_sec": -1}, "invalid outbound connection rate"),
 	)
 })
 

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib_test.go
@@ -37,7 +37,13 @@ var _ = Describe("LoadWrapperConfig", func() {
 				"some": "info"
 			},
 			"iptables_denied_logs_per_sec": 2,
-			"iptables_accepted_udp_logs_per_sec": 4
+			"iptables_accepted_udp_logs_per_sec": 4,
+			"outbound_connections": {
+				"limit": true,
+				"max": 1000,
+				"burst": 900,
+				"rate_per_sec": 100
+			}
 		}`)
 	})
 
@@ -62,6 +68,12 @@ var _ = Describe("LoadWrapperConfig", func() {
 			VTEPName:                      "some-device",
 			IPTablesDeniedLogsPerSec:      2,
 			IPTablesAcceptedUDPLogsPerSec: 4,
+			OutConn: lib.OutConnConfig{
+				Limit:      true,
+				Max:        1000,
+				Burst:      900,
+				RatePerSec: 100,
+			},
 		}))
 	})
 
@@ -143,6 +155,9 @@ var _ = Describe("LoadWrapperConfig", func() {
 	},
 		Entry("denied logs per sec", "iptables_denied_logs_per_sec", -1, "invalid denied logs per sec"),
 		Entry("accepted udp logs per sec", "iptables_accepted_udp_logs_per_sec", -1, "invalid accepted udp logs per sec"),
+		Entry("out conn max", "outbound_connections", map[string]interface{}{"max": 0}, "invalid outbound connection max"),
+		Entry("out conn burst", "outbound_connections", map[string]interface{}{"max": 1, "burst": -1}, "invalid outbound connection burst"),
+		Entry("out conn rate", "outbound_connections", map[string]interface{}{"max": 1, "burst": 1, "rate_per_sec": -1}, "invalid outbound connection rate"),
 	)
 })
 

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
@@ -147,10 +147,10 @@ func cmdAdd(args *skel.CmdArgs) error {
 		DNSServers:        localDNSServers,
 		ContainerWorkload: containerWorkload,
 		Conn: legacynet.OutConn{
-			Limit: cfg.OutConn.Limit,
-			Max:   strconv.Itoa(cfg.OutConn.Max),
-			Burst: strconv.Itoa(cfg.OutConn.Burst),
-			Rate:  fmt.Sprintf("%d/sec", cfg.OutConn.RatePerSec),
+			Limit:      cfg.OutConn.Limit,
+			Max:        cfg.OutConn.Max,
+			Burst:      cfg.OutConn.Burst,
+			RatePerSec: cfg.OutConn.RatePerSec,
 		},
 	}
 	if err := netOutProvider.Initialize(); err != nil {

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
@@ -149,7 +149,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 		Conn: legacynet.OutConn{
 			Limit:      cfg.OutConn.Limit,
 			Logging:    cfg.OutConn.Logging,
-			Max:        cfg.OutConn.Max,
 			Burst:      cfg.OutConn.Burst,
 			RatePerSec: cfg.OutConn.RatePerSec,
 		},

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
@@ -146,6 +146,12 @@ func cmdAdd(args *skel.CmdArgs) error {
 		},
 		DNSServers:        localDNSServers,
 		ContainerWorkload: containerWorkload,
+		Conn: legacynet.OutConn{
+			Limit: cfg.OutConn.Limit,
+			Max:   strconv.Itoa(cfg.OutConn.Max),
+			Burst: strconv.Itoa(cfg.OutConn.Burst),
+			Rate:  fmt.Sprintf("%d/sec", cfg.OutConn.RatePerSec),
+		},
 	}
 	if err := netOutProvider.Initialize(); err != nil {
 		return fmt.Errorf("initialize net out: %s", err)
@@ -264,6 +270,9 @@ func cmdDel(args *skel.CmdArgs) error {
 		ContainerHandle:    args.ContainerID,
 		ContainerIP:        container.IP,
 		HostInterfaceNames: interfaceNames,
+		Conn: legacynet.OutConn{
+			Limit: n.OutConn.Limit,
+		},
 	}
 
 	if err = netOutProvider.Cleanup(); err != nil {

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
@@ -148,6 +148,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		ContainerWorkload: containerWorkload,
 		Conn: legacynet.OutConn{
 			Limit:      cfg.OutConn.Limit,
+			Logging:    cfg.OutConn.Logging,
 			Max:        cfg.OutConn.Max,
 			Burst:      cfg.OutConn.Burst,
 			RatePerSec: cfg.OutConn.RatePerSec,
@@ -271,7 +272,8 @@ func cmdDel(args *skel.CmdArgs) error {
 		ContainerIP:        container.IP,
 		HostInterfaceNames: interfaceNames,
 		Conn: legacynet.OutConn{
-			Limit: n.OutConn.Limit,
+			Limit:   n.OutConn.Limit,
+			Logging: n.OutConn.Logging,
 		},
 	}
 

--- a/src/code.cloudfoundry.org/lib/rules/rules.go
+++ b/src/code.cloudfoundry.org/lib/rules/rules.go
@@ -282,11 +282,12 @@ func NewNetOutRelatedEstablishedRule() IPTablesRule {
 	}
 }
 
-func NewNetOutConnRateLimitRule(rate, burst, containerHandle, rateLimitLogChainName string) IPTablesRule {
+func NewNetOutConnRateLimitRule(rate, burst, containerHandle, expiryPeriod, rateLimitLogChainName string) IPTablesRule {
 	return IPTablesRule{
 		"-m", "conntrack", "--ctstate", "NEW",
 		"-m", "hashlimit", "--hashlimit-above", rate, "--hashlimit-burst", burst,
-		"--hashlimit-mode", "dstip", "--hashlimit-name", containerHandle, "-j", rateLimitLogChainName,
+		"--hashlimit-mode", "dstip", "--hashlimit-name", containerHandle,
+		"--hashlimit-htable-expire", expiryPeriod, "-j", rateLimitLogChainName,
 	}
 }
 

--- a/src/code.cloudfoundry.org/lib/rules/rules.go
+++ b/src/code.cloudfoundry.org/lib/rules/rules.go
@@ -284,9 +284,10 @@ func NewNetOutRelatedEstablishedRule() IPTablesRule {
 
 func NewNetOutConnRateLimitRule(rate, burst, containerHandle, expiryPeriod, rateLimitLogChainName string) IPTablesRule {
 	return IPTablesRule{
+		"-p", "tcp",
 		"-m", "conntrack", "--ctstate", "NEW",
 		"-m", "hashlimit", "--hashlimit-above", rate, "--hashlimit-burst", burst,
-		"--hashlimit-mode", "dstip", "--hashlimit-name", containerHandle,
+		"--hashlimit-mode", "dstip,dstport", "--hashlimit-name", containerHandle,
 		"--hashlimit-htable-expire", expiryPeriod, "-j", rateLimitLogChainName,
 	}
 }

--- a/src/code.cloudfoundry.org/lib/rules/rules.go
+++ b/src/code.cloudfoundry.org/lib/rules/rules.go
@@ -291,14 +291,6 @@ func NewNetOutConnRateLimitRule(rate, burst, containerHandle, expiryPeriod, rate
 	}
 }
 
-func NewNetOutConnHardLimitRule(max, hardLimitLogChainName string) IPTablesRule {
-	return IPTablesRule{
-		"-m", "conntrack", "--ctstate", "NEW",
-		"-m", "connlimit", "--connlimit-above", max, "--connlimit-mask", "32", "--connlimit-daddr",
-		"-j", hardLimitLogChainName,
-	}
-}
-
 func NewOverlayTagAcceptRule(containerIP, tag string) IPTablesRule {
 	return IPTablesRule{
 		"-d", containerIP,
@@ -344,10 +336,6 @@ func NewOverlayRelatedEstablishedRule(containerIP string) IPTablesRule {
 
 func NewNetOutDefaultRejectLogRule(containerHandle string, deniedLogsPerSec int) IPTablesRule {
 	return newNetOutRejectLogRule(containerHandle, "DENY", deniedLogsPerSec)
-}
-
-func NewNetOutConnHardLimitRejectLogRule(containerHandle string, deniedLogsPerSec int) IPTablesRule {
-	return newNetOutRejectLogRule(containerHandle, "DENY_OHL", deniedLogsPerSec)
 }
 
 func NewNetOutConnRateLimitRejectLogRule(containerHandle string, deniedLogsPerSec int) IPTablesRule {

--- a/src/code.cloudfoundry.org/lib/rules/rules_test.go
+++ b/src/code.cloudfoundry.org/lib/rules/rules_test.go
@@ -143,6 +143,30 @@ var _ = Describe("Rules", func() {
 		})
 	})
 
+	Describe("NewNetOutConnHardLimitRejectLogRule", func() {
+		Context("when the log prefix is greater than 28 characters", func() {
+			It("shortens the log-prefix to 28 characters and adds a space", func() {
+				rule := rules.NewNetOutConnHardLimitRejectLogRule("some-very-very-very-long-app-guid", 4)
+				Expect(rule).To(gomegamatchers.ContainSequence(rules.IPTablesRule{
+					"-m", "limit", "--limit", "4/s", "--limit-burst", "4",
+				}))
+				Expect(rule).To(ContainElement(`"DENY_OHL_some-very-very-very "`))
+			})
+		})
+	})
+
+	Describe("NewNetOutConnRateLimitRejectLogRule", func() {
+		Context("when the log prefix is greater than 28 characters", func() {
+			It("shortens the log-prefix to 28 characters and adds a space", func() {
+				rule := rules.NewNetOutConnRateLimitRejectLogRule("some-very-very-very-long-app-guid", 5)
+				Expect(rule).To(gomegamatchers.ContainSequence(rules.IPTablesRule{
+					"-m", "limit", "--limit", "5/s", "--limit-burst", "5",
+				}))
+				Expect(rule).To(ContainElement(`"DENY_ORL_some-very-very-very "`))
+			})
+		})
+	})
+
 	Describe("NewIngressMarkRules", func() {
 		It("creates a jump rule when given one interface", func() {
 			jumpRule := rules.NewIngressMarkRules([]string{"eth0"}, 2000, "2.3.4.5", "1")

--- a/src/code.cloudfoundry.org/lib/rules/rules_test.go
+++ b/src/code.cloudfoundry.org/lib/rules/rules_test.go
@@ -143,18 +143,6 @@ var _ = Describe("Rules", func() {
 		})
 	})
 
-	Describe("NewNetOutConnHardLimitRejectLogRule", func() {
-		Context("when the log prefix is greater than 28 characters", func() {
-			It("shortens the log-prefix to 28 characters and adds a space", func() {
-				rule := rules.NewNetOutConnHardLimitRejectLogRule("some-very-very-very-long-app-guid", 4)
-				Expect(rule).To(gomegamatchers.ContainSequence(rules.IPTablesRule{
-					"-m", "limit", "--limit", "4/s", "--limit-burst", "4",
-				}))
-				Expect(rule).To(ContainElement(`"DENY_OHL_some-very-very-very "`))
-			})
-		})
-	})
-
 	Describe("NewNetOutConnRateLimitRejectLogRule", func() {
 		Context("when the log prefix is greater than 28 characters", func() {
 			It("shortens the log-prefix to 28 characters and adds a space", func() {


### PR DESCRIPTION
This PR is done as part of #30. It introduces the ability to rate limit the number of outbound container connections per destination host. This should solve the problem with apps opening multiple short-lived connections that could lead to a port exhaustion of the NAT gateway.

Rate limiting is achieved by appending a rule to the `netout` chains. It utilizes the `hashlimit` module of `iptables` to apply rate limits.

Additionally logging chains for packets denied due to the rate limits could be added for better collection of data.

---

Unfortunately I wasn't able to produce hard limits since there is an issue with the `iptables connlimit` module that causes it to lose track of the currently open connections whenever a new iptables rule is added, i.e. whenever a new container is started. Thus the hard limits get reset every time a new container is pushed. More on it could be read in this [stack exchange question](https://unix.stackexchange.com/questions/654525/how-can-i-prevent-iptables-connlimit-counter-from-resetting-each-time-an-iptable).