### PR TITLE
fix handling of ASGs with spaces between ports

### DIFF
--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/security_group_rule.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/security_group_rule.go
@@ -55,17 +55,17 @@ func (r *securityGroupRule) Ports() []PortRange {
 	for _, portRangeStr := range portRangeStrs {
 		ports := strings.Split(portRangeStr, "-")
 		if len(ports) == 1 {
-			port, err := strconv.Atoi(ports[0])
+			port, err := strconv.Atoi(strings.TrimSpace(ports[0]))
 			if err != nil {
 				continue
 			}
 			portRanges = append(portRanges, PortRange{Start: uint16(port), End: uint16(port)})
 		} else if len(ports) == 2 {
-			startPort, err := strconv.Atoi(ports[0])
+			startPort, err := strconv.Atoi(strings.TrimSpace(ports[0]))
 			if err != nil {
 				continue
 			}
-			endPort, err := strconv.Atoi(ports[1])
+			endPort, err := strconv.Atoi(strings.TrimSpace(ports[1]))
 			if err != nil {
 				continue
 			}

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/security_group_rule_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/security_group_rule_test.go
@@ -165,5 +165,19 @@ var _ = Describe("SecurityGroupRule", func() {
 				netrules.PortRange{Start: 443, End: 443},
 			))
 		})
+		It("parses ports and ranges with spaces", func() {
+			securityGroupRule := policy_client.SecurityGroupRule{
+				Destination: "10.0.0.1",
+				Ports:       "1000 -2000, 8080, 3000 - 4000, 443 ",
+			}
+			rule, err := netrules.NewRuleFromSecurityGroupRule(securityGroupRule)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rule.Ports()).To(ConsistOf(
+				netrules.PortRange{Start: 1000, End: 2000},
+				netrules.PortRange{Start: 8080, End: 8080},
+				netrules.PortRange{Start: 3000, End: 4000},
+				netrules.PortRange{Start: 443, End: 443},
+			))
+		})
 	})
 })


### PR DESCRIPTION
Port definitions that included spaces where not parsed correctly and silently ignored. E.g. in "1000 -2000, 8080, 3000 - 4000, 443 " only the 2000 from "1000 -2000" would have been recognized.
It was initially reported here https://github.com/cloudfoundry/cf-networking-release/issues/149
