### PR TITLE
add job to sync app log metadata from garden to silk datastore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This release contains the following jobs:
 - `silk-controller`
 - `silk-daemon`
 - `silk-cni`
+- `silk-datastore-syncer`
 - `netmon`
 - `vxlan-policy-agent`
 - `iptables-logger`

--- a/jobs/silk-datastore-syncer/monit
+++ b/jobs/silk-datastore-syncer/monit
@@ -1,0 +1,7 @@
+<% unless p("disable") %>
+check process silk-datastore-syncer
+  with pidfile /var/vcap/sys/run/bpm/silk-datastore-syncer/silk-datastore-syncer.pid
+  start program "/var/vcap/jobs/bpm/bin/bpm start silk-datastore-syncer"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop silk-datastore-syncer"
+  group vcap
+<% end %>

--- a/jobs/silk-datastore-syncer/spec
+++ b/jobs/silk-datastore-syncer/spec
@@ -1,0 +1,26 @@
+---
+name: silk-datastore-syncer
+
+templates:
+  bpm.yml.erb: config/bpm.yml
+  start.erb: bin/start
+
+packages:
+  - silk-datastore-syncer
+
+properties:
+  disable:
+    description: "Disable this monit job. It will not run. Required for backwards compatability."
+    default: false
+  sync_interval_in_seconds:
+    description: "Interval to check garden for new metadata."
+    default: 30
+  garden.address:
+    description: "Garden server listening address."
+    default: /var/vcap/data/garden/garden.sock
+  garden.network:
+    description: "Network type for the garden server connection (tcp or unix)."
+    default: unix
+  log_level:
+    description: "Logging level (debug, info, warn, error)."
+    default: info

--- a/jobs/silk-datastore-syncer/templates/bpm.yml.erb
+++ b/jobs/silk-datastore-syncer/templates/bpm.yml.erb
@@ -1,0 +1,14 @@
+---
+processes:
+  - name: silk-datastore-syncer
+    unsafe:
+      privileged: true
+    executable: "/var/vcap/jobs/silk-datastore-syncer/bin/start"
+    additional_volumes:
+    - path: /var/vcap/data/container-metadata
+      writable: true
+    - path: /var/vcap/data/garden
+      writable: true
+    capabilities:
+    - NET_RAW
+    - NET_ADMIN

--- a/jobs/silk-datastore-syncer/templates/start.erb
+++ b/jobs/silk-datastore-syncer/templates/start.erb
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+/var/vcap/packages/silk-datastore-syncer/bin/silk-datastore-syncer \
+  -n <%= p("sync_interval_in_seconds") %> \
+  -gardenNetwork <%= p("garden.network") %> \
+  -gardenAddr <%= p("garden.address") %> \
+  -silkFile /var/vcap/data/container-metadata/store.json \
+  -silkFileOwner vcap \
+  -silkFileGroup vcap \
+  -logLevel <%= p("log_level") %>

--- a/packages/silk-datastore-syncer/packaging
+++ b/packages/silk-datastore-syncer/packaging
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+set -u
+
+mkdir -p ${BOSH_INSTALL_TARGET}/src
+mv * ${BOSH_INSTALL_TARGET}/src
+mv ${BOSH_INSTALL_TARGET}/src .
+mkdir -p ${BOSH_INSTALL_TARGET}/bin
+
+source /var/vcap/packages/golang-*-linux/bosh/compile.env
+
+pushd src/code.cloudfoundry.org/silk-datastore-syncer
+go build -o "${BOSH_INSTALL_TARGET}/bin/silk-datastore-syncer" code.cloudfoundry.org/silk-datastore-syncer
+popd

--- a/packages/silk-datastore-syncer/spec
+++ b/packages/silk-datastore-syncer/spec
@@ -5,4 +5,30 @@ dependencies:
   - golang-1.19-linux
 
 files:
-  - code.cloudfoundry.org/**/*
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/bbs/encryption/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/bbs/format/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/bbs/models/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/executor/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/filelock/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/client/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/client/connection/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/routes/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/transport/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/internal/truncate/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/lagerflags/*.go # gosub-main-module
+  - code.cloudfoundry.org/lib/common/*.go # gosub-main-module
+  - code.cloudfoundry.org/lib/datastore/*.go # gosub-main-module
+  - code.cloudfoundry.org/lib/serial/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/code.cloudfoundry.org/routing-info/internalroutes/*.go # gosub-main-module
+  - code.cloudfoundry.org/silk-datastore-syncer/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/github.com/bmizerany/pat/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/github.com/gogo/protobuf/gogoproto/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/github.com/gogo/protobuf/proto/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/github.com/gogo/protobuf/protoc-gen-gogo/descriptor/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/github.com/gogo/protobuf/sortkeys/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/github.com/tedsuo/rata/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/golang.org/x/sys/internal/unsafeheader/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/golang.org/x/sys/windows/*.go # gosub-main-module
+  - code.cloudfoundry.org/vendor/golang.org/x/sys/windows/*.s # gosub-main-module

--- a/packages/silk-datastore-syncer/spec
+++ b/packages/silk-datastore-syncer/spec
@@ -1,0 +1,8 @@
+---
+name: silk-datastore-syncer
+
+dependencies:
+  - golang-1.19-linux
+
+files:
+  - code.cloudfoundry.org/**/*

--- a/scripts/sync-package-specs
+++ b/scripts/sync-package-specs
@@ -87,6 +87,9 @@ sync_package netmon \
 sync_package silk-controller \
   -app code.cloudfoundry.org/silk/cmd/silk-controller
 
+sync_package silk-datastore-syncer \
+  -app code.cloudfoundry.org/silk-datastore-syncer
+
 sync_package silk-daemon \
   -app code.cloudfoundry.org/silk/cmd/silk-daemon \
   -app code.cloudfoundry.org/silk/cmd/silk-teardown \

--- a/src/code.cloudfoundry.org/cni-teardown/integration/integration_suite_test.go
+++ b/src/code.cloudfoundry.org/cni-teardown/integration/integration_suite_test.go
@@ -32,7 +32,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	var err error
 
 	fmt.Fprintf(GinkgoWriter, "building binary...")
-	paths.TeardownBin, err = gexec.Build("code.cloudfoundry.org/cni-teardown")
+	paths.TeardownBin, err = gexec.Build("code.cloudfoundry.org/cni-teardown", "-buildvcs=false")
 	fmt.Fprintf(GinkgoWriter, "done")
 	Expect(err).NotTo(HaveOccurred())
 

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_suite_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_suite_test.go
@@ -35,7 +35,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(os.Chown(noopBin, 65534, 65534)).To(Succeed())
 	noopDir, _ := filepath.Split(noopBin)
 
-	pathToPlugin, err := gexec.Build(packagePath)
+	pathToPlugin, err := gexec.Build(packagePath, "-buildvcs=false")
 	Expect(err).NotTo(HaveOccurred())
 	Expect(os.Chown(pathToPlugin, 65534, 65534)).To(Succeed())
 	wrapperDir, _ := filepath.Split(pathToPlugin)

--- a/src/code.cloudfoundry.org/iptables-logger/integration/integration_suite_test.go
+++ b/src/code.cloudfoundry.org/iptables-logger/integration/integration_suite_test.go
@@ -27,7 +27,7 @@ func TestIntegration(t *testing.T) {
 var _ = SynchronizedBeforeSuite(func() []byte {
 	fmt.Fprintf(GinkgoWriter, "building binary...")
 	var err error
-	binaryPath, err = gexec.Build("code.cloudfoundry.org/iptables-logger/cmd/iptables-logger", "-race")
+	binaryPath, err = gexec.Build("code.cloudfoundry.org/iptables-logger/cmd/iptables-logger", "-race", "-buildvcs=false")
 	fmt.Fprintf(GinkgoWriter, "done")
 	Expect(err).NotTo(HaveOccurred())
 

--- a/src/code.cloudfoundry.org/lib/datastore/datastore_integration_test.go
+++ b/src/code.cloudfoundry.org/lib/datastore/datastore_integration_test.go
@@ -76,6 +76,8 @@ var _ = Describe("Datastore Lifecycle", func() {
 
 	AfterEach(func() {
 		os.Remove(dataFilePath)
+		os.Remove(versionFilePath)
+		os.Remove(lockFilePath)
 	})
 
 	Context("when empty", func() {

--- a/src/code.cloudfoundry.org/silk-daemon-bootstrap/integration/integration_suite_test.go
+++ b/src/code.cloudfoundry.org/silk-daemon-bootstrap/integration/integration_suite_test.go
@@ -59,7 +59,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(err).NotTo(HaveOccurred())
 
 	fmt.Fprintf(GinkgoWriter, "building binary...")
-	paths.BoostrapBin, err = gexec.Build("code.cloudfoundry.org/silk-daemon-bootstrap")
+	paths.BoostrapBin, err = gexec.Build("code.cloudfoundry.org/silk-daemon-bootstrap", "-buildvcs=false")
 	fmt.Fprintf(GinkgoWriter, "done")
 	Expect(err).NotTo(HaveOccurred())
 

--- a/src/code.cloudfoundry.org/silk-daemon-shutdown/integration/integration_suite_test.go
+++ b/src/code.cloudfoundry.org/silk-daemon-shutdown/integration/integration_suite_test.go
@@ -29,7 +29,7 @@ func TestIntegration(t *testing.T) {
 var _ = SynchronizedBeforeSuite(func() []byte {
 	var err error
 	fmt.Fprintf(GinkgoWriter, "building binary...")
-	paths.TeardownBin, err = gexec.Build("code.cloudfoundry.org/silk-daemon-shutdown")
+	paths.TeardownBin, err = gexec.Build("code.cloudfoundry.org/silk-daemon-shutdown", "-buildvcs=false")
 	fmt.Fprintf(GinkgoWriter, "done")
 	Expect(err).NotTo(HaveOccurred())
 

--- a/src/code.cloudfoundry.org/silk-datastore-syncer/integration/integration_suite_test.go
+++ b/src/code.cloudfoundry.org/silk-datastore-syncer/integration/integration_suite_test.go
@@ -19,7 +19,7 @@ func TestIntegration(t *testing.T) {
 
 var _ = SynchronizedBeforeSuite(func() []byte {
 	fmt.Fprintf(GinkgoWriter, "building binary...")
-	binaryPath, err := gexec.Build("code.cloudfoundry.org/silk-datastore-syncer")
+	binaryPath, err := gexec.Build("code.cloudfoundry.org/silk-datastore-syncer", "-buildvcs=false")
 	fmt.Fprintf(GinkgoWriter, "done")
 	Expect(err).NotTo(HaveOccurred())
 	return []byte(binaryPath)

--- a/src/code.cloudfoundry.org/silk-datastore-syncer/integration/integration_suite_test.go
+++ b/src/code.cloudfoundry.org/silk-datastore-syncer/integration/integration_suite_test.go
@@ -1,0 +1,32 @@
+package integration_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+
+	"testing"
+)
+
+var binaryPath string
+
+func TestIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Silk Datastore Syncer Suite")
+}
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	fmt.Fprintf(GinkgoWriter, "building binary...")
+	binaryPath, err := gexec.Build("code.cloudfoundry.org/silk-datastore-syncer")
+	fmt.Fprintf(GinkgoWriter, "done")
+	Expect(err).NotTo(HaveOccurred())
+	return []byte(binaryPath)
+}, func(data []byte) {
+	binaryPath = string(data)
+})
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	gexec.CleanupBuildArtifacts()
+})

--- a/src/code.cloudfoundry.org/silk-datastore-syncer/integration/integration_test.go
+++ b/src/code.cloudfoundry.org/silk-datastore-syncer/integration/integration_test.go
@@ -1,0 +1,128 @@
+package integration_test
+
+import (
+	"net/http"
+	"os"
+	"os/exec"
+	"os/user"
+	"sync"
+
+	"code.cloudfoundry.org/filelock"
+	"code.cloudfoundry.org/lib/datastore"
+	"code.cloudfoundry.org/lib/serial"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("Datastore syncer", func() {
+	var (
+		silkFile     *os.File
+		silkLockFile *os.File
+		fakeGarden   *ghttp.Server
+		session      *gexec.Session
+		store        *datastore.Store
+	)
+
+	BeforeEach(func() {
+		var err error
+		silkFile, err = os.CreateTemp(GinkgoT().TempDir(), "silkfile")
+		Expect(err).ToNot(HaveOccurred())
+		u, err := user.Current()
+		Expect(err).ToNot(HaveOccurred())
+		groups, err := u.GroupIds()
+		Expect(err).ToNot(HaveOccurred())
+		group, err := user.LookupGroupId(groups[0])
+		Expect(err).ToNot(HaveOccurred())
+		store = &datastore.Store{
+			Serializer: &serial.Serial{},
+			Locker: &filelock.Locker{
+				FileLocker: filelock.NewLocker(silkFile.Name() + "_lock"),
+				Mutex:      new(sync.Mutex),
+			},
+			DataFilePath:    silkFile.Name(),
+			VersionFilePath: silkFile.Name() + "_version",
+			LockedFilePath:  silkFile.Name() + "_lock",
+			FileOwner:       u.Name,
+			FileGroup:       group.Name,
+			CacheMutex:      new(sync.RWMutex),
+		}
+
+		fakeGarden = ghttp.NewUnstartedServer()
+		fakeGarden.AllowUnhandledRequests = false
+		fakeGarden.RouteToHandler("GET", "/ping", ghttp.RespondWithJSONEncoded(http.StatusOK, struct{}{}))
+		fakeGarden.Start()
+
+		cmd := exec.Command(binaryPath, "-n", "1", "--gardenNetwork", "tcp", "--gardenAddr", fakeGarden.Addr(), "--silkFile", silkFile.Name(), "--silkFileOwner", u.Name, "--silkFileGroup", group.Name)
+		session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		session.Kill().Wait()
+		silkFile.Close()
+		silkLockFile.Close()
+		fakeGarden.Close()
+	})
+
+	It("updates the log config", func() {
+		err := store.Add("test", "127.0.0.1", map[string]interface{}{"log_config": `{"guid":"test","index":0,"source_name":"test","tags":{"test":"value"}}`})
+		Expect(err).ToNot(HaveOccurred())
+		containers := struct {
+			Handles []string
+		}{
+			Handles: []string{"test"},
+		}
+		properties := map[string]string{"log_config": `{"guid":"test","index":0,"source_name":"test","tags":{"test":"value2"}}`}
+		fakeGarden.RouteToHandler("GET", "/containers", ghttp.RespondWithJSONEncoded(http.StatusOK, containers))
+		fakeGarden.RouteToHandler("GET", "/containers/test/properties", ghttp.RespondWithJSONEncoded(http.StatusOK, properties))
+
+		Eventually(func() datastore.Container {
+			readContainers, err := store.ReadAll()
+			Expect(err).ToNot(HaveOccurred())
+			return readContainers["test"]
+		}, 10).Should(Equal(datastore.Container{
+			Handle:   "test",
+			IP:       "127.0.0.1",
+			Metadata: map[string]interface{}{"log_config": `{"guid":"test","index":0,"source_name":"test","tags":{"test":"value2"}}`},
+		}))
+	})
+	It("doesn't add new entries, or remove old entries in the log config", func() {
+		err := store.Add("test", "127.0.0.1", map[string]interface{}{"log_config": `{"guid":"test","index":0,"source_name":"test","tags":{"test":"value"}}`})
+		Expect(err).ToNot(HaveOccurred())
+		containers := struct {
+			Handles []string
+		}{
+			Handles: []string{"test-non-exist"},
+		}
+		properties := map[string]string{"log_config": `{"guid":"test-non-exist","index":0,"source_name":"test-non-exist","tags":{"test":"value"}}`}
+		fakeGarden.RouteToHandler("GET", "/containers", ghttp.RespondWithJSONEncoded(http.StatusOK, containers))
+		fakeGarden.RouteToHandler("GET", "/containers/test-non-exist/properties", ghttp.RespondWithJSONEncoded(http.StatusOK, properties))
+
+		Eventually(func() datastore.Container {
+			readContainers, err := store.ReadAll()
+			Expect(err).ToNot(HaveOccurred())
+			return readContainers["test"]
+		}, 10).Should(Equal(datastore.Container{
+			Handle:   "test",
+			IP:       "127.0.0.1",
+			Metadata: map[string]interface{}{"log_config": `{"guid":"test","index":0,"source_name":"test","tags":{"test":"value"}}`},
+		}))
+	})
+
+	It("doesn't crash when containers fails", func() {
+		fakeGarden.RouteToHandler("GET", "/containers", ghttp.RespondWithJSONEncoded(http.StatusNotFound, struct{}{}))
+		Consistently(session, 3).ShouldNot(gexec.Exit())
+	})
+	It("doesn't crash when container fails", func() {
+		containers := struct {
+			Handles []string
+		}{
+			Handles: []string{"test"},
+		}
+		fakeGarden.RouteToHandler("GET", "/containers", ghttp.RespondWithJSONEncoded(http.StatusOK, containers))
+		fakeGarden.RouteToHandler("GET", "/containers/test/properties", ghttp.RespondWithJSONEncoded(http.StatusNotFound, struct{}{}))
+		Consistently(session, 3).ShouldNot(gexec.Exit())
+	})
+})

--- a/src/code.cloudfoundry.org/silk-datastore-syncer/main.go
+++ b/src/code.cloudfoundry.org/silk-datastore-syncer/main.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	"code.cloudfoundry.org/executor"
+	"code.cloudfoundry.org/filelock"
+	"code.cloudfoundry.org/garden"
+	"code.cloudfoundry.org/garden/client"
+	"code.cloudfoundry.org/garden/client/connection"
+	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/lager/lagerflags"
+	"code.cloudfoundry.org/lib/common"
+	"code.cloudfoundry.org/lib/datastore"
+	"code.cloudfoundry.org/lib/serial"
+)
+
+var (
+	interval      *int
+	gardenNetwork *string
+	gardenAddr    *string
+	silkFile      *string
+	silkFileOwner *string
+	silkFileGroup *string
+	logLevel      *string
+)
+
+func init() {
+	interval = flag.Int("n", 30, "sync interval in seconds.")
+	gardenNetwork = flag.String("gardenNetwork", "", "garden network type.")
+	gardenAddr = flag.String("gardenAddr", "", "garden address.")
+	silkFile = flag.String("silkFile", "", "silk file.")
+	silkFileOwner = flag.String("silkFileOwner", "", "owner of silk file")
+	silkFileGroup = flag.String("silkFileGroup", "", "group owner of silk file")
+	logLevel = flag.String("logLevel", lager.INFO.String(), "log level")
+}
+
+func main() {
+	flag.Parse()
+	loggerConfig := common.GetLagerConfig()
+	loggerConfig.LogLevel = *logLevel
+	logger, _ := lagerflags.NewFromConfig(fmt.Sprintf("%s.%s", "cfnetworking", "silk-datastore-syncer"), loggerConfig)
+
+	logger.Info("properties", lager.Data{
+		"interval":      interval,
+		"gardenNetwork": gardenNetwork,
+		"gardenAddr":    gardenAddr,
+		"silkFile":      silkFile,
+		"silkFileOwner": *silkFileOwner,
+		"silkFileGroup": *silkFileGroup,
+	})
+
+	gardenClient := client.New(connection.New(*gardenNetwork, *gardenAddr))
+	WaitForGarden(gardenClient, logger)
+	store := makeDatastore()
+
+	duration := time.Duration(*interval) * time.Second
+	for {
+		time.Sleep(duration)
+		logger.Debug("Starting sync loop")
+
+		gardenContainers, err := gardenClient.Containers(nil)
+		if err != nil {
+			logger.Error("Garden: error retrieving containers:", err)
+			continue
+		}
+
+		storeContainers, err := store.ReadAll()
+		if err != nil {
+			logger.Error("Datastore: error retrieving containers from datastore:", err)
+			continue
+		}
+
+		for _, c := range gardenContainers {
+			desiredLogConfig, err := getGardenLogConfig(c)
+			if err != nil {
+				logger.Error("error getting garden log config", err)
+				continue
+			}
+			logger.Debug("Garden container", lager.Data{"log info": desiredLogConfig})
+
+			sc := storeContainers[c.Handle()]
+			actualLogConfig, err := getSilkLogConfig(sc)
+			if err != nil {
+				logger.Error("error getting silk log config", err)
+				continue
+			}
+			logger.Debug("Datastore container", lager.Data{"log info": actualLogConfig})
+
+			if reflect.DeepEqual(desiredLogConfig, actualLogConfig) {
+				logger.Debug("They are equal no action taken")
+				continue
+			}
+
+			logger.Debug("Datastore container reconciling with Garden container", lager.Data{"handle": sc.Handle})
+			b, err := json.Marshal(desiredLogConfig)
+			if err != nil {
+				logger.Error("Garden container error marshalling container log config", err, lager.Data{"handle": sc.Handle})
+				continue
+			}
+			sc.Metadata["log_config"] = string(b)
+			err = store.Add(sc.Handle, sc.IP, sc.Metadata)
+			if err != nil {
+				logger.Error("Error updating log config", err)
+			}
+		}
+	}
+}
+
+func WaitForGarden(gardenClient garden.Client, logger lager.Logger) {
+	for {
+		logger.Debug("Attempting to ping Garden")
+		err := gardenClient.Ping()
+		if err == nil {
+			break
+		}
+		switch err.(type) {
+		case nil:
+			break
+		case garden.UnrecoverableError:
+			logger.Fatal("Garden: unrecoverable", err)
+		default:
+			logger.Error("Garden: cannot connect", err)
+			time.Sleep(1 * time.Second)
+		}
+	}
+
+}
+func makeDatastore() *datastore.Store {
+	store := &datastore.Store{
+		Serializer: &serial.Serial{},
+		Locker: &filelock.Locker{
+			FileLocker: filelock.NewLocker(*silkFile + "_lock"),
+			Mutex:      new(sync.Mutex),
+		},
+		DataFilePath:    *silkFile,
+		VersionFilePath: *silkFile + "_version",
+		LockedFilePath:  *silkFile + "_lock",
+		FileOwner:       *silkFileOwner,
+		FileGroup:       *silkFileGroup,
+		CacheMutex:      new(sync.RWMutex),
+	}
+	return store
+}
+
+func getGardenLogConfig(c garden.Container) (executor.LogConfig, error) {
+	props, err := c.Properties()
+	if err != nil {
+		err = fmt.Errorf("Garden container: %s: error retrieving properties: %w", c.Handle(), err)
+		return executor.LogConfig{}, err
+	}
+	logConfigStr, ok := props["log_config"]
+	var desiredLogConfig executor.LogConfig
+	if ok {
+		err := json.Unmarshal([]byte(logConfigStr), &desiredLogConfig)
+		if err != nil {
+			err = fmt.Errorf("Garden container: %s unmarshalling container log config from datastore: %w", c.Handle(), err)
+			return executor.LogConfig{}, err
+		}
+	}
+	return desiredLogConfig, nil
+}
+
+func getSilkLogConfig(sc datastore.Container) (executor.LogConfig, error) {
+	var actualLogConfig executor.LogConfig
+	logConfigStr, ok := sc.Metadata["log_config"].(string)
+	if ok {
+		err := json.Unmarshal([]byte(logConfigStr), &actualLogConfig)
+		if err != nil {
+			err = fmt.Errorf("Datastore container: %s: error unmarshalling container log config from datastore: %w", sc.Handle, err)
+			return executor.LogConfig{}, err
+		}
+	}
+	return actualLogConfig, nil
+}

--- a/src/code.cloudfoundry.org/silk-datastore-syncer/main.go
+++ b/src/code.cloudfoundry.org/silk-datastore-syncer/main.go
@@ -104,7 +104,7 @@ func main() {
 				continue
 			}
 			sc.Metadata["log_config"] = string(b)
-			err = store.Add(sc.Handle, sc.IP, sc.Metadata)
+			err = store.Update(sc.Handle, sc.IP, sc.Metadata)
 			if err != nil {
 				logger.Error("Error updating log config", err)
 			}

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/client/client.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/client/client.go
@@ -1,0 +1,80 @@
+package client
+
+import (
+	"code.cloudfoundry.org/garden"
+	"code.cloudfoundry.org/garden/client/connection"
+)
+
+type Client interface {
+	garden.Client
+}
+
+type client struct {
+	connection connection.Connection
+}
+
+func New(connection connection.Connection) Client {
+	return &client{
+		connection: connection,
+	}
+}
+
+func (client *client) Ping() error {
+	return client.connection.Ping()
+}
+
+func (client *client) Capacity() (garden.Capacity, error) {
+	return client.connection.Capacity()
+}
+
+func (client *client) Create(spec garden.ContainerSpec) (garden.Container, error) {
+	handle, err := client.connection.Create(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return newContainer(handle, client.connection), nil
+}
+
+func (client *client) Containers(properties garden.Properties) ([]garden.Container, error) {
+	handles, err := client.connection.List(properties)
+	if err != nil {
+		return nil, err
+	}
+
+	containers := []garden.Container{}
+	for _, handle := range handles {
+		containers = append(containers, newContainer(handle, client.connection))
+	}
+
+	return containers, nil
+}
+
+func (client *client) Destroy(handle string) error {
+	err := client.connection.Destroy(handle)
+
+	return err
+}
+
+func (client *client) BulkInfo(handles []string) (map[string]garden.ContainerInfoEntry, error) {
+	return client.connection.BulkInfo(handles)
+}
+
+func (client *client) BulkMetrics(handles []string) (map[string]garden.ContainerMetricsEntry, error) {
+	return client.connection.BulkMetrics(handles)
+}
+
+func (client *client) Lookup(handle string) (garden.Container, error) {
+	handles, err := client.connection.List(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, h := range handles {
+		if h == handle {
+			return newContainer(handle, client.connection), nil
+		}
+	}
+
+	return nil, garden.ContainerNotFoundError{Handle: handle}
+}

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/client/connection/connection.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/client/connection/connection.go
@@ -1,0 +1,601 @@
+package connection
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	"code.cloudfoundry.org/garden"
+	"code.cloudfoundry.org/garden/routes"
+	"code.cloudfoundry.org/garden/transport"
+	"code.cloudfoundry.org/lager"
+	"github.com/tedsuo/rata"
+)
+
+var ErrDisconnected = errors.New("disconnected")
+var ErrInvalidMessage = errors.New("invalid message payload")
+
+//go:generate counterfeiter . Connection
+type Connection interface {
+	Ping() error
+
+	Capacity() (garden.Capacity, error)
+
+	Create(spec garden.ContainerSpec) (string, error)
+	List(properties garden.Properties) ([]string, error)
+
+	// Destroys the container with the given handle. If the container cannot be
+	// found, garden.ContainerNotFoundError is returned. If deletion fails for another
+	// reason, another error type is returned.
+	Destroy(handle string) error
+
+	Stop(handle string, kill bool) error
+
+	Info(handle string) (garden.ContainerInfo, error)
+	BulkInfo(handles []string) (map[string]garden.ContainerInfoEntry, error)
+	BulkMetrics(handles []string) (map[string]garden.ContainerMetricsEntry, error)
+
+	StreamIn(handle string, spec garden.StreamInSpec) error
+	StreamOut(handle string, spec garden.StreamOutSpec) (io.ReadCloser, error)
+
+	CurrentBandwidthLimits(handle string) (garden.BandwidthLimits, error)
+	CurrentCPULimits(handle string) (garden.CPULimits, error)
+	CurrentDiskLimits(handle string) (garden.DiskLimits, error)
+	CurrentMemoryLimits(handle string) (garden.MemoryLimits, error)
+
+	Run(handle string, spec garden.ProcessSpec, io garden.ProcessIO) (garden.Process, error)
+	Attach(handle string, processID string, io garden.ProcessIO) (garden.Process, error)
+
+	NetIn(handle string, hostPort, containerPort uint32) (uint32, uint32, error)
+	NetOut(handle string, rule garden.NetOutRule) error
+	BulkNetOut(handle string, rules []garden.NetOutRule) error
+
+	SetGraceTime(handle string, graceTime time.Duration) error
+
+	Properties(handle string) (garden.Properties, error)
+	Property(handle string, name string) (string, error)
+	SetProperty(handle string, name string, value string) error
+
+	Metrics(handle string) (garden.Metrics, error)
+	RemoveProperty(handle string, name string) error
+}
+
+//go:generate counterfeiter . HijackStreamer
+type HijackStreamer interface {
+	Stream(handler string, body io.Reader, params rata.Params, query url.Values, contentType string) (io.ReadCloser, error)
+	Hijack(handler string, body io.Reader, params rata.Params, query url.Values, contentType string) (net.Conn, *bufio.Reader, error)
+}
+
+type connection struct {
+	hijacker HijackStreamer
+	log      lager.Logger
+}
+
+type Error struct {
+	StatusCode int
+	Message    string
+}
+
+func (err Error) Error() string {
+	return err.Message
+}
+
+func New(network, address string) Connection {
+	return NewWithLogger(network, address, lager.NewLogger("garden-connection"))
+}
+
+func NewWithLogger(network, address string, logger lager.Logger) Connection {
+	hijacker := NewHijackStreamer(network, address)
+	return NewWithHijacker(hijacker, logger)
+}
+
+func NewWithDialerAndLogger(dialer DialerFunc, log lager.Logger) Connection {
+	hijacker := NewHijackStreamerWithDialer(dialer)
+	return NewWithHijacker(hijacker, log)
+}
+
+func NewWithHijacker(hijacker HijackStreamer, log lager.Logger) Connection {
+	return &connection{
+		hijacker: hijacker,
+		log:      log,
+	}
+}
+
+func (c *connection) Ping() error {
+	return c.do(routes.Ping, nil, &struct{}{}, nil, nil)
+}
+
+func (c *connection) Capacity() (garden.Capacity, error) {
+	capacity := garden.Capacity{}
+	err := c.do(routes.Capacity, nil, &capacity, nil, nil)
+	if err != nil {
+		return garden.Capacity{}, err
+	}
+
+	return capacity, nil
+}
+
+func (c *connection) Create(spec garden.ContainerSpec) (string, error) {
+	res := struct {
+		Handle string `json:"handle"`
+	}{}
+
+	err := c.do(routes.Create, spec, &res, nil, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return res.Handle, nil
+}
+
+func (c *connection) Stop(handle string, kill bool) error {
+	return c.do(
+		routes.Stop,
+		map[string]bool{
+			"kill": kill,
+		},
+		&struct{}{},
+		rata.Params{
+			"handle": handle,
+		},
+		nil,
+	)
+}
+
+func (c *connection) Destroy(handle string) error {
+	return c.do(
+		routes.Destroy,
+		nil,
+		&struct{}{},
+		rata.Params{
+			"handle": handle,
+		},
+		nil,
+	)
+}
+
+func (c *connection) Run(handle string, spec garden.ProcessSpec, processIO garden.ProcessIO) (garden.Process, error) {
+	reqBody := new(bytes.Buffer)
+
+	err := transport.WriteMessage(reqBody, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	hijackedConn, hijackedResponseReader, err := c.hijacker.Hijack(
+		routes.Run,
+		reqBody,
+		rata.Params{
+			"handle": handle,
+		},
+		nil,
+		"application/json",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.streamProcess(handle, processIO, hijackedConn, hijackedResponseReader)
+}
+
+func (c *connection) Attach(handle string, processID string, processIO garden.ProcessIO) (garden.Process, error) {
+	reqBody := new(bytes.Buffer)
+
+	hijackedConn, hijackedResponseReader, err := c.hijacker.Hijack(
+		routes.Attach,
+		reqBody,
+		rata.Params{
+			"handle": handle,
+			"pid":    processID,
+		},
+		nil,
+		"",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.streamProcess(handle, processIO, hijackedConn, hijackedResponseReader)
+}
+
+func (c *connection) streamProcess(handle string, processIO garden.ProcessIO, hijackedConn net.Conn, hijackedResponseReader *bufio.Reader) (garden.Process, error) {
+	decoder := json.NewDecoder(hijackedResponseReader)
+
+	payload := &transport.ProcessPayload{}
+	if err := decoder.Decode(payload); err != nil {
+		return nil, err
+	}
+
+	processPipeline := &processStream{
+		processID: payload.ProcessID,
+		conn:      hijackedConn,
+	}
+
+	hijack := func(streamType string) (net.Conn, io.Reader, error) {
+		params := rata.Params{
+			"handle":   handle,
+			"pid":      processPipeline.ProcessID(),
+			"streamid": payload.StreamID,
+		}
+
+		return c.hijacker.Hijack(
+			streamType,
+			nil,
+			params,
+			nil,
+			"application/json",
+		)
+	}
+
+	process := newProcess(payload.ProcessID, processPipeline)
+	streamHandler := newStreamHandler(c.log)
+	streamHandler.streamIn(processPipeline, processIO.Stdin)
+
+	var stdoutConn net.Conn
+	if processIO.Stdout != nil {
+		var (
+			stdout io.Reader
+			err    error
+		)
+		stdoutConn, stdout, err = hijack(routes.Stdout)
+		if err != nil {
+			werr := fmt.Errorf("connection: failed to hijack stream %s: %s", routes.Stdout, err)
+			process.exited(0, werr)
+			hijackedConn.Close()
+			return process, nil
+		}
+		streamHandler.streamOut(processIO.Stdout, stdout)
+	}
+
+	var stderrConn net.Conn
+	if processIO.Stderr != nil {
+		var (
+			stderr io.Reader
+			err    error
+		)
+		stderrConn, stderr, err = hijack(routes.Stderr)
+		if err != nil {
+			werr := fmt.Errorf("connection: failed to hijack stream %s: %s", routes.Stderr, err)
+			process.exited(0, werr)
+			hijackedConn.Close()
+			return process, nil
+		}
+		streamHandler.streamOut(processIO.Stderr, stderr)
+	}
+
+	go func() {
+		defer hijackedConn.Close()
+		if stdoutConn != nil {
+			defer stdoutConn.Close()
+		}
+		if stderrConn != nil {
+			defer stderrConn.Close()
+		}
+
+		exitCode, err := streamHandler.wait(decoder)
+		process.exited(exitCode, err)
+	}()
+
+	return process, nil
+}
+
+func (c *connection) NetIn(handle string, hostPort, containerPort uint32) (uint32, uint32, error) {
+	res := &transport.NetInResponse{}
+
+	err := c.do(
+		routes.NetIn,
+		&transport.NetInRequest{
+			Handle:        handle,
+			HostPort:      hostPort,
+			ContainerPort: containerPort,
+		},
+		res,
+		rata.Params{
+			"handle": handle,
+		},
+		nil,
+	)
+
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return res.HostPort, res.ContainerPort, nil
+}
+
+func (c *connection) BulkNetOut(handle string, rules []garden.NetOutRule) error {
+	return c.do(
+		routes.BulkNetOut,
+		rules,
+		&struct{}{},
+		rata.Params{
+			"handle": handle,
+		},
+		nil,
+	)
+}
+
+func (c *connection) NetOut(handle string, rule garden.NetOutRule) error {
+	return c.do(
+		routes.NetOut,
+		rule,
+		&struct{}{},
+		rata.Params{
+			"handle": handle,
+		},
+		nil,
+	)
+}
+
+func (c *connection) Property(handle string, name string) (string, error) {
+	var res struct {
+		Value string `json:"value"`
+	}
+
+	err := c.do(
+		routes.Property,
+		nil,
+		&res,
+		rata.Params{
+			"handle": handle,
+			"key":    name,
+		},
+		nil,
+	)
+
+	return res.Value, err
+}
+
+func (c *connection) SetProperty(handle string, name string, value string) error {
+	err := c.do(
+		routes.SetProperty,
+		map[string]string{
+			"value": value,
+		},
+		&struct{}{},
+		rata.Params{
+			"handle": handle,
+			"key":    name,
+		},
+		nil,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *connection) RemoveProperty(handle string, name string) error {
+	err := c.do(
+		routes.RemoveProperty,
+		nil,
+		&struct{}{},
+		rata.Params{
+			"handle": handle,
+			"key":    name,
+		},
+		nil,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *connection) CurrentBandwidthLimits(handle string) (garden.BandwidthLimits, error) {
+	res := garden.BandwidthLimits{}
+
+	err := c.do(
+		routes.CurrentBandwidthLimits,
+		nil,
+		&res,
+		rata.Params{
+			"handle": handle,
+		},
+		nil,
+	)
+
+	return res, err
+}
+
+func (c *connection) CurrentCPULimits(handle string) (garden.CPULimits, error) {
+	res := garden.CPULimits{}
+
+	err := c.do(
+		routes.CurrentCPULimits,
+		nil,
+		&res,
+		rata.Params{
+			"handle": handle,
+		},
+		nil,
+	)
+
+	return res, err
+}
+
+func (c *connection) CurrentDiskLimits(handle string) (garden.DiskLimits, error) {
+	res := garden.DiskLimits{}
+
+	err := c.do(
+		routes.CurrentDiskLimits,
+		nil,
+		&res,
+		rata.Params{
+			"handle": handle,
+		},
+		nil,
+	)
+
+	return res, err
+}
+
+func (c *connection) CurrentMemoryLimits(handle string) (garden.MemoryLimits, error) {
+	res := garden.MemoryLimits{}
+
+	err := c.do(
+		routes.CurrentMemoryLimits,
+		nil,
+		&res,
+		rata.Params{
+			"handle": handle,
+		},
+		nil,
+	)
+
+	return res, err
+}
+
+func (c *connection) StreamIn(handle string, spec garden.StreamInSpec) error {
+	body, err := c.hijacker.Stream(
+		routes.StreamIn,
+		spec.TarStream,
+		rata.Params{
+			"handle": handle,
+		},
+		url.Values{
+			"user":        []string{spec.User},
+			"destination": []string{spec.Path},
+		},
+		"application/x-tar",
+	)
+	if err != nil {
+		return err
+	}
+
+	return body.Close()
+}
+
+func (c *connection) StreamOut(handle string, spec garden.StreamOutSpec) (io.ReadCloser, error) {
+	return c.hijacker.Stream(
+		routes.StreamOut,
+		nil,
+		rata.Params{
+			"handle": handle,
+		},
+		url.Values{
+			"user":   []string{spec.User},
+			"source": []string{spec.Path},
+		},
+		"",
+	)
+}
+
+func (c *connection) List(filterProperties garden.Properties) ([]string, error) {
+	values := url.Values{}
+	for name, val := range filterProperties {
+		values[name] = []string{val}
+	}
+
+	res := &struct {
+		Handles []string
+	}{}
+
+	if err := c.do(
+		routes.List,
+		nil,
+		&res,
+		nil,
+		values,
+	); err != nil {
+		return nil, err
+	}
+
+	return res.Handles, nil
+}
+
+func (c *connection) SetGraceTime(handle string, graceTime time.Duration) error {
+	return c.do(routes.SetGraceTime, graceTime, &struct{}{}, rata.Params{"handle": handle}, nil)
+}
+
+func (c *connection) Properties(handle string) (garden.Properties, error) {
+	res := make(garden.Properties)
+	err := c.do(routes.Properties, nil, &res, rata.Params{"handle": handle}, nil)
+	return res, err
+}
+
+func (c *connection) Metrics(handle string) (garden.Metrics, error) {
+	res := garden.Metrics{}
+	err := c.do(routes.Metrics, nil, &res, rata.Params{"handle": handle}, nil)
+	return res, err
+}
+
+func (c *connection) Info(handle string) (garden.ContainerInfo, error) {
+	res := garden.ContainerInfo{}
+
+	err := c.do(routes.Info, nil, &res, rata.Params{"handle": handle}, nil)
+	if err != nil {
+		return garden.ContainerInfo{}, err
+	}
+
+	return res, nil
+}
+
+func (c *connection) BulkInfo(handles []string) (map[string]garden.ContainerInfoEntry, error) {
+	res := make(map[string]garden.ContainerInfoEntry)
+	queryParams := url.Values{
+		"handles": []string{strings.Join(handles, ",")},
+	}
+	err := c.do(routes.BulkInfo, nil, &res, nil, queryParams)
+	return res, err
+}
+
+func (c *connection) BulkMetrics(handles []string) (map[string]garden.ContainerMetricsEntry, error) {
+	res := make(map[string]garden.ContainerMetricsEntry)
+	queryParams := url.Values{
+		"handles": []string{strings.Join(handles, ",")},
+	}
+	err := c.do(routes.BulkMetrics, nil, &res, nil, queryParams)
+	return res, err
+}
+
+func (c *connection) do(
+	handler string,
+	req, res interface{},
+	params rata.Params,
+	query url.Values,
+) error {
+	var body io.Reader
+
+	if req != nil {
+		buf := new(bytes.Buffer)
+
+		err := transport.WriteMessage(buf, req)
+		if err != nil {
+			return err
+		}
+
+		body = buf
+	}
+
+	contentType := ""
+	if req != nil {
+		contentType = "application/json"
+	}
+
+	response, err := c.hijacker.Stream(
+		handler,
+		body,
+		params,
+		query,
+		contentType,
+	)
+	if err != nil {
+		return err
+	}
+
+	defer response.Close()
+
+	return json.NewDecoder(response).Decode(res)
+}

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/client/connection/connection_hijacker.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/client/connection/connection_hijacker.go
@@ -1,0 +1,127 @@
+package connection
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+
+	"code.cloudfoundry.org/garden"
+	"code.cloudfoundry.org/garden/routes"
+	"github.com/tedsuo/rata"
+)
+
+type DialerFunc func(network, address string) (net.Conn, error)
+
+type hijackable struct {
+	req               *rata.RequestGenerator
+	noKeepaliveClient *http.Client
+	dialer            DialerFunc
+}
+
+func NewHijackStreamer(network, address string) HijackStreamer {
+	return NewHijackStreamerWithDialer(func(string, string) (net.Conn, error) {
+		return net.DialTimeout(network, address, 2*time.Second)
+	})
+}
+
+func NewHijackStreamerWithDialer(dialFunc DialerFunc) HijackStreamer {
+	return &hijackable{
+		req:    rata.NewRequestGenerator("http://api", routes.Routes),
+		dialer: dialFunc,
+		noKeepaliveClient: &http.Client{
+			Transport: &http.Transport{
+				Dial:              dialFunc,
+				DisableKeepAlives: true,
+			},
+		},
+	}
+}
+
+func (h *hijackable) Hijack(handler string, body io.Reader, params rata.Params, query url.Values, contentType string) (net.Conn, *bufio.Reader, error) {
+	request, err := h.req.CreateRequest(handler, params, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if contentType != "" {
+		request.Header.Set("Content-Type", contentType)
+	}
+
+	if query != nil {
+		request.URL.RawQuery = query.Encode()
+	}
+
+	conn, err := h.dialer("tcp", "api") // net/addr don't matter here
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client := httputil.NewClientConn(conn, nil)
+
+	httpResp, err := client.Do(request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode > 299 {
+		defer httpResp.Body.Close()
+
+		errRespBytes, err := ioutil.ReadAll(httpResp.Body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Backend error: Exit status: %d, Body: %s, error reading response body: %s", httpResp.StatusCode, string(errRespBytes), err)
+		}
+
+		var result garden.Error
+		err = json.Unmarshal(errRespBytes, &result)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Backend error: Exit status: %d, Body: %s, error reading response body: %s", httpResp.StatusCode, string(errRespBytes), err)
+		}
+
+		return nil, nil, result.Err
+	}
+
+	hijackedConn, hijackedResponseReader := client.Hijack()
+
+	return hijackedConn, hijackedResponseReader, nil
+}
+
+func (c *hijackable) Stream(handler string, body io.Reader, params rata.Params, query url.Values, contentType string) (io.ReadCloser, error) {
+	request, err := c.req.CreateRequest(handler, params, body)
+	if err != nil {
+		return nil, err
+	}
+
+	if contentType != "" {
+		request.Header.Set("Content-Type", contentType)
+	}
+
+	if query != nil {
+		request.URL.RawQuery = query.Encode()
+	}
+
+	httpResp, err := c.noKeepaliveClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode > 299 {
+		defer httpResp.Body.Close()
+
+		var result garden.Error
+		err := json.NewDecoder(httpResp.Body).Decode(&result)
+		if err != nil {
+			return nil, fmt.Errorf("bad response: %s", err)
+		}
+
+		return nil, result.Err
+	}
+
+	return httpResp.Body, nil
+}

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/client/connection/process.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/client/connection/process.go
@@ -1,0 +1,59 @@
+package connection
+
+import (
+	"sync"
+
+	"code.cloudfoundry.org/garden"
+)
+
+type process struct {
+	id string
+
+	processInputStream *processStream
+	done               bool
+	exitStatus         int
+	exitErr            error
+	doneL              *sync.Cond
+}
+
+func newProcess(id string, processInputStream *processStream) *process {
+	return &process{
+		id:                 id,
+		processInputStream: processInputStream,
+		doneL:              sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+func (p *process) ID() string {
+	return p.id
+}
+
+func (p *process) Wait() (int, error) {
+	p.doneL.L.Lock()
+
+	for !p.done {
+		p.doneL.Wait()
+	}
+
+	defer p.doneL.L.Unlock()
+
+	return p.exitStatus, p.exitErr
+}
+
+func (p *process) SetTTY(tty garden.TTYSpec) error {
+	return p.processInputStream.SetTTY(tty)
+}
+
+func (p *process) Signal(signal garden.Signal) error {
+	return p.processInputStream.Signal(signal)
+}
+
+func (p *process) exited(exitStatus int, err error) {
+	p.doneL.L.Lock()
+	p.exitStatus = exitStatus
+	p.exitErr = err
+	p.done = true
+	p.doneL.L.Unlock()
+
+	p.doneL.Broadcast()
+}

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/client/connection/process_stream.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/client/connection/process_stream.go
@@ -1,0 +1,66 @@
+package connection
+
+import (
+	"net"
+	"sync"
+
+	"code.cloudfoundry.org/garden"
+	"code.cloudfoundry.org/garden/transport"
+)
+
+type processStream struct {
+	processID string
+	conn      net.Conn
+
+	sync.Mutex
+}
+
+func (s *processStream) Write(data []byte) (int, error) {
+	d := string(data)
+	stdin := transport.Stdin
+	return len(data), s.sendPayload(transport.ProcessPayload{
+		ProcessID: s.processID,
+		Source:    &stdin,
+		Data:      &d,
+	})
+}
+
+func (s *processStream) Close() error {
+	stdin := transport.Stdin
+	return s.sendPayload(transport.ProcessPayload{
+		ProcessID: s.processID,
+		Source:    &stdin,
+	})
+}
+
+func (s *processStream) SetTTY(spec garden.TTYSpec) error {
+	return s.sendPayload(&transport.ProcessPayload{
+		ProcessID: s.processID,
+		TTY:       &spec,
+	})
+}
+
+func (s *processStream) Signal(signal garden.Signal) error {
+	return s.sendPayload(&transport.ProcessPayload{
+		ProcessID: s.processID,
+		Signal:    &signal,
+	})
+}
+
+func (s *processStream) sendPayload(payload interface{}) error {
+	s.Lock()
+
+	err := transport.WriteMessage(s.conn, payload)
+	if err != nil {
+		s.Unlock()
+		return err
+	}
+
+	s.Unlock()
+
+	return nil
+}
+
+func (s *processStream) ProcessID() string {
+	return s.processID
+}

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/client/connection/stream_handler.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/client/connection/stream_handler.go
@@ -1,0 +1,72 @@
+package connection
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+
+	"code.cloudfoundry.org/garden/transport"
+	"code.cloudfoundry.org/lager"
+)
+
+type hijackFunc func(streamType string) (net.Conn, io.Reader, error)
+
+type streamHandler struct {
+	log lager.Logger
+	wg  *sync.WaitGroup
+}
+
+func newStreamHandler(log lager.Logger) *streamHandler {
+	return &streamHandler{
+		log: log,
+		wg:  new(sync.WaitGroup),
+	}
+}
+
+func (sh *streamHandler) streamIn(processWriter io.WriteCloser, stdin io.Reader) {
+	if stdin == nil {
+		return
+	}
+
+	go func(processInputStream io.WriteCloser, stdin io.Reader, log lager.Logger) {
+		if _, err := io.Copy(processInputStream, stdin); err == nil {
+			processInputStream.Close()
+		} else {
+			log.Error("streaming-stdin-payload", err)
+		}
+	}(processWriter, stdin, sh.log)
+}
+
+func (sh *streamHandler) streamOut(streamWriter io.Writer, streamReader io.Reader) {
+	sh.wg.Add(1)
+	go func() {
+		io.Copy(streamWriter, streamReader)
+		sh.wg.Done()
+	}()
+}
+
+func (sh *streamHandler) wait(decoder *json.Decoder) (int, error) {
+	for {
+		payload := &transport.ProcessPayload{}
+		err := decoder.Decode(payload)
+		if err != nil {
+			sh.wg.Wait()
+			return 0, fmt.Errorf("connection: decode failed: %s", err)
+		}
+
+		if payload.Error != nil {
+			sh.wg.Wait()
+			return 0, fmt.Errorf("connection: process error: %s", *payload.Error)
+		}
+
+		if payload.ExitStatus != nil {
+			sh.wg.Wait()
+			status := int(*payload.ExitStatus)
+			return status, nil
+		}
+
+		// discard other payloads
+	}
+}

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/client/container.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/client/container.go
@@ -1,0 +1,103 @@
+package client
+
+import (
+	"io"
+	"time"
+
+	"code.cloudfoundry.org/garden"
+	"code.cloudfoundry.org/garden/client/connection"
+)
+
+type container struct {
+	handle string
+
+	connection connection.Connection
+}
+
+func newContainer(handle string, connection connection.Connection) garden.Container {
+	return &container{
+		handle: handle,
+
+		connection: connection,
+	}
+}
+
+func (container *container) Handle() string {
+	return container.handle
+}
+
+func (container *container) Stop(kill bool) error {
+	return container.connection.Stop(container.handle, kill)
+}
+
+func (container *container) Info() (garden.ContainerInfo, error) {
+	return container.connection.Info(container.handle)
+}
+
+func (container *container) StreamIn(spec garden.StreamInSpec) error {
+	return container.connection.StreamIn(container.handle, spec)
+}
+
+func (container *container) StreamOut(spec garden.StreamOutSpec) (io.ReadCloser, error) {
+	return container.connection.StreamOut(container.handle, spec)
+}
+
+func (container *container) CurrentBandwidthLimits() (garden.BandwidthLimits, error) {
+	return container.connection.CurrentBandwidthLimits(container.handle)
+}
+
+func (container *container) CurrentCPULimits() (garden.CPULimits, error) {
+	return container.connection.CurrentCPULimits(container.handle)
+}
+
+func (container *container) CurrentDiskLimits() (garden.DiskLimits, error) {
+	return container.connection.CurrentDiskLimits(container.handle)
+}
+
+func (container *container) CurrentMemoryLimits() (garden.MemoryLimits, error) {
+	return container.connection.CurrentMemoryLimits(container.handle)
+}
+
+func (container *container) Run(spec garden.ProcessSpec, io garden.ProcessIO) (garden.Process, error) {
+	return container.connection.Run(container.handle, spec, io)
+}
+
+func (container *container) Attach(processID string, io garden.ProcessIO) (garden.Process, error) {
+	return container.connection.Attach(container.handle, processID, io)
+}
+
+func (container *container) NetIn(hostPort, containerPort uint32) (uint32, uint32, error) {
+	return container.connection.NetIn(container.handle, hostPort, containerPort)
+}
+
+func (container *container) NetOut(netOutRule garden.NetOutRule) error {
+	return container.connection.NetOut(container.handle, netOutRule)
+}
+
+func (container *container) BulkNetOut(netOutRules []garden.NetOutRule) error {
+	return container.connection.BulkNetOut(container.handle, netOutRules)
+}
+
+func (container *container) Metrics() (garden.Metrics, error) {
+	return container.connection.Metrics(container.handle)
+}
+
+func (container *container) SetGraceTime(graceTime time.Duration) error {
+	return container.connection.SetGraceTime(container.handle, graceTime)
+}
+
+func (container *container) Properties() (garden.Properties, error) {
+	return container.connection.Properties(container.handle)
+}
+
+func (container *container) Property(name string) (string, error) {
+	return container.connection.Property(container.handle, name)
+}
+
+func (container *container) SetProperty(name string, value string) error {
+	return container.connection.SetProperty(container.handle, name, value)
+}
+
+func (container *container) RemoveProperty(name string) error {
+	return container.connection.RemoveProperty(container.handle, name)
+}

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/routes/routes.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/routes/routes.go
@@ -1,0 +1,86 @@
+package routes
+
+import "github.com/tedsuo/rata"
+
+const (
+	Ping     = "Ping"
+	Capacity = "Capacity"
+
+	List        = "List"
+	Create      = "Create"
+	Info        = "Info"
+	BulkInfo    = "BulkInfo"
+	BulkMetrics = "BulkMetrics"
+	Destroy     = "Destroy"
+
+	Stop = "Stop"
+
+	StreamIn  = "StreamIn"
+	StreamOut = "StreamOut"
+
+	Stdout = "Stdout"
+	Stderr = "Stderr"
+
+	CurrentBandwidthLimits = "CurrentBandwidthLimits"
+	CurrentCPULimits       = "CurrentCPULimits"
+	CurrentDiskLimits      = "CurrentDiskLimits"
+	CurrentMemoryLimits    = "CurrentMemoryLimits"
+
+	NetIn      = "NetIn"
+	NetOut     = "NetOut"
+	BulkNetOut = "BulkNetOut"
+
+	Run    = "Run"
+	Attach = "Attach"
+
+	SetGraceTime = "SetGraceTime"
+
+	Properties  = "Properties"
+	Property    = "Property"
+	SetProperty = "SetProperty"
+
+	Metrics = "Metrics"
+
+	RemoveProperty = "RemoveProperty"
+)
+
+var Routes = rata.Routes{
+	{Path: "/ping", Method: "GET", Name: Ping},
+	{Path: "/capacity", Method: "GET", Name: Capacity},
+
+	{Path: "/containers", Method: "GET", Name: List},
+	{Path: "/containers", Method: "POST", Name: Create},
+
+	{Path: "/containers/:handle/info", Method: "GET", Name: Info},
+	{Path: "/containers/bulk_info", Method: "GET", Name: BulkInfo},
+	{Path: "/containers/bulk_metrics", Method: "GET", Name: BulkMetrics},
+
+	{Path: "/containers/:handle", Method: "DELETE", Name: Destroy},
+	{Path: "/containers/:handle/stop", Method: "PUT", Name: Stop},
+
+	{Path: "/containers/:handle/files", Method: "PUT", Name: StreamIn},
+	{Path: "/containers/:handle/files", Method: "GET", Name: StreamOut},
+
+	{Path: "/containers/:handle/limits/bandwidth", Method: "GET", Name: CurrentBandwidthLimits},
+	{Path: "/containers/:handle/limits/cpu", Method: "GET", Name: CurrentCPULimits},
+	{Path: "/containers/:handle/limits/disk", Method: "GET", Name: CurrentDiskLimits},
+	{Path: "/containers/:handle/limits/memory", Method: "GET", Name: CurrentMemoryLimits},
+
+	{Path: "/containers/:handle/net/in", Method: "POST", Name: NetIn},
+	{Path: "/containers/:handle/net/out", Method: "POST", Name: NetOut},
+	{Path: "/containers/:handle/net/out/bulk", Method: "POST", Name: BulkNetOut},
+
+	{Path: "/containers/:handle/processes/:pid/attaches/:streamid/stdout", Method: "GET", Name: Stdout},
+	{Path: "/containers/:handle/processes/:pid/attaches/:streamid/stderr", Method: "GET", Name: Stderr},
+	{Path: "/containers/:handle/processes", Method: "POST", Name: Run},
+	{Path: "/containers/:handle/processes/:pid", Method: "GET", Name: Attach},
+
+	{Path: "/containers/:handle/grace_time", Method: "PUT", Name: SetGraceTime},
+
+	{Path: "/containers/:handle/properties", Method: "GET", Name: Properties},
+	{Path: "/containers/:handle/properties/:key", Method: "GET", Name: Property},
+	{Path: "/containers/:handle/properties/:key", Method: "PUT", Name: SetProperty},
+	{Path: "/containers/:handle/properties/:key", Method: "DELETE", Name: RemoveProperty},
+
+	{Path: "/containers/:handle/metrics", Method: "GET", Name: Metrics},
+}

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/transport/message_writer.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/transport/message_writer.go
@@ -1,0 +1,10 @@
+package transport
+
+import (
+	"encoding/json"
+	"io"
+)
+
+func WriteMessage(writer io.Writer, req interface{}) error {
+	return json.NewEncoder(writer).Encode(req)
+}

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/transport/payload.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/garden/transport/payload.go
@@ -1,0 +1,33 @@
+package transport
+
+import "code.cloudfoundry.org/garden"
+
+type Source int
+
+const (
+	Stdin Source = iota
+	Stdout
+	Stderr
+)
+
+type ProcessPayload struct {
+	ProcessID  string          `json:"process_id,omitempty"`
+	StreamID   string          `json:"stream_id,omitempty"`
+	Source     *Source         `json:"source,omitempty"`
+	Data       *string         `json:"data,omitempty"`
+	ExitStatus *int            `json:"exit_status,omitempty"`
+	Error      *string         `json:"error,omitempty"`
+	TTY        *garden.TTYSpec `json:"tty,omitempty"`
+	Signal     *garden.Signal  `json:"signal,omitempty"`
+}
+
+type NetInRequest struct {
+	Handle        string `json:"handle,omitempty"`
+	HostPort      uint32 `json:"host_port,omitempty"`
+	ContainerPort uint32 `json:"container_port,omitempty"`
+}
+
+type NetInResponse struct {
+	HostPort      uint32 `json:"host_port,omitempty"`
+	ContainerPort uint32 `json:"container_port,omitempty"`
+}

--- a/src/code.cloudfoundry.org/vendor/modules.txt
+++ b/src/code.cloudfoundry.org/vendor/modules.txt
@@ -37,6 +37,10 @@ code.cloudfoundry.org/filelock
 # code.cloudfoundry.org/garden v0.0.0-20210608104724-fa3a10d59c82
 ## explicit; go 1.16
 code.cloudfoundry.org/garden
+code.cloudfoundry.org/garden/client
+code.cloudfoundry.org/garden/client/connection
+code.cloudfoundry.org/garden/routes
+code.cloudfoundry.org/garden/transport
 # code.cloudfoundry.org/go-diodes v0.0.0-20190809170250-f77fb823c7ee
 ## explicit
 code.cloudfoundry.org/go-diodes

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/integration/linux/linux_suite_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/integration/linux/linux_suite_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package linux_test
@@ -93,7 +94,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(err).NotTo(HaveOccurred())
 
 	fmt.Fprintf(GinkgoWriter, "building binary...")
-	paths.VxlanPolicyAgentPath, err = gexec.Build("code.cloudfoundry.org/vxlan-policy-agent/cmd/vxlan-policy-agent", "-race")
+	paths.VxlanPolicyAgentPath, err = gexec.Build("code.cloudfoundry.org/vxlan-policy-agent/cmd/vxlan-policy-agent", "-race", "-buildvcs=false")
 	fmt.Fprintf(GinkgoWriter, "done")
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Updates silk datastore so that silk will refelect app renames correctly. 