### PR TITLE
Delete rules by rule-number when cleaning up parent chains with dynamic asgs

### DIFF
--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -25,7 +25,7 @@ require (
 	code.cloudfoundry.org/garden v0.0.0-20210608104724-fa3a10d59c82
 	code.cloudfoundry.org/go-loggregator/v8 v8.0.5
 	code.cloudfoundry.org/lager v2.0.0+incompatible
-	code.cloudfoundry.org/policy_client v0.0.0-20220203234022-670e720134e3
+	code.cloudfoundry.org/policy_client v0.0.0-20220427143037-36975d7cc48d
 	code.cloudfoundry.org/runtimeschema v0.0.0-00010101000000-000000000000
 	code.cloudfoundry.org/silk v0.0.0-20211004235850-da152076940f
 	github.com/cloudfoundry/dropsonde v1.0.0

--- a/src/code.cloudfoundry.org/go.sum
+++ b/src/code.cloudfoundry.org/go.sum
@@ -27,6 +27,8 @@ code.cloudfoundry.org/lager v1.1.1-0.20210513163233-569157d2803b h1:jgCg9ARoZ2ME
 code.cloudfoundry.org/lager v1.1.1-0.20210513163233-569157d2803b/go.mod h1:SF6BAZkl2+itWGVny2ILQCY9UNXIRwgi/m181VkHfrI=
 code.cloudfoundry.org/policy_client v0.0.0-20220203234022-670e720134e3 h1:qjjgXJEYFcd8FVQ367yji8jjGfIJg5sjRz4j7mzUy8g=
 code.cloudfoundry.org/policy_client v0.0.0-20220203234022-670e720134e3/go.mod h1:bzqpNvN9V1gJd0ny82Qnqxow5MFAnU97Sti/l4ORHWY=
+code.cloudfoundry.org/policy_client v0.0.0-20220427143037-36975d7cc48d h1:FHnbEVper+q+NdWLZ8gaEiQI9ApeihwUwo3YvNmC0WY=
+code.cloudfoundry.org/policy_client v0.0.0-20220427143037-36975d7cc48d/go.mod h1:bzqpNvN9V1gJd0ny82Qnqxow5MFAnU97Sti/l4ORHWY=
 code.cloudfoundry.org/routing-info v0.0.0-20220215234142-7d023ecb0fad h1:FHI7/GgnWlgG97a0bEf+UezN0dJez2YoNTjkwOOImj8=
 code.cloudfoundry.org/routing-info v0.0.0-20220215234142-7d023ecb0fad/go.mod h1:ykLgqzJGV5PTkvxtfyOy8hcQy7wxPaoV5ZPyk74aqp8=
 code.cloudfoundry.org/runtimeschema v0.0.0-20180622181441-7dcd19348be6 h1:J08p1/LBnhv5BDDf0WLpHRyMJFCws3vd3fLCFL/iVnQ=

--- a/src/code.cloudfoundry.org/lib/fakes/iptables_extended.go
+++ b/src/code.cloudfoundry.org/lib/fakes/iptables_extended.go
@@ -71,6 +71,19 @@ type IPTablesAdapter struct {
 	deleteReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DeleteAfterRuleNumStub        func(string, string, int) error
+	deleteAfterRuleNumMutex       sync.RWMutex
+	deleteAfterRuleNumArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 int
+	}
+	deleteAfterRuleNumReturns struct {
+		result1 error
+	}
+	deleteAfterRuleNumReturnsOnCall map[int]struct {
+		result1 error
+	}
 	DeleteChainStub        func(string, string) error
 	deleteChainMutex       sync.RWMutex
 	deleteChainArgsForCall []struct {
@@ -474,6 +487,69 @@ func (fake *IPTablesAdapter) DeleteReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.deleteReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *IPTablesAdapter) DeleteAfterRuleNum(arg1 string, arg2 string, arg3 int) error {
+	fake.deleteAfterRuleNumMutex.Lock()
+	ret, specificReturn := fake.deleteAfterRuleNumReturnsOnCall[len(fake.deleteAfterRuleNumArgsForCall)]
+	fake.deleteAfterRuleNumArgsForCall = append(fake.deleteAfterRuleNumArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 int
+	}{arg1, arg2, arg3})
+	stub := fake.DeleteAfterRuleNumStub
+	fakeReturns := fake.deleteAfterRuleNumReturns
+	fake.recordInvocation("DeleteAfterRuleNum", []interface{}{arg1, arg2, arg3})
+	fake.deleteAfterRuleNumMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *IPTablesAdapter) DeleteAfterRuleNumCallCount() int {
+	fake.deleteAfterRuleNumMutex.RLock()
+	defer fake.deleteAfterRuleNumMutex.RUnlock()
+	return len(fake.deleteAfterRuleNumArgsForCall)
+}
+
+func (fake *IPTablesAdapter) DeleteAfterRuleNumCalls(stub func(string, string, int) error) {
+	fake.deleteAfterRuleNumMutex.Lock()
+	defer fake.deleteAfterRuleNumMutex.Unlock()
+	fake.DeleteAfterRuleNumStub = stub
+}
+
+func (fake *IPTablesAdapter) DeleteAfterRuleNumArgsForCall(i int) (string, string, int) {
+	fake.deleteAfterRuleNumMutex.RLock()
+	defer fake.deleteAfterRuleNumMutex.RUnlock()
+	argsForCall := fake.deleteAfterRuleNumArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *IPTablesAdapter) DeleteAfterRuleNumReturns(result1 error) {
+	fake.deleteAfterRuleNumMutex.Lock()
+	defer fake.deleteAfterRuleNumMutex.Unlock()
+	fake.DeleteAfterRuleNumStub = nil
+	fake.deleteAfterRuleNumReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *IPTablesAdapter) DeleteAfterRuleNumReturnsOnCall(i int, result1 error) {
+	fake.deleteAfterRuleNumMutex.Lock()
+	defer fake.deleteAfterRuleNumMutex.Unlock()
+	fake.DeleteAfterRuleNumStub = nil
+	if fake.deleteAfterRuleNumReturnsOnCall == nil {
+		fake.deleteAfterRuleNumReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteAfterRuleNumReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -935,6 +1011,8 @@ func (fake *IPTablesAdapter) Invocations() map[string][][]interface{} {
 	defer fake.clearChainMutex.RUnlock()
 	fake.deleteMutex.RLock()
 	defer fake.deleteMutex.RUnlock()
+	fake.deleteAfterRuleNumMutex.RLock()
+	defer fake.deleteAfterRuleNumMutex.RUnlock()
 	fake.deleteChainMutex.RLock()
 	defer fake.deleteChainMutex.RUnlock()
 	fake.existsMutex.RLock()

--- a/src/code.cloudfoundry.org/lib/rules/locked_iptables.go
+++ b/src/code.cloudfoundry.org/lib/rules/locked_iptables.go
@@ -26,6 +26,7 @@ type IPTablesAdapter interface {
 	FlushAndRestore(rawInput string) error
 	Exists(table, chain string, rulespec IPTablesRule) (bool, error)
 	Delete(table, chain string, rulespec IPTablesRule) error
+	DeleteAfterRuleNum(table, chain string, ruleNum int) error
 	List(table, chain string) ([]string, error)
 	ListChains(table string) ([]string, error)
 	NewChain(table, chain string) error
@@ -148,6 +149,29 @@ func (l *LockedIPTables) Delete(table, chain string, rulespec IPTablesRule) erro
 	err := l.IPTables.Delete(table, chain, rulespec...)
 	if err != nil {
 		return handleIPTablesError(err, l.Locker.Unlock())
+	}
+
+	return l.Locker.Unlock()
+}
+
+func (l *LockedIPTables) DeleteAfterRuleNum(table, chain string, ruleNum int) error {
+	if err := l.Locker.Lock(); err != nil {
+		return fmt.Errorf("lock: %s", err)
+	}
+
+	rules, err := l.IPTables.List(table, chain)
+	if err != nil {
+		return handleIPTablesError(err, l.Locker.Unlock())
+	}
+
+	//iptables rule numbers are 1-indexed, but the list will include the create-chainline.
+	//so this takes the place of the '0' index of rules, and we don't need to offset anything
+	for range rules[ruleNum:] {
+		// rule numbers adjust after each deletion, so always delete the same number each time
+		err := l.IPTables.Delete(table, chain, fmt.Sprintf("%d", ruleNum), "--wait")
+		if err != nil {
+			return handleIPTablesError(err, l.Locker.Unlock())
+		}
 	}
 
 	return l.Locker.Unlock()

--- a/src/code.cloudfoundry.org/rule-converter/.gitignore
+++ b/src/code.cloudfoundry.org/rule-converter/.gitignore
@@ -1,0 +1,1 @@
+rule-converter

--- a/src/code.cloudfoundry.org/rule-converter/README.md
+++ b/src/code.cloudfoundry.org/rule-converter/README.md
@@ -1,0 +1,17 @@
+# rule-converter
+
+Converts garden.NetOutRule definitions into ASG-compatible rules.
+
+This utility is handy for troubleshooting IPTables issues when garden spits out errors for external-cni-up failures, as those
+contain json-encoded rulesets that are passed into the CNI.
+
+# Usage
+
+1. Take the rulesets from the garden logs.
+  1. `grep 'cfnetworking: cni up failed:' /var/vcap/sys/log/garden.stdout.log`
+  1. Select the log message for the CNI error you're interested in, and , and pipe them into rule-converter, redirecting its output to a file:
+
+```
+message='{"timestamp":"2022-04-26T19:32:52.646992461Z","level":"error","source":"guardian","message":"guardian.create.external-networker-result","data":{"action":"up","error":"exit status 1","handle":"6de68121-5eb5-47f6-4c1e-6884","session":"592","stderr":"cfnetworking: cni up failed: add network list failed: asg sync returned 500 with message: failed to update asgs for container 6de68121-5eb5-47f6-4c1e-6884: 1 error occurred:\n\t* enforce-asg: cleaning up: clean up parent chain: iptables call: running [/var/vcap/packages/iptables/sbin/iptables -t filter -D netout--6de68121-5eb5-47f6-4 -p icmp -m iprange --dst-range 0.0.0.0-255.255.255.255 -m icmp --icmp-type any -j ACCEPT --wait]: exit status 1: iptables: Bad rule (does a matching rule exist in that chain?).\n and unlock: \u003cnil\u003e\n\n\n","stdin":"{\"Pid\":428166,\"Properties\":{\"app_id\":\"5355a9d8-00a9-43f5-af13-d3f83c4a39d1\",\"container_workload\":\"app\",\"org_id\":\"f2c2cf77-71b2-4a11-830f-f51758d6fc85\",\"policy_group_id\":\"5355a9d8-00a9-43f5-af13-d3f83c4a39d1\",\"ports\":\"8080\",\"space_id\":\"d47b339b-c948-4ca5-8720-e94a00a6d2ff\"},\"netout_rules\":[{\"protocol\":3,\"networks\":[{\"start\":\"0.0.0.0\",\"end\":\"255.255.255.255\"}],\"icmps\":{\"type\":255,\"code\":1}}],\"netin\":[{\"host_port\":0,\"container_port\":8080},{\"host_port\":0,\"container_port\":2222},{\"host_port\":0,\"container_port\":61001},{\"host_port\":0,\"container_port\":61443},{\"host_port\":0,\"container_port\":61002}]}","stdout":""}}'
+echo "${message}" | jq -r .data.stdin | jq -c .netout_rules  | ./rule-converter > sg.json
+```

--- a/src/code.cloudfoundry.org/rule-converter/main.go
+++ b/src/code.cloudfoundry.org/rule-converter/main.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"code.cloudfoundry.org/cni-wrapper-plugin/netrules"
+	"code.cloudfoundry.org/garden"
+)
+
+func main() {
+	asgs := []SecurityGroupRule{}
+	// read rules from stdin
+	scanner := bufio.NewScanner(os.Stdin)
+	// optionally, resize scanner's capacity for lines over 64K, see next example
+	for scanner.Scan() {
+		line := scanner.Text()
+		rule := garden.NetOutRule{}
+		err := json.Unmarshal([]byte(line), &rule)
+		if err != nil {
+			log.Fatalf("Error unmarshalling '%s' to a garden.NetOutRule: %s", line, err)
+		}
+
+		asgRule := netoutToASGRule(rule)
+
+		asgs = append(asgs, asgRule)
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("Error reading from stdin: %s", err)
+	}
+
+	data, err := json.Marshal(asgs)
+	if err != nil {
+		log.Fatalf("Couldn't json encode ASG rules: %s", err)
+	}
+	fmt.Printf("%s\n", data)
+}
+
+type SecurityGroupRule struct {
+	Protocol    string           `json:"protocol"`
+	Destination string           `json:"destination"`
+	Ports       string           `json:"ports,omitempty"`
+	Type        *garden.ICMPType `json:"type,omitempty"`
+	Code        *garden.ICMPCode `json:"code,omitempty"`
+	Description string           `json:"description,omitempty"`
+	Log         bool             `json:"log"`
+}
+
+type intptr *int
+
+func netoutToASGRule(rule garden.NetOutRule) SecurityGroupRule {
+
+	sg := SecurityGroupRule{}
+
+	switch rule.Protocol {
+	case garden.ProtocolTCP:
+		sg.Protocol = string(netrules.ProtocolTCP)
+	case garden.ProtocolUDP:
+		sg.Protocol = string(netrules.ProtocolUDP)
+	case garden.ProtocolICMP:
+		sg.Protocol = string(netrules.ProtocolICMP)
+		sg.Type = &rule.ICMPs.Type
+		sg.Code = rule.ICMPs.Code
+	case garden.ProtocolAll:
+		sg.Protocol = string(netrules.ProtocolAll)
+	}
+	sg.Destination = fmt.Sprintf("%s-%s", rule.Networks[0].Start.String(), rule.Networks[0].End.String())
+	if len(rule.Ports) > 0 {
+		if rule.Ports[0].Start != rule.Ports[0].End {
+			sg.Ports = fmt.Sprintf("%d-%d", rule.Ports[0].Start, rule.Ports[0].End)
+		} else {
+			sg.Ports = fmt.Sprintf("%d", rule.Ports[0].Start)
+		}
+	}
+	sg.Log = rule.Log
+
+	return sg
+}

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/policy_client/api.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/policy_client/api.go
@@ -15,12 +15,6 @@ type Policy struct {
 	Destination Destination `json:"destination"`
 }
 
-type EgressPolicy struct {
-	Source       *EgressSource      `json:"source"`
-	Destination  *EgressDestination `json:"destination"`
-	AppLifecycle string             `json:"app_lifecycle"`
-}
-
 type SecurityGroup struct {
 	Guid              string             `json:"guid"`
 	Name              string             `json:"name"`
@@ -29,19 +23,6 @@ type SecurityGroup struct {
 	RunningDefault    bool               `json:"running_default"`
 	StagingSpaceGuids []string           `json:"staging_space_guids"`
 	RunningSpaceGuids []string           `json:"running_space_guids"`
-}
-
-type EgressSource struct {
-	ID   string `json:"id"`
-	Type string `json:"type"`
-}
-
-type EgressDestination struct {
-	Protocol string    `json:"protocol"`
-	Ports    []Ports   `json:"ports"`
-	IPRanges []IPRange `json:"ips"`
-	ICMPType int       `json:"icmp_type"`
-	ICMPCode int       `json:"icmp_code"`
 }
 
 type IPRange struct {
@@ -79,13 +60,13 @@ type Space struct {
 type SecurityGroupRules []SecurityGroupRule
 
 type SecurityGroupRule struct {
-	Protocol    string `json: "protocol"`
-	Destination string `json: "destination"`
-	Ports       string `json: "ports"`
-	Type        int    `json: "type"`
-	Code        int    `json: "code"`
-	Description string `json: "description"`
-	Log         bool   `json: "log"`
+	Protocol    string `json:"protocol"`
+	Destination string `json:"destination"`
+	Ports       string `json:"ports,omitempty"`
+	Type        int    `json:"type"`
+	Code        int    `json:"code"`
+	Description string `json:"description,omitempty"`
+	Log         bool   `json:"log"`
 }
 
 func (sgr *SecurityGroupRules) UnmarshalJSON(data []byte) error {

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/policy_client/internal_policy_client.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/policy_client/internal_policy_client.go
@@ -11,7 +11,7 @@ import (
 
 //go:generate counterfeiter -o fakes/internal_policy_client.go --fake-name InternalPolicyClient . InternalPolicyClient
 type InternalPolicyClient interface {
-	GetPolicies() ([]*Policy, []*EgressPolicy, error)
+	GetPolicies() ([]*Policy, error)
 	GetSecurityGroupsForSpace(spaceGuids []string) ([]*SecurityGroup, error)
 }
 
@@ -45,31 +45,29 @@ func NewInternal(logger lager.Logger, httpClient json_client.HttpClient, baseURL
 	}
 }
 
-func (c *InternalClient) GetPolicies() ([]*Policy, []*EgressPolicy, error) {
+func (c *InternalClient) GetPolicies() ([]*Policy, error) {
 	var policies struct {
-		Policies       []*Policy       `json:"policies"`
-		EgressPolicies []*EgressPolicy `json:"egress_policies"`
+		Policies []*Policy `json:"policies"`
 	}
 	err := c.JsonClient.Do("GET", "/networking/v1/internal/policies", nil, &policies, "")
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return policies.Policies, policies.EgressPolicies, nil
+	return policies.Policies, nil
 }
 
-func (c *InternalClient) GetPoliciesByID(ids ...string) ([]Policy, []EgressPolicy, error) {
+func (c *InternalClient) GetPoliciesByID(ids ...string) ([]Policy, error) {
 	var policies struct {
-		Policies       []Policy       `json:"policies"`
-		EgressPolicies []EgressPolicy `json:"egress_policies"`
+		Policies []Policy `json:"policies"`
 	}
 	if len(ids) == 0 {
-		return nil, nil, errors.New("ids cannot be empty")
+		return nil, errors.New("ids cannot be empty")
 	}
 	err := c.JsonClient.Do("GET", "/networking/v1/internal/policies?id="+strings.Join(ids, ","), nil, &policies, "")
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return policies.Policies, policies.EgressPolicies, nil
+	return policies.Policies, nil
 }
 
 func (c *InternalClient) GetSecurityGroupsForSpace(spaceGuids ...string) ([]SecurityGroup, error) {

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/policy_client/policy_slice.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/policy_client/policy_slice.go
@@ -28,27 +28,3 @@ func (s PolicySlice) Less(i, j int) bool {
 func (s PolicySlice) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
-
-type EgressPolicySlice []EgressPolicy
-
-func (s EgressPolicySlice) Len() int {
-	return len(s)
-}
-
-func (s EgressPolicySlice) Less(i, j int) bool {
-	a, err := json.Marshal(s[i])
-	if err != nil {
-		panic(err)
-	}
-
-	b, err := json.Marshal(s[j])
-	if err != nil {
-		panic(err)
-	}
-
-	return strings.Compare(string(a), string(b)) < 0
-}
-
-func (s EgressPolicySlice) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}

--- a/src/code.cloudfoundry.org/vendor/modules.txt
+++ b/src/code.cloudfoundry.org/vendor/modules.txt
@@ -49,7 +49,7 @@ code.cloudfoundry.org/lager/internal/truncate
 code.cloudfoundry.org/lager/lagerctx
 code.cloudfoundry.org/lager/lagerflags
 code.cloudfoundry.org/lager/lagertest
-# code.cloudfoundry.org/policy_client v0.0.0-20220203234022-670e720134e3
+# code.cloudfoundry.org/policy_client v0.0.0-20220427143037-36975d7cc48d
 ## explicit; go 1.17
 code.cloudfoundry.org/policy_client
 # code.cloudfoundry.org/routing-info v0.0.0-20220215234142-7d023ecb0fad

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
@@ -173,11 +173,11 @@ var _ = Describe("Enforcer", func() {
 				_, err := ruleEnforcer.Enforce("some-table", "some-chain", "asg-001-", "asg-\\d\\d\\d-", true, []rules.IPTablesRule{fakeRule}...)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(iptables.DeleteCallCount()).To(Equal(7))
-				table, chain, ruleSpec := iptables.DeleteArgsForCall(0)
+				Expect(iptables.DeleteAfterRuleNumCallCount()).To(Equal(1))
+				table, chain, ruleSpec := iptables.DeleteAfterRuleNumArgsForCall(0)
 				Expect(table).To(Equal("some-table"))
 				Expect(chain).To(Equal("some-chain"))
-				Expect(ruleSpec).To(Equal(rules.IPTablesRule{"-j", "asg-000-9999999999111110"}))
+				Expect(ruleSpec).To(Equal(2))
 				Expect(iptables.ClearChainCallCount()).To(Equal(1))
 				table, chain = iptables.ClearChainArgsForCall(0)
 				Expect(table).To(Equal("some-table"))
@@ -186,36 +186,6 @@ var _ = Describe("Enforcer", func() {
 				table, chain = iptables.DeleteChainArgsForCall(0)
 				Expect(table).To(Equal("some-table"))
 				Expect(chain).To(Equal("asg-000-9999999999111110"))
-
-				table, chain, ruleSpec = iptables.DeleteArgsForCall(1)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("some-chain"))
-				Expect(ruleSpec).To(Equal(rules.IPTablesRule{"-j", "some-chain--log"}))
-
-				table, chain, ruleSpec = iptables.DeleteArgsForCall(2)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("some-chain"))
-				Expect(ruleSpec).To(Equal(rules.IPTablesRule{"-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"}))
-
-				table, chain, ruleSpec = iptables.DeleteArgsForCall(3)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("some-chain"))
-				Expect(ruleSpec).To(Equal(rules.IPTablesRule{"-p", "tcp", "-m", "state", "--state", "INVALID", "-j", "DROP"}))
-
-				table, chain, ruleSpec = iptables.DeleteArgsForCall(4)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("some-chain"))
-				Expect(ruleSpec).To(Equal(rules.IPTablesRule{"-m", "iprange", "--dst-range", "0.0.0.0-9.255.255.255", "-j", "ACCEPT"}))
-
-				table, chain, ruleSpec = iptables.DeleteArgsForCall(5)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("some-chain"))
-				Expect(ruleSpec).To(Equal(rules.IPTablesRule{"-j", "REJECT", "--reject-with", "icmp-port-unreachable"}))
-
-				table, chain, ruleSpec = iptables.DeleteArgsForCall(6)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("some-chain"))
-				Expect(ruleSpec).To(Equal(rules.IPTablesRule{"-j", "LOG", "--log-prefix", "DENY_ee8fd40b "}))
 			})
 
 			It("does not delete other rules in parent chain if parent chain cleanup is not requested", func() {


### PR DESCRIPTION
There are cases where `iptables -S` output cannot be directly translated
back into `iptables -D` commands. If that happens, the Enforce fails,
which has the side-effect of preventing new containers from being
created in garden.

This was run into with rules specifying ICMP packets with type 255, and
code 255. iptables -S uses the "any" shortcut for these rules, but the
rule can only be deleted with the rulespec it was given ("255/255").