### PR TITLE
silk-datastore-syncer: fix assignment to entry in nil map in Metadata field

### DIFF
--- a/src/code.cloudfoundry.org/silk-datastore-syncer/main.go
+++ b/src/code.cloudfoundry.org/silk-datastore-syncer/main.go
@@ -108,6 +108,9 @@ func main() {
 				logger.Error("Garden container error marshalling container log config", err, lager.Data{"handle": sc.Handle})
 				continue
 			}
+			if sc.Metadata == nil {
+				sc.Metadata = make(map[string]interface{})
+			}
 			sc.Metadata["log_config"] = string(b)
 			err = store.Update(sc.Handle, sc.IP, sc.Metadata)
 			if err != nil {


### PR DESCRIPTION
Trying to fix panic `assignment to entry in nil map` in `silk-datastore-syncer` code.

When unmarshalling container infos in corresponding struct `datastore.Container`, `Metadata` map isn't always instantiated, resulting in a panic error when `silk-datastore-syncer` tries to store a `log_config` entry into it.

The panic encountered using v3.30.0 (same on v3.39.0) :
```
panic: assignment to entry in nil map

goroutine 1 [running]:
main.main()
/var/vcap/data/compile/silk-datastore-syncer/src/code.cloudfoundry.org/silk-datastore-syncer/main.go:106 +0xf52
```