### PR TITLE
Introduce 'dry-run' configuration option

### DIFF
--- a/jobs/silk-cni/spec
+++ b/jobs/silk-cni/spec
@@ -112,3 +112,7 @@ properties:
     description: |
       EXPERIMENTAL: Maximum number of outbound connections to be opened per second per port on destination host per container given that the burst is exhausted.
       Has no effect when `outbound_connections.limit` is false.
+
+  outbound_connections.dry_run:
+    description: "Introduce the options of a dry-run mode. Default: false"
+    default: false

--- a/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
+++ b/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
@@ -83,6 +83,7 @@
         'logging' => p('iptables_logging'),
         'burst' => p('outbound_connections.burst'),
         'rate_per_sec' => p('outbound_connections.rate_per_sec'),
+        'dry_run' => p('runtime.dry_run')
       }
     }, {
       'name' => 'bandwidth-limit',

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"encoding/json"
 	"fmt"
+
 	"code.cloudfoundry.org/lib/rules"
 
 	"code.cloudfoundry.org/garden"
@@ -28,6 +29,7 @@ type OutConnConfig struct {
 	Logging    bool `json:"logging"`
 	Burst      int  `json:"burst" validate:"min=1"`
 	RatePerSec int  `json:"rate_per_sec" validate:"min=1"`
+	DryRun     bool `json:"dry_run:`
 }
 
 type WrapperConfig struct {
@@ -105,6 +107,11 @@ func LoadWrapperConfig(bytes []byte) (*WrapperConfig, error) {
 		return nil, fmt.Errorf("invalid outbound connection rate")
 	}
 
+	if n.OutConn.DryRun {
+		if !n.OutConn.Limit {
+			return nil, fmt.Errorf("invalid rate-limiting value in dry-run mode")
+		}
+	}
 	validator.Validate(n)
 
 	return n, nil

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
@@ -151,6 +151,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			Logging:    cfg.OutConn.Logging,
 			Burst:      cfg.OutConn.Burst,
 			RatePerSec: cfg.OutConn.RatePerSec,
+			DryRun:     cfg.OutConn.DryRun
 		},
 	}
 	if err := netOutProvider.Initialize(); err != nil {


### PR DESCRIPTION
Proposed 'dry-run' configuration option that should be used to estimate rate-limiting functionality without affecting actual applications.
 