### PR TITLE
Support comma-delimited IP adresses

### DIFF
--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/security_group_rule.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/security_group_rule.go
@@ -90,7 +90,6 @@ func (r *securityGroupRule) ICMPInfo() *ICMPInfo {
 }
 
 func toIPRange(dest string) (IPRange, error) {
-	dest = strings.TrimSpace(dest)
 	idx := strings.IndexAny(dest, "-/")
 
 	// Not a range or a CIDR

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/security_group_rule_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/security_group_rule_test.go
@@ -81,7 +81,7 @@ var _ = Describe("SecurityGroupRule", func() {
 
 			It("parses all three possible destinations together: address, cidr, and range", func() {
 				securityGroupRule := policy_client.SecurityGroupRule{
-					Destination: "1.1.1.1, 192.168.0.0/24, 10.0.0.1-10.0.1.10",
+					Destination: "1.1.1.1,192.168.0.0/24,10.0.0.1-10.0.1.10",
 				}
 				rule, err := netrules.NewRuleFromSecurityGroupRule(securityGroupRule)
 				Expect(err).NotTo(HaveOccurred())
@@ -94,7 +94,7 @@ var _ = Describe("SecurityGroupRule", func() {
 
 			It("raises an error when one of the destinations is invalid", func() {
 				securityGroupRule := policy_client.SecurityGroupRule{
-					Destination: "1.1.1.1, 192.168.0.0/24, 10.0.0.1-123",
+					Destination: "1.1.1.1,192.168.0.0/24,10.0.0.1-123",
 				}
 				_, err := netrules.NewRuleFromSecurityGroupRule(securityGroupRule)
 				Expect(err).To(HaveOccurred())


### PR DESCRIPTION
When a user of CF defines an ASG, it is usually of the form:
```
[
  {
    "protocol": "tcp",
    "destination": "10.0.10.0/24",
    "ports": "80,443",
    "log": true,
    "description": "Allow http and https traffic to ZoneA"
  },
 {
    "protocol": "tcp",
    "destination": "10.0.20.0/24",
    "ports": "80,443",
    "log": true,
    "description": "Allow http and https traffic to ZoneB"
  }
]
```

This commit will allow users to define the `destinations` with comma-delimited lists, allowing the previous ASG to be condensed to:

```
[
  {
    "protocol": "tcp",
    "destination": "10.0.10.0/24,10.0.20.0/24", 👈 🥳
    "ports": "80,443",
    "log": true,
    "description": "Allow http and https traffic to ZoneA and ZoneB"
  }
]
```


[#186770285](https://www.pivotaltracker.com/story/show/186770285)

Signed-off-by: Josh Russett <josh.russett@broadcom.com>
