### PR TITLE
Introduce dry_run option for outbound connection rate limit

### DIFF
--- a/jobs/silk-cni/spec
+++ b/jobs/silk-cni/spec
@@ -126,3 +126,8 @@ properties:
     description: |
       EXPERIMENTAL: Maximum number of outbound connections to be opened per second per port on destination host per container given that the burst is exhausted.
       Has no effect when `outbound_connections.limit` is false.
+
+  outbound_connections.dry_run:
+    default: false
+    description: |
+      EXPERIMENTAL: When set to true negates the effect of `outbound_connections.limit`. Enables the specific DENY_ORL entries to the kernel log.

--- a/jobs/silk-cni/spec
+++ b/jobs/silk-cni/spec
@@ -27,6 +27,7 @@ provides:
   - outbound_connections.limit
   - outbound_connections.burst
   - outbound_connections.rate_per_sec
+  - outbound_connections.dry_run
 
 properties:
   no_masquerade_cidr_range:

--- a/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
+++ b/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
@@ -107,6 +107,7 @@
         'logging' => p('iptables_logging'),
         'burst' => p('outbound_connections.burst'),
         'rate_per_sec' => p('outbound_connections.rate_per_sec'),
+        'dry_run' => p('outbound_connections.dry_run'),
       }
     }, {
       'name' => 'bandwidth-limit',

--- a/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
+++ b/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
@@ -95,6 +95,7 @@ module Bosh::Template::Test
               'logging' => true,
               'burst' => 1000,
               'rate_per_sec' => 100,
+              'dry_run' => false,
             }
           }, {
             'name' => 'bandwidth-limit',

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib.go
@@ -28,6 +28,7 @@ type OutConnConfig struct {
 	Logging    bool `json:"logging"`
 	Burst      int  `json:"burst" validate:"min=1"`
 	RatePerSec int  `json:"rate_per_sec" validate:"min=1"`
+	DryRun     bool `json:"dry_run"`
 }
 
 type WrapperConfig struct {

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/lib/lib_test.go
@@ -42,7 +42,8 @@ var _ = Describe("LoadWrapperConfig", func() {
 				"limit": true,
 				"logging": true,
 				"burst": 900,
-				"rate_per_sec": 100
+				"rate_per_sec": 100,
+				"dry_run": false
 			}
 		}`)
 	})
@@ -73,6 +74,7 @@ var _ = Describe("LoadWrapperConfig", func() {
 				Logging:    true,
 				Burst:      900,
 				RatePerSec: 100,
+				DryRun:     false,
 			},
 		}))
 	})

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
@@ -130,6 +130,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		Logging:    cfg.OutConn.Logging,
 		Burst:      cfg.OutConn.Burst,
 		RatePerSec: cfg.OutConn.RatePerSec,
+		DryRun:     cfg.OutConn.DryRun,
 	}
 
 	netOutChain := &netrules.NetOutChain{

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
@@ -291,6 +291,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	outConn := netrules.OutConn{
 		Limit:   n.OutConn.Limit,
 		Logging: n.OutConn.Logging,
+		DryRun:  n.OutConn.DryRun,
 	}
 
 	netOutChain := &netrules.NetOutChain{

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/netout.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/netout.go
@@ -232,13 +232,13 @@ func (m *NetOut) connRateLimitLogChain(forwardChainName string) (IpTablesFullCha
 	logRules := []rules.IPTablesRule{}
 	
 	if m.Conn.Logging || m.Conn.DryRun {
-		logRules = append(rules.NewNetOutConnRateLimitRejectLogRule(m.ContainerHandle, m.DeniedLogsPerSec))
+		logRules = append(logRules, rules.NewNetOutConnRateLimitRejectLogRule(m.ContainerHandle, m.DeniedLogsPerSec))
 	}
     
 	if !m.Conn.DryRun {
-		logRules = append(rules.NewNetOutDefaultRejectRule())
+		logRules = append(logRules, rules.NewNetOutDefaultRejectRule())
 	}
-	
+
 	return m.netOutLogChain(forwardChainName, suffixNetOutRateLimitLog, logRules)
 }
 

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/netout.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/netout.go
@@ -232,12 +232,13 @@ func (m *NetOut) connRateLimitLogChain(forwardChainName string) (IpTablesFullCha
 	logRules := []rules.IPTablesRule{}
 	
 	if m.Conn.Logging || m.Conn.DryRun {
-		rules.NewNetOutConnRateLimitRejectLogRule(m.ContainerHandle, m.DeniedLogsPerSec),
+		logRules = append(rules.NewNetOutConnRateLimitRejectLogRule(m.ContainerHandle, m.DeniedLogsPerSec))
 	}
     
 	if !m.Conn.DryRun {
-		rules.NewNetOutDefaultRejectRule(),
+		logRules = append(rules.NewNetOutDefaultRejectRule())
 	}
+	
 	return m.netOutLogChain(forwardChainName, suffixNetOutRateLimitLog, logRules)
 }
 

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/netout_chain.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/netout_chain.go
@@ -64,7 +64,7 @@ func (c *NetOutChain) IPTablesRules(containerHandle string, containerWorkload st
 	iptablesRules := c.Converter.BulkConvert(ruleSpec, logChain, c.ASGLogging)
 	iptablesRules = append(iptablesRules, c.denyNetworksRules(containerWorkload)...)
 
-	if c.Conn.Limit {
+	if c.Conn.Limit || c.Conn.DryRun {
 		rateLimitRule, err := c.rateLimitRule(forwardChainName, containerHandle)
 		if err != nil {
 			return nil, fmt.Errorf("getting chain name: %s", err)
@@ -106,7 +106,7 @@ func (c *NetOutChain) denyNetworksRules(containerWorkload string) []rules.IPTabl
 func (c *NetOutChain) rateLimitRule(forwardChainName string, containerHandle string) (rule rules.IPTablesRule, err error) {
 	jumpTarget := "REJECT"
 
-	if c.Conn.Logging {
+	if c.Conn.Logging || c.Conn.DryRun {
 		jumpTarget, err = c.ChainNamer.Postfix(forwardChainName, suffixNetOutRateLimitLog)
 		if err != nil {
 			return rules.IPTablesRule{}, err

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/netout_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/netout_test.go
@@ -44,6 +44,7 @@ var _ = Describe("Netout", func() {
 			ContainerWorkload:     "app",
 			Conn: netrules.OutConn{
 				Limit: false,
+				DryRun: false,
 			},
 		}
 		chainNamer.PrefixStub = func(prefix, handle string) string {


### PR DESCRIPTION
Add a dry run option to the connection rate limiting as discussed in issue https://github.com/cloudfoundry/silk-release/issues/39. This replaces PR https://github.com/cloudfoundry/silk-release/pull/43 .