### PR TITLE
Remove deprecated net.Error.Temporary() usage

### DIFF
--- a/src/code.cloudfoundry.org/silk-daemon-shutdown/main.go
+++ b/src/code.cloudfoundry.org/silk-daemon-shutdown/main.go
@@ -192,10 +192,6 @@ func checkIfServerUp(serverName string, url string) bool {
 				return true
 
 			}
-			if netErr.Temporary() {
-				logger.Debug("pinging server returned temporary error. trying again.")
-				return true
-			}
 		}
 	} else {
 		defer response.Body.Close()


### PR DESCRIPTION
Per the docs it should not be relied on, and mostly returns timeout errors, and the other ones were unexpected, which we are already checking.

https://github.com/golang/go/issues/45729