### PR TITLE
Enable netmon telemetry

### DIFF
--- a/jobs/netmon/spec
+++ b/jobs/netmon/spec
@@ -35,3 +35,7 @@ properties:
   disable:
     description: "Disable this monit job.  It will not run. Required for backwards compatability"
     default: false
+
+  telemetry_enabled:
+    description: "Enables logging to a dedicated logfile that can be used for telemetry"
+    default: false

--- a/jobs/netmon/templates/netmon.json.erb
+++ b/jobs/netmon/templates/netmon.json.erb
@@ -8,6 +8,7 @@
     "log_level" => p("log_level"),
     "log_prefix" => "cfnetworking",
     "iptables_lock_file" => "/var/vcap/data/garden-cni/iptables.lock",
+    "telemetry_enabled" => p("telemetry_enabled"),
   }
 
     JSON.pretty_generate(toRender)

--- a/src/code.cloudfoundry.org/netmon/config/config.go
+++ b/src/code.cloudfoundry.org/netmon/config/config.go
@@ -19,6 +19,7 @@ type Netmon struct {
 	LogLevel         string `json:"log_level"`
 	LogPrefix        string `json:"log_prefix" validate:"nonzero"`
 	IPTablesLockFile string `json:"iptables_lock_file" validate:"nonzero"`
+	TelemetryEnabled bool   `json:"telemetry_enabled"`
 }
 
 func (n Netmon) ParseLogLevel() (lager.LogLevel, error) {

--- a/src/code.cloudfoundry.org/netmon/config/config_test.go
+++ b/src/code.cloudfoundry.org/netmon/config/config_test.go
@@ -62,7 +62,8 @@ var _ = Describe("Config", func() {
 					"interface_name": "eth0",
 					"log_level": "debug",
 					"log_prefix": "cfnetworking",
-					"iptables_lock_file": "iptables-lock-file"
+					"iptables_lock_file": "iptables-lock-file",
+					"telemetry_enabled": true
 				}`)
 				c, err := config.New(file.Name())
 				Expect(err).NotTo(HaveOccurred())
@@ -72,6 +73,7 @@ var _ = Describe("Config", func() {
 				Expect(c.LogLevel).To(Equal("debug"))
 				Expect(c.LogPrefix).To(Equal("cfnetworking"))
 				Expect(c.IPTablesLockFile).To(Equal("iptables-lock-file"))
+				Expect(c.TelemetryEnabled).To(BeTrue())
 			})
 		})
 
@@ -94,6 +96,23 @@ var _ = Describe("Config", func() {
 			It("returns the error", func() {
 				_, err = config.New(file.Name())
 				Expect(err).To(MatchError(ContainSubstring("parsing config")))
+			})
+		})
+
+		Context("when `telemetry_enabled` is not set", func() {
+			It("defaults to false", func() {
+				file.WriteString(`{
+					"poll_interval": 1234,
+					"metron_address": "http://1.2.3.4:1234",
+					"interface_name": "eth0",
+					"log_level": "debug",
+					"log_prefix": "cfnetworking",
+					"iptables_lock_file": "iptables-lock-file"
+				}`)
+				c, err := config.New(file.Name())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(c.TelemetryEnabled).To(BeFalse())
+
 			})
 		})
 

--- a/src/code.cloudfoundry.org/netmon/poller/poller_test.go
+++ b/src/code.cloudfoundry.org/netmon/poller/poller_test.go
@@ -60,6 +60,28 @@ var _ = Describe("Poller Run", func() {
 		iptablesLog := logger.Logs()[2]
 		Expect(iptablesLog.Data["IPTablesRuleCount"]).To(Equal(float64(4)))
 	})
+
+	Context("when a telemetry logger is configured", func() {
+		var (
+			telemetryLogger *lagertest.TestLogger
+		)
+
+		BeforeEach(func() {
+			telemetryLogger = lagertest.NewTestLogger("telemetry")
+			metrics = &poller.SystemMetrics{
+				Logger:          logger,
+				TelemetryLogger: telemetryLogger,
+				PollInterval:    pollInterval,
+				InterfaceName:   "meow",
+				IPTablesAdapter: iptables,
+			}
+		})
+
+		It("logs the number of iptables rules in the telemetry log", func() {
+			runTest(metrics, pollInterval)
+			Expect(telemetryLogger.LogMessages()).To(Equal([]string{"telemetry.count-iptables-rules"}))
+		})
+	})
 })
 
 func runTest(metrics *poller.SystemMetrics, pollInterval time.Duration) {


### PR DESCRIPTION
Adds a option (`telemetry_enabled`) that configures netmon to log certain data to a dedicated `telemetry.log` file for a colocated telemetry agent to scrape. Currently, netmon periodically logs only IPTablesRulesCount.