### PR TITLE
Run error cases in Serial

### DIFF
--- a/src/code.cloudfoundry.org/silk/teardown/integration/error_cases_test.go
+++ b/src/code.cloudfoundry.org/silk/teardown/integration/error_cases_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/onsi/gomega/gexec"
 )
 
-var _ = Describe("error cases", func() {
+var _ = Describe("error cases", Serial, func() {
 	var configFilePath string
 
 	BeforeEach(func() {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Error cases in this case Stops http server in integration_test.go this cauases an isue when stopping/starting services.

Without this fix, silk tests flakes quite often when running teardown tests

Context: https://ci.funtime.lol/teams/wg-arp-networking/pipelines/cf-networking-release/jobs/unit-and-integration-tests/builds/105


Backward Compatibility
---------------
Breaking Change? **No**

