### PR TITLE
Use absolute path for iptables.lock file in pre-start script

### DIFF
--- a/jobs/vxlan-policy-agent/templates/pre-start.erb
+++ b/jobs/vxlan-policy-agent/templates/pre-start.erb
@@ -4,5 +4,5 @@
 export PATH="<%= link("iptables").p("garden.iptables_bin_dir") %>:$PATH"
 
 # Completely cleanup IPTables Filter and NAT tables
-/var/vcap/packages/vxlan-policy-agent/bin/pre-start -lock-file var/vcap/data/garden-cni/iptables.lock
+/var/vcap/packages/vxlan-policy-agent/bin/pre-start -lock-file /var/vcap/data/garden-cni/iptables.lock
 <% end %>


### PR DESCRIPTION
Using a relative path creates a discrepency between the pre-start script and running process itself