### PR TITLE
Tests for docker_test were failing with VCS issues

### DIFF
--- a/src/code.cloudfoundry.org/cni-teardown/integration/integration_suite_test.go
+++ b/src/code.cloudfoundry.org/cni-teardown/integration/integration_suite_test.go
@@ -32,7 +32,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	var err error
 
 	fmt.Fprintf(GinkgoWriter, "building binary...")
-	paths.TeardownBin, err = gexec.Build("code.cloudfoundry.org/cni-teardown")
+	paths.TeardownBin, err = gexec.Build("code.cloudfoundry.org/cni-teardown", "-buildvcs=false")
 	fmt.Fprintf(GinkgoWriter, "done")
 	Expect(err).NotTo(HaveOccurred())
 

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_suite_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_suite_test.go
@@ -35,7 +35,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(os.Chown(noopBin, 65534, 65534)).To(Succeed())
 	noopDir, _ := filepath.Split(noopBin)
 
-	pathToPlugin, err := gexec.Build(packagePath)
+	pathToPlugin, err := gexec.Build(packagePath, "-buildvcs=false")
 	Expect(err).NotTo(HaveOccurred())
 	Expect(os.Chown(pathToPlugin, 65534, 65534)).To(Succeed())
 	wrapperDir, _ := filepath.Split(pathToPlugin)

--- a/src/code.cloudfoundry.org/iptables-logger/integration/integration_suite_test.go
+++ b/src/code.cloudfoundry.org/iptables-logger/integration/integration_suite_test.go
@@ -27,7 +27,7 @@ func TestIntegration(t *testing.T) {
 var _ = SynchronizedBeforeSuite(func() []byte {
 	fmt.Fprintf(GinkgoWriter, "building binary...")
 	var err error
-	binaryPath, err = gexec.Build("code.cloudfoundry.org/iptables-logger/cmd/iptables-logger", "-race")
+	binaryPath, err = gexec.Build("code.cloudfoundry.org/iptables-logger/cmd/iptables-logger", "-race", "-buildvcs=false")
 	fmt.Fprintf(GinkgoWriter, "done")
 	Expect(err).NotTo(HaveOccurred())
 

--- a/src/code.cloudfoundry.org/silk-daemon-bootstrap/integration/integration_suite_test.go
+++ b/src/code.cloudfoundry.org/silk-daemon-bootstrap/integration/integration_suite_test.go
@@ -59,7 +59,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(err).NotTo(HaveOccurred())
 
 	fmt.Fprintf(GinkgoWriter, "building binary...")
-	paths.BoostrapBin, err = gexec.Build("code.cloudfoundry.org/silk-daemon-bootstrap")
+	paths.BoostrapBin, err = gexec.Build("code.cloudfoundry.org/silk-daemon-bootstrap", "-buildvcs=false")
 	fmt.Fprintf(GinkgoWriter, "done")
 	Expect(err).NotTo(HaveOccurred())
 

--- a/src/code.cloudfoundry.org/silk-daemon-shutdown/integration/integration_suite_test.go
+++ b/src/code.cloudfoundry.org/silk-daemon-shutdown/integration/integration_suite_test.go
@@ -29,7 +29,7 @@ func TestIntegration(t *testing.T) {
 var _ = SynchronizedBeforeSuite(func() []byte {
 	var err error
 	fmt.Fprintf(GinkgoWriter, "building binary...")
-	paths.TeardownBin, err = gexec.Build("code.cloudfoundry.org/silk-daemon-shutdown")
+	paths.TeardownBin, err = gexec.Build("code.cloudfoundry.org/silk-daemon-shutdown", "-buildvcs=false")
 	fmt.Fprintf(GinkgoWriter, "done")
 	Expect(err).NotTo(HaveOccurred())
 

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/integration/linux/linux_suite_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/integration/linux/linux_suite_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package linux_test
@@ -93,7 +94,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(err).NotTo(HaveOccurred())
 
 	fmt.Fprintf(GinkgoWriter, "building binary...")
-	paths.VxlanPolicyAgentPath, err = gexec.Build("code.cloudfoundry.org/vxlan-policy-agent/cmd/vxlan-policy-agent", "-race")
+	paths.VxlanPolicyAgentPath, err = gexec.Build("code.cloudfoundry.org/vxlan-policy-agent/cmd/vxlan-policy-agent", "-race", "-buildvcs=false")
 	fmt.Fprintf(GinkgoWriter, "done")
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
added `-buildvcs=false` in the tests to circumvent the VCS's issues that get invoked with ginkgo's `gexec.Build` command