### PR TITLE
add template test for subnet_prefix_length

### DIFF
--- a/jobs/silk-controller/templates/silk-controller.json.erb
+++ b/jobs/silk-controller/templates/silk-controller.json.erb
@@ -49,6 +49,12 @@
     if size < 1 || size > 30
       raise 'subnet_prefix_length must be a value between 1-30'
     end
+
+    network = p('network')
+    if IPAddr.new(network).prefix >= size
+      raise "subnet_prefix_length '#{size}' must be smaller than the network '#{network.to_s}'"
+    end
+
     size
   end
 

--- a/spec/silk-controller/silk_controller_spec.rb
+++ b/spec/silk-controller/silk_controller_spec.rb
@@ -149,6 +149,22 @@ module Bosh::Template::Test
         }.to raise_error('subnet_prefix_length must be a value between 1-30')
       end
 
+      it 'raises an error when the subnet_prefix_length larger than the network' do
+        merged_manifest_properties['subnet_prefix_length'] = 15
+        merged_manifest_properties['network'] = '10.255.0.0/16'
+        expect{
+          JSON.parse(template.render(merged_manifest_properties))
+        }.to raise_error('subnet_prefix_length \'15\' must be smaller than the network \'10.255.0.0/16\'')
+      end
+
+      it 'raises an error when the subnet_prefix_length is the same size as the network' do
+        merged_manifest_properties['subnet_prefix_length'] = 16
+        merged_manifest_properties['network'] = '10.255.0.0/16'
+        expect{
+          JSON.parse(template.render(merged_manifest_properties))
+        }.to raise_error('subnet_prefix_length \'16\' must be smaller than the network \'10.255.0.0/16\'')
+      end
+
       it 'raises an error when the driver (type) is unknown' do
         merged_manifest_properties['database']['type'] = 'bar'
         expect {


### PR DESCRIPTION
Do not let the diego cell subnet be the same size or larger than the overlay subnet.