### PR TITLE
Introduce logs for rate-limited apps in a dry-run mode #39

### DIFF
--- a/jobs/silk-cni/spec
+++ b/jobs/silk-cni/spec
@@ -116,5 +116,4 @@ properties:
   outbound_connections.dry_run:
     default: false
     description: |
-      EXPERIMENTAL: When set to True negates the effect of `outbound_connections.limit`. Used together with `iptables_logging` to log what connections would be rejected without actually rejecting them.
-      Has no effect when `outbound_connections.limit` is false.
+      EXPERIMENTAL: When set to true negates the effect of `outbound_connections.limit`. Enables the specific DENY_ORL entries to the kernel log.

--- a/jobs/silk-cni/spec
+++ b/jobs/silk-cni/spec
@@ -112,3 +112,9 @@ properties:
     description: |
       EXPERIMENTAL: Maximum number of outbound connections to be opened per second per port on destination host per container given that the burst is exhausted.
       Has no effect when `outbound_connections.limit` is false.
+
+  outbound_connections.dry_run:
+    default: false
+    description: |
+      EXPERIMENTAL: When set to True negates the effect of `outbound_connections.limit`. Used together with `iptables_logging` to log what connections would be rejected without actually rejecting them.
+      Has no effect when `outbound_connections.limit` is false.

--- a/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
+++ b/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
@@ -83,6 +83,7 @@
         'logging' => p('iptables_logging'),
         'burst' => p('outbound_connections.burst'),
         'rate_per_sec' => p('outbound_connections.rate_per_sec'),
+        'dry_run' => p('outbound_connections.dry_run'),
       }
     }, {
       'name' => 'bandwidth-limit',

--- a/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
+++ b/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
@@ -91,10 +91,11 @@ module Bosh::Template::Test
               'mtu' => 0
             },
             'outbound_connections' => {
-              'limit' => true,
-              'logging' => true,
+              'limit' => false,
+              'logging' => false,
               'burst' => 1000,
               'rate_per_sec' => 100,
+              'dry_run' => false,
             }
           }, {
             'name' => 'bandwidth-limit',

--- a/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
+++ b/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
@@ -91,8 +91,8 @@ module Bosh::Template::Test
               'mtu' => 0
             },
             'outbound_connections' => {
-              'limit' => false,
-              'logging' => false,
+              'limit' => true,
+              'logging' => true,
               'burst' => 1000,
               'rate_per_sec' => 100,
               'dry_run' => false,

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/legacynet/netout.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/legacynet/netout.go
@@ -101,7 +101,7 @@ func (m *NetOut) BulkInsertRules(netOutRules []garden.NetOutRule) error {
 	ruleSpec := m.Converter.BulkConvert(netOutRules, logChain, m.ASGLogging)
 	ruleSpec = append(ruleSpec, m.denyNetworksRules()...)
 
-	if m.Conn.Limit {
+	if m.Conn.Limit && !m.Conn.DryRun {
 		rateLimitRule, err := m.rateLimitRule(chain)
 		if err != nil {
 			return fmt.Errorf("getting chain name: %s", err)

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/legacynet/netout.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/legacynet/netout.go
@@ -101,7 +101,7 @@ func (m *NetOut) BulkInsertRules(netOutRules []garden.NetOutRule) error {
 	ruleSpec := m.Converter.BulkConvert(netOutRules, logChain, m.ASGLogging)
 	ruleSpec = append(ruleSpec, m.denyNetworksRules()...)
 
-	if m.Conn.Limit {
+	if m.Conn.Limit || m.Conn.DryRun {
 		rateLimitRule, err := m.rateLimitRule(chain)
 		if err != nil {
 			return fmt.Errorf("getting chain name: %s", err)
@@ -312,7 +312,7 @@ func (m *NetOut) denyNetworksRules() []rules.IPTablesRule {
 func (m *NetOut) rateLimitRule(forwardChainName string) (rule rules.IPTablesRule, err error) {
 	jumpTarget := "REJECT"
 
-	if m.Conn.Logging {
+	if m.Conn.Logging || m.Conn.DryRun {
 		jumpTarget, err = m.ChainNamer.Postfix(forwardChainName, suffixNetOutRateLimitLog)
 		if err != nil {
 			return rules.IPTablesRule{}, err
@@ -337,7 +337,7 @@ func (m *NetOut) rateLimitExpiryPeriod() string {
 
 func (m *NetOut) connRateLimitLogChain(forwardChainName string) (IpTablesFullChain, error) {
 	logRules := []rules.IPTablesRule{}
-	if m.Conn.Logging {
+	if m.Conn.Logging || m.Conn.Logging {
 		logRules = append(logRules, rules.NewNetOutConnRateLimitRejectLogRule(m.ContainerHandle, m.DeniedLogsPerSec))
 	}
 	if !m.Conn.DryRun {

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/legacynet/netout.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/legacynet/netout.go
@@ -28,6 +28,7 @@ type OutConn struct {
 	Logging    bool
 	Burst      int
 	RatePerSec int
+	DryRun     bool
 }
 
 type NetOut struct {

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/legacynet/netout.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/legacynet/netout.go
@@ -179,7 +179,7 @@ func (m *NetOut) defaultNetOutRules() ([]IpTablesFullChain, error) {
 
 	args = append(args, logChain)
 
-	if m.Conn.Limit {
+	if (m.Conn.Limit && m.Conn.Logging) || m.Conn.DryRun {
 		rateLimitLogChain, err := m.connRateLimitLogChain(forwardChainName)
 		if err != nil {
 			return []IpTablesFullChain{}, fmt.Errorf("getting chain name: %s", err)
@@ -337,7 +337,7 @@ func (m *NetOut) rateLimitExpiryPeriod() string {
 
 func (m *NetOut) connRateLimitLogChain(forwardChainName string) (IpTablesFullChain, error) {
 	logRules := []rules.IPTablesRule{}
-	if m.Conn.Logging || m.Conn.Logging {
+	if m.Conn.Logging || m.Conn.DryRun {
 		logRules = append(logRules, rules.NewNetOutConnRateLimitRejectLogRule(m.ContainerHandle, m.DeniedLogsPerSec))
 	}
 	if !m.Conn.DryRun {

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib.go
@@ -28,6 +28,7 @@ type OutConnConfig struct {
 	Logging    bool `json:"logging"`
 	Burst      int  `json:"burst" validate:"min=1"`
 	RatePerSec int  `json:"rate_per_sec" validate:"min=1"`
+	DryRun     bool `json:"dry_run"`
 }
 
 type WrapperConfig struct {

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
@@ -151,6 +151,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			Logging:    cfg.OutConn.Logging,
 			Burst:      cfg.OutConn.Burst,
 			RatePerSec: cfg.OutConn.RatePerSec,
+			DryRun:     cfg.OutConn.DryRun
 		},
 	}
 	if err := netOutProvider.Initialize(); err != nil {

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
@@ -151,7 +151,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			Logging:    cfg.OutConn.Logging,
 			Burst:      cfg.OutConn.Burst,
 			RatePerSec: cfg.OutConn.RatePerSec,
-			DryRun:     cfg.OutConn.DryRun
+			DryRun:     cfg.OutConn.DryRun,
 		},
 	}
 	if err := netOutProvider.Initialize(); err != nil {

--- a/src/code.cloudfoundry.org/lib/rules/rules.go
+++ b/src/code.cloudfoundry.org/lib/rules/rules.go
@@ -340,7 +340,7 @@ func NewNetOutDefaultRejectLogRule(containerHandle string, deniedLogsPerSec int)
 }
 
 func NewNetOutConnRateLimitRejectLogRule(containerHandle string, deniedLogsPerSec int) IPTablesRule {
-	return newNetOutRejectLogRule(containerHandle, "OCRL", deniedLogsPerSec)
+	return newNetOutRejectLogRule(containerHandle, "DENY_ORL", deniedLogsPerSec)
 }
 
 func NewNetOutDefaultRejectRule() IPTablesRule {

--- a/src/code.cloudfoundry.org/lib/rules/rules.go
+++ b/src/code.cloudfoundry.org/lib/rules/rules.go
@@ -340,7 +340,7 @@ func NewNetOutDefaultRejectLogRule(containerHandle string, deniedLogsPerSec int)
 }
 
 func NewNetOutConnRateLimitRejectLogRule(containerHandle string, deniedLogsPerSec int) IPTablesRule {
-	return newNetOutRejectLogRule(containerHandle, "DENY_ORL", deniedLogsPerSec)
+	return newNetOutRejectLogRule(containerHandle, "OCRL", deniedLogsPerSec)
 }
 
 func NewNetOutDefaultRejectRule() IPTablesRule {


### PR DESCRIPTION
This PR adds a dry run option to the connection rate limiting discussed in issue #39 .