### PR TITLE
Add force-orphaned-asgs-cleanup endpoint to vxlan-policy-agent

### DIFF
--- a/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/vxlan-policy-agent/main.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/vxlan-policy-agent/main.go
@@ -241,7 +241,7 @@ func main() {
 			PollCycleFunc: singlePollCycle.DoPolicyCycle,
 		},
 		"/force-asgs-for-container": &handlers.ForceASGsForContainer{
-			ASGUpdateFunc:    singlePollCycle.SyncASGsForContainer,
+			ASGUpdateFunc:    singlePollCycle.SyncASGsForContainers,
 			EnableASGSyncing: conf.EnableASGSyncing,
 		},
 		"/force-orphaned-asgs-cleanup": &handlers.ForceOrphanedASGsCleanup{

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/vxlan-policy-agent/main.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/vxlan-policy-agent/main.go
@@ -236,7 +236,7 @@ func main() {
 
 	forcePolicyPollCycleServerAddress := fmt.Sprintf("%s:%d", conf.ForcePolicyPollCycleHost, conf.ForcePolicyPollCyclePort)
 
-	forceUpdateHandlers := map[string]http.Handler{
+	forceHandlers := map[string]http.Handler{
 		"/force-policy-poll-cycle": &handlers.ForcePolicyPollCycle{
 			PollCycleFunc: singlePollCycle.DoPolicyCycle,
 		},
@@ -244,9 +244,13 @@ func main() {
 			ASGUpdateFunc:    singlePollCycle.SyncASGsForContainer,
 			EnableASGSyncing: conf.EnableASGSyncing,
 		},
+		"/force-orphaned-asgs-cleanup": &handlers.ForceOrphanedASGsCleanup{
+			ASGCleanupFunc:   singlePollCycle.CleanupOrphanedASGsChains,
+			EnableASGSyncing: conf.EnableASGSyncing,
+		},
 	}
 
-	forcePolicyPollCycleServer := createForceUpdateServer(forcePolicyPollCycleServerAddress, forceUpdateHandlers)
+	forcePolicyPollCycleServer := createForceUpdateServer(forcePolicyPollCycleServerAddress, forceHandlers)
 
 	debugServerAddress := fmt.Sprintf("%s:%d", conf.DebugServerHost, conf.DebugServerPort)
 	debugServer := createCustomDebugServer(debugServerAddress, reconfigurableSink, iptablesLoggingState)

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger_test.go
@@ -675,13 +675,13 @@ var _ = Describe("Single Poll Cycle", func() {
 
 		Describe("SyncASGsForContainer", func() {
 			It("passes specified containers to the planner", func() {
-				err := p.SyncASGsForContainer("container-1", "container-2")
+				err := p.SyncASGsForContainers("container-1", "container-2")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(fakeASGPlanner.GetASGRulesAndChainsArgsForCall(0)).To(Equal([]string{"container-1", "container-2"}))
 			})
 
 			It("does not clean up orphans when syncing specific containers", func() {
-				err := p.SyncASGsForContainer("container-1", "container-2")
+				err := p.SyncASGsForContainers("container-1", "container-2")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(fakeEnforcer.CleanChainsMatchingCallCount()).To(Equal(0))
 			})
@@ -695,14 +695,6 @@ var _ = Describe("Single Poll Cycle", func() {
 				asgRegex, desiredChains := fakeEnforcer.CleanChainsMatchingArgsForCall(0)
 				Expect(asgRegex.String()).To(MatchRegexp("asg-[a-z0-9]{6}"))
 				Expect(desiredChains).To(BeEmpty())
-			})
-
-			It("sends the duration metric", func() {
-				err := p.CleanupOrphanedASGsChains("some-container-handle")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(metricsSender.SendDurationCallCount()).To(Equal(1))
-				metricName, _ := metricsSender.SendDurationArgsForCall(0)
-				Expect(metricName).To(Equal("asgIptablesOrphanedCleanupTime"))
 			})
 
 			Context("the enforcer returns an error", func() {

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/handlers/force_orphaned_asgs_cleanup.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/handlers/force_orphaned_asgs_cleanup.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type ForceOrphanedASGsCleanup struct {
+	ASGCleanupFunc   func(string) error
+	EnableASGSyncing bool
+}
+
+func (h *ForceOrphanedASGsCleanup) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !h.EnableASGSyncing {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		w.Write([]byte("ASG syncing has been disabled administratively"))
+		return
+	}
+
+	container := r.URL.Query().Get("container")
+	if container == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("no container specified"))
+		return
+	}
+	if err := h.ASGCleanupFunc(container); err != nil {
+		errorMessage := fmt.Sprintf("failed to cleanup ASGs for container %s: %s", container, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(errorMessage))
+		return
+	}
+
+	w.Write([]byte(fmt.Sprintf("cleaned up ASGs for container %s", container)))
+}

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner.go
@@ -1,6 +1,8 @@
 package planner
 
 import (
+	"crypto/sha1"
+	"fmt"
 	"sort"
 	"time"
 
@@ -68,6 +70,14 @@ type netOutChain interface {
 const metricContainerMetadata = "containerMetadataTime"
 const metricPolicyServerPoll = "policyServerPollTime"
 const metricPolicyServerASGPoll = "policyServerASGPollTime"
+
+func ASGChainPrefix(handle string) string {
+	h := sha1.New()
+	h.Write([]byte(handle))
+	smallHash := h.Sum(nil)
+
+	return fmt.Sprintf("asg-%x", smallHash[0:3]) //only need 6 digits so we use 3.
+}
 
 func (p *VxlanPolicyPlanner) readFile(specifiedContainers ...string) ([]container, error) {
 	containerMetadataStartTime := time.Now()


### PR DESCRIPTION
This endpoint is now called from the cni-wrapper-plugin in order to
clean up the asg chains for each container when it is being deleted.

Signed-off-by: Maria Shaldybin <mariash@vmware.com>
Signed-off-by: Chris Selzo <cselzo@vmware.com>