### PR TITLE
Fix executor go module upgrade

### DIFF
--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -8,6 +8,12 @@ replace code.cloudfoundry.org/runtimeschema => code.cloudfoundry.org/runtimesche
 
 replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 
+// Prevents `go get -u ./...` from trying to get a branch of executor that we
+// tried to make an independent module (adding it's own go mod)`
+//   Generated from story https://www.pivotaltracker.com/story/show/184869807
+// i.e. we need executor to float on main (v0.0.0-...)
+exclude code.cloudfoundry.org/executor v0.1442.0
+
 require (
 	code.cloudfoundry.org/cf-networking-helpers v0.0.0-20240216144931-b667c0bc980a
 	code.cloudfoundry.org/debugserver v0.0.0-20240216143506-a6177cebb9a9


### PR DESCRIPTION
- Forces the go mod to float on the main branch of exectuor instead of trying to use the one published tag (v0.1442.0) that exists because of an explore that we did in this story: https://www.pivotaltracker.com/story/show/184869807

Should resolve issue:
```
go: code.cloudfoundry.org/executor@v0.1442.0 requires go >= 1.22.0 (running go 1.21.8)
```