### PR TITLE
Run integration tests with 1 node

### DIFF
--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/bin/test.bash
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/bin/test.bash
@@ -8,4 +8,4 @@ set -o pipefail
 args=${@} 
 go run github.com/onsi/ginkgo/v2/ginkgo  --skip-package integration $args
 # run in serial
-go run github.com/onsi/ginkgo/v2/ginkgo $(echo $args | sed 's/-p //g') ./integration
+go run github.com/onsi/ginkgo/v2/ginkgo $args --nodes=1 ./integration

--- a/src/code.cloudfoundry.org/silk-daemon-bootstrap/bin/test.bash
+++ b/src/code.cloudfoundry.org/silk-daemon-bootstrap/bin/test.bash
@@ -8,4 +8,4 @@ set -o pipefail
 args=${@} 
 go run github.com/onsi/ginkgo/v2/ginkgo  --skip-package integration $args
 # run in serial
-go run github.com/onsi/ginkgo/v2/ginkgo $(echo $args | sed 's/-p //g') ./integration
+go run github.com/onsi/ginkgo/v2/ginkgo $args --nodes=1 ./integration

--- a/src/code.cloudfoundry.org/silk-daemon-shutdown/bin/test.bash
+++ b/src/code.cloudfoundry.org/silk-daemon-shutdown/bin/test.bash
@@ -7,4 +7,4 @@ set -o pipefail
 # Double-quoting array expansion here causes ginkgo to fail
 args=${@} 
 # run in serial
-go run github.com/onsi/ginkgo/v2/ginkgo $(echo $args | sed 's/-p //g') ./integration
+go run github.com/onsi/ginkgo/v2/ginkgo $args --nodes=1 ./integration

--- a/src/code.cloudfoundry.org/silk/bin/test.bash
+++ b/src/code.cloudfoundry.org/silk/bin/test.bash
@@ -9,4 +9,4 @@ configure_db "${DB}"
 args=${@} 
 go run github.com/onsi/ginkgo/v2/ginkgo  --skip-package cni $args
 # run in serial
-go run github.com/onsi/ginkgo/v2/ginkgo $(echo $args | sed 's/-p //g') ./cni
+go run github.com/onsi/ginkgo/v2/ginkgo $args --nodes=1 ./cni

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/bin/test.bash
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/bin/test.bash
@@ -8,4 +8,4 @@ set -o pipefail
 args=${@} 
 go run github.com/onsi/ginkgo/v2/ginkgo  --skip-package integration $args
 # run in serial
-go run github.com/onsi/ginkgo/v2/ginkgo $(echo $args | sed 's/-p //g') ./integration
+go run github.com/onsi/ginkgo/v2/ginkgo $args --nodes=1 ./integration


### PR DESCRIPTION
Arguments were changed from `-p` to `--nodes=7` and that broke the sed command. So instead specify `--nodes=1` to run integration test serially.