### PR TITLE
Ignore cleanup failures when applying ASG updates

### DIFF
--- a/src/code.cloudfoundry.org/lib/fakes/iptables_extended.go
+++ b/src/code.cloudfoundry.org/lib/fakes/iptables_extended.go
@@ -84,6 +84,19 @@ type IPTablesAdapter struct {
 	deleteAfterRuleNumReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DeleteAfterRuleNumKeepRejectStub        func(string, string, int) error
+	deleteAfterRuleNumKeepRejectMutex       sync.RWMutex
+	deleteAfterRuleNumKeepRejectArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 int
+	}
+	deleteAfterRuleNumKeepRejectReturns struct {
+		result1 error
+	}
+	deleteAfterRuleNumKeepRejectReturnsOnCall map[int]struct {
+		result1 error
+	}
 	DeleteChainStub        func(string, string) error
 	deleteChainMutex       sync.RWMutex
 	deleteChainArgsForCall []struct {
@@ -554,6 +567,69 @@ func (fake *IPTablesAdapter) DeleteAfterRuleNumReturnsOnCall(i int, result1 erro
 	}{result1}
 }
 
+func (fake *IPTablesAdapter) DeleteAfterRuleNumKeepReject(arg1 string, arg2 string, arg3 int) error {
+	fake.deleteAfterRuleNumKeepRejectMutex.Lock()
+	ret, specificReturn := fake.deleteAfterRuleNumKeepRejectReturnsOnCall[len(fake.deleteAfterRuleNumKeepRejectArgsForCall)]
+	fake.deleteAfterRuleNumKeepRejectArgsForCall = append(fake.deleteAfterRuleNumKeepRejectArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 int
+	}{arg1, arg2, arg3})
+	stub := fake.DeleteAfterRuleNumKeepRejectStub
+	fakeReturns := fake.deleteAfterRuleNumKeepRejectReturns
+	fake.recordInvocation("DeleteAfterRuleNumKeepReject", []interface{}{arg1, arg2, arg3})
+	fake.deleteAfterRuleNumKeepRejectMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *IPTablesAdapter) DeleteAfterRuleNumKeepRejectCallCount() int {
+	fake.deleteAfterRuleNumKeepRejectMutex.RLock()
+	defer fake.deleteAfterRuleNumKeepRejectMutex.RUnlock()
+	return len(fake.deleteAfterRuleNumKeepRejectArgsForCall)
+}
+
+func (fake *IPTablesAdapter) DeleteAfterRuleNumKeepRejectCalls(stub func(string, string, int) error) {
+	fake.deleteAfterRuleNumKeepRejectMutex.Lock()
+	defer fake.deleteAfterRuleNumKeepRejectMutex.Unlock()
+	fake.DeleteAfterRuleNumKeepRejectStub = stub
+}
+
+func (fake *IPTablesAdapter) DeleteAfterRuleNumKeepRejectArgsForCall(i int) (string, string, int) {
+	fake.deleteAfterRuleNumKeepRejectMutex.RLock()
+	defer fake.deleteAfterRuleNumKeepRejectMutex.RUnlock()
+	argsForCall := fake.deleteAfterRuleNumKeepRejectArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *IPTablesAdapter) DeleteAfterRuleNumKeepRejectReturns(result1 error) {
+	fake.deleteAfterRuleNumKeepRejectMutex.Lock()
+	defer fake.deleteAfterRuleNumKeepRejectMutex.Unlock()
+	fake.DeleteAfterRuleNumKeepRejectStub = nil
+	fake.deleteAfterRuleNumKeepRejectReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *IPTablesAdapter) DeleteAfterRuleNumKeepRejectReturnsOnCall(i int, result1 error) {
+	fake.deleteAfterRuleNumKeepRejectMutex.Lock()
+	defer fake.deleteAfterRuleNumKeepRejectMutex.Unlock()
+	fake.DeleteAfterRuleNumKeepRejectStub = nil
+	if fake.deleteAfterRuleNumKeepRejectReturnsOnCall == nil {
+		fake.deleteAfterRuleNumKeepRejectReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteAfterRuleNumKeepRejectReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *IPTablesAdapter) DeleteChain(arg1 string, arg2 string) error {
 	fake.deleteChainMutex.Lock()
 	ret, specificReturn := fake.deleteChainReturnsOnCall[len(fake.deleteChainArgsForCall)]
@@ -1013,6 +1089,8 @@ func (fake *IPTablesAdapter) Invocations() map[string][][]interface{} {
 	defer fake.deleteMutex.RUnlock()
 	fake.deleteAfterRuleNumMutex.RLock()
 	defer fake.deleteAfterRuleNumMutex.RUnlock()
+	fake.deleteAfterRuleNumKeepRejectMutex.RLock()
+	defer fake.deleteAfterRuleNumKeepRejectMutex.RUnlock()
 	fake.deleteChainMutex.RLock()
 	defer fake.deleteChainMutex.RUnlock()
 	fake.existsMutex.RLock()

--- a/src/code.cloudfoundry.org/lib/rules/locked_iptables_test.go
+++ b/src/code.cloudfoundry.org/lib/rules/locked_iptables_test.go
@@ -289,6 +289,103 @@ var _ = Describe("LockedIptables", func() {
 
 	})
 
+	Describe("DeleteAfterRuleNumKeepReject", func() {
+		BeforeEach(func() {
+			ipt.ListReturns([]string{
+				"-N some-chain",
+				"-A some-chain rule-1",
+				"-A some-chain rule-2",
+				"-A some-chain -j REJECT --reject-with icmp-port-unreachable",
+				"-A some-chain rule-3",
+			}, nil)
+		})
+
+		It("locks and passes the correct parameters to iptables", func() {
+			err := lockedIPT.DeleteAfterRuleNumKeepReject("some-table", "some-chain", 2)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(lock.LockCallCount()).To(Equal(1))
+			Expect(lock.UnlockCallCount()).To(Equal(1))
+			Expect(ipt.DeleteCallCount()).To(Equal(3))
+			Expect(ipt.ListCallCount()).To(Equal(1))
+
+			table, chain := ipt.ListArgsForCall(0)
+			Expect(table).To(Equal("some-table"))
+			Expect(chain).To(Equal("some-chain"))
+
+			table, chain, ruleNum := ipt.DeleteArgsForCall(0)
+			Expect(table).To(Equal("some-table"))
+			Expect(chain).To(Equal("some-chain"))
+			Expect(ruleNum).To(Equal([]string{"2", "--wait"}))
+			table, chain, ruleNum = ipt.DeleteArgsForCall(1)
+			Expect(table).To(Equal("some-table"))
+			Expect(chain).To(Equal("some-chain"))
+			Expect(ruleNum).To(Equal([]string{"2", "--wait"}))
+			table, chain, ruleNum = ipt.DeleteArgsForCall(2)
+			Expect(table).To(Equal("some-table"))
+			Expect(chain).To(Equal("some-chain"))
+			Expect(ruleNum).To(Equal([]string{"2", "--wait"}))
+
+			Expect(ipt.AppendUniqueCallCount()).To(Equal(1))
+			table, chain, rules := ipt.AppendUniqueArgsForCall(0)
+			Expect(table).To(Equal("some-table"))
+			Expect(chain).To(Equal("some-chain"))
+			Expect(rules).To(Equal([]string{"--jump", "REJECT", "--reject-with", "icmp-port-unreachable"}))
+		})
+
+		Context("when locking fails", func() {
+			BeforeEach(func() {
+				lock.LockReturns(errors.New("banana"))
+			})
+			It("returns an error", func() {
+				err := lockedIPT.DeleteAfterRuleNumKeepReject("some-table", "some-chain", 2)
+				Expect(err).To(MatchError("lock: banana"))
+			})
+		})
+
+		Context("when iptables list fails and unlock succeeds", func() {
+			BeforeEach(func() {
+				ipt.ListReturns([]string{}, errors.New("banana"))
+			})
+			It("returns an error", func() {
+				err := lockedIPT.DeleteAfterRuleNumKeepReject("some-table", "some-chain", 2)
+				Expect(err).To(MatchError("iptables call: banana and unlock: <nil>"))
+			})
+		})
+
+		Context("when iptables list fails and unlock fails", func() {
+			BeforeEach(func() {
+				lock.UnlockReturns(errors.New("banana"))
+				ipt.ListReturns([]string{}, errors.New("patato"))
+			})
+			It("returns an error", func() {
+				err := lockedIPT.DeleteAfterRuleNumKeepReject("some-table", "some-chain", 2)
+				Expect(err).To(MatchError("iptables call: patato and unlock: banana"))
+			})
+		})
+
+		Context("when iptables delete fails and unlock succeeds", func() {
+			BeforeEach(func() {
+				ipt.DeleteReturns(errors.New("banana"))
+			})
+			It("returns an error", func() {
+				err := lockedIPT.DeleteAfterRuleNumKeepReject("some-table", "some-chain", 2)
+				Expect(err).To(MatchError("iptables call: banana and unlock: <nil>"))
+			})
+		})
+
+		Context("when iptables delete fails and unlock fails", func() {
+			BeforeEach(func() {
+				lock.UnlockReturns(errors.New("banana"))
+				ipt.DeleteReturns(errors.New("patato"))
+			})
+			It("returns an error", func() {
+				err := lockedIPT.DeleteAfterRuleNumKeepReject("some-table", "some-chain", 2)
+				Expect(err).To(MatchError("iptables call: patato and unlock: banana"))
+			})
+		})
+	})
+
 	Describe("Delete", func() {
 		It("locks and passes the correct parameters to the iptables library", func() {
 			err := lockedIPT.Delete("some-table", "some-chain", rule)

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger.go
@@ -156,11 +156,10 @@ func (m *SinglePollCycle) SyncASGsForContainers(containers ...string) error {
 				chain, err := m.enforcer.EnforceRulesAndChain(ruleset)
 				if err != nil {
 					if _, ok := err.(*enforcer.CleanupErr); ok {
-						m.logger.Error("failed-to-cleanup", err)
 						m.updateRuleSet(chainKey, chain, ruleset)
-					} else {
-						errors = multierror.Append(errors, fmt.Errorf("enforce-asg: %s", err))
 					}
+
+					errors = multierror.Append(errors, fmt.Errorf("enforce-asg: %s", err))
 				} else {
 					m.updateRuleSet(chainKey, chain, ruleset)
 				}

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger.go
@@ -155,12 +155,14 @@ func (m *SinglePollCycle) SyncASGsForContainers(containers ...string) error {
 				})
 				chain, err := m.enforcer.EnforceRulesAndChain(ruleset)
 				if err != nil {
-					errors = multierror.Append(errors, fmt.Errorf("enforce-asg: %s", err))
+					if _, ok := err.(*enforcer.CleanupErr); ok {
+						m.logger.Error("failed-to-cleanup", err)
+						m.updateRuleSet(chainKey, chain, ruleset)
+					} else {
+						errors = multierror.Append(errors, fmt.Errorf("enforce-asg: %s", err))
+					}
 				} else {
-					// only overwrite the container/rule caches if we did not error here
-					m.containerToASGChain[chainKey] = chain
-					m.asgRuleSets[chainKey] = ruleset
-					m.sendAppLog(ruleset.LogConfig)
+					m.updateRuleSet(chainKey, chain, ruleset)
 				}
 			}
 			desiredChains = append(desiredChains, enforcer.LiveChain{Table: ruleset.Chain.Table, Name: m.containerToASGChain[chainKey]})
@@ -196,6 +198,12 @@ func (m *SinglePollCycle) CleanupOrphanedASGsChains(containerHandle string) erro
 	defer m.asgMutex.Unlock()
 
 	return m.cleanupASGsChains(planner.ASGChainPrefix(containerHandle), []enforcer.LiveChain{})
+}
+
+func (m *SinglePollCycle) updateRuleSet(chainKey enforcer.LiveChain, chain string, ruleset enforcer.RulesWithChain) {
+	m.containerToASGChain[chainKey] = chain
+	m.asgRuleSets[chainKey] = ruleset
+	m.sendAppLog(ruleset.LogConfig)
 }
 
 func (m *SinglePollCycle) cleanupASGsChains(prefix string, desiredChains []enforcer.LiveChain) error {

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer.go
@@ -65,6 +65,14 @@ type RulesWithChain struct {
 	LogConfig executor.LogConfig
 }
 
+type CleanupErr struct {
+	Err error
+}
+
+func (e *CleanupErr) Error() string {
+	return fmt.Sprintf("cleaning up: %s", e.Err)
+}
+
 func (r *RulesWithChain) Equals(other RulesWithChain) bool {
 	if r.Chain != other.Chain {
 		return false
@@ -180,7 +188,7 @@ func (e *Enforcer) Enforce(table, parentChain, chainPrefix, managedChainsRegex s
 	err = e.cleanupOldRules(logger, table, parentChain, managedChainsRegex, cleanupParentChain, newTime)
 	if err != nil {
 		logger.Error("cleanup-rules", err)
-		return "", fmt.Errorf("cleaning up: %s", err)
+		return "", &CleanupErr{err}
 	}
 
 	return chain, nil

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer.go
@@ -225,7 +225,7 @@ func (e *Enforcer) cleanupOldRules(logger lager.Logger, table, parentChain, mana
 		// Everything else is either an original rule from before asg-syncing kicked in, or the previous asg-* chain jump rule
 		// Nothing should be modifying the netout-* chains, as the first rule will always end up being a jump to the asg-*
 		// chain after ~60s, and it ends in a blanket REJECT, so no other rules would be effective anyway.
-		err := e.iptables.DeleteAfterRuleNum(table, parentChain, 2)
+		err := e.iptables.DeleteAfterRuleNumKeepReject(table, parentChain, 2)
 		if err != nil {
 			return fmt.Errorf("clean up parent chain: %s", err)
 		}

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
@@ -267,9 +267,11 @@ var _ = Describe("Enforcer", func() {
 				iptables.ListReturns(nil, errors.New("blueberry"))
 			})
 
-			It("it logs and returns a useful error", func() {
+			It("it logs and returns a cleanup error", func() {
 				_, err := ruleEnforcer.Enforce("some-table", "some-chain", "foo", "foo", false, []rules.IPTablesRule{fakeRule}...)
 				Expect(err).To(MatchError("cleaning up: listing forward rules: blueberry"))
+				_, isCleanupErr := err.(*enforcer.CleanupErr)
+				Expect(isCleanupErr).To(BeTrue())
 				Expect(logger).To(gbytes.Say("cleanup-rules.*blueberry"))
 			})
 		})
@@ -283,6 +285,8 @@ var _ = Describe("Enforcer", func() {
 			It("returns a useful error", func() {
 				_, err := ruleEnforcer.Enforce("some-table", "some-chain", "foo", "foo", false, []rules.IPTablesRule{fakeRule}...)
 				Expect(err).To(MatchError("cleaning up: remove reference to old chain: banana"))
+				_, isCleanupErr := err.(*enforcer.CleanupErr)
+				Expect(isCleanupErr).To(BeTrue())
 			})
 		})
 

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
@@ -169,15 +169,17 @@ var _ = Describe("Enforcer", func() {
 				}, nil)
 			})
 
-			It("deletes other rules in parent chain after the current chain if parent chain cleanup requested", func() {
+			It("deletes other rules in parent chain after the current chain and keeps the reject rule if parent chain cleanup requested", func() {
 				_, err := ruleEnforcer.Enforce("some-table", "some-chain", "asg-001-", "asg-\\d\\d\\d-", true, []rules.IPTablesRule{fakeRule}...)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(iptables.DeleteAfterRuleNumCallCount()).To(Equal(1))
-				table, chain, ruleSpec := iptables.DeleteAfterRuleNumArgsForCall(0)
+				Expect(iptables.DeleteAfterRuleNumKeepRejectCallCount()).To(Equal(1))
+				table, chain, ruleSpec := iptables.DeleteAfterRuleNumKeepRejectArgsForCall(0)
 				Expect(table).To(Equal("some-table"))
 				Expect(chain).To(Equal("some-chain"))
 				Expect(ruleSpec).To(Equal(2))
+				Expect(iptables.BulkAppendCallCount()).To(Equal(1))
+
 				Expect(iptables.ClearChainCallCount()).To(Equal(1))
 				table, chain = iptables.ClearChainArgsForCall(0)
 				Expect(table).To(Equal("some-table"))

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/integration/linux/linux_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/integration/linux/linux_test.go
@@ -343,14 +343,14 @@ var _ = Describe("VXLAN Policy Agent", func() {
 						Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -j REJECT --reject-with icmp-port-unreachable`))
 					})
 
-					It("cleans up the parent asg", func() {
+					It("cleans up the parent asg keeping the reject rule", func() {
 						Eventually(iptablesFilterRules, "4s", "1s").ShouldNot(MatchRegexp(`-A netout--some-handle -m state --state RELATED,ESTABLISHED -j ACCEPT`))
 						Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -p tcp -m state --state INVALID -j DROP`))
 						Expect(iptablesFilterRules()).To(MatchRegexp(`-A netout--some-handle -j asg-\d+`))
 						Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -p icmp -m iprange --dst-range 0.0.0.0-255.255.255.255 -m icmp --icmp-type 0/0 -j ACCEPT`))
 						Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -m iprange --dst-range 11.0.0.0-169.253.255.255 -j ACCEPT`))
 						Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -m iprange --dst-range 0.0.0.0-9.255.255.255 -j ACCEPT`))
-						Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -j REJECT --reject-with icmp-port-unreachable`))
+						Expect(iptablesFilterRules()).To(MatchRegexp(`-A netout--some-handle -j REJECT --reject-with icmp-port-unreachable`))
 					})
 
 					Context("when the container is staging", func() {


### PR DESCRIPTION
After new ASG chain is created and we fail to clean up old ASG chain we
log the error but continue on and consider our new ASG chain as
successful and save it in the in-memory map for subsequent comparison.
This is to avoid re-applying the same chain. As well as saving it in a
map as a desired chain to avoid deleting it right after we create it.

Original ASG chain fails to be deleted because cascading deletion of
referenced chains might fail. In the observed case we saw that
referenced chain is the netout-...-log chain that is getting referenced
by the new ASG chain now.

Signed-off-by: Marc Paquette <mpaquette@vmware.com>