### PR TITLE
Use container guid in ASG chain name instead of sha1

### DIFF
--- a/src/code.cloudfoundry.org/lib/fakes/iptables.go
+++ b/src/code.cloudfoundry.org/lib/fakes/iptables.go
@@ -19,6 +19,20 @@ type IPTables struct {
 	appendUniqueReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ChainExistsStub        func(string, string) (bool, error)
+	chainExistsMutex       sync.RWMutex
+	chainExistsArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	chainExistsReturns struct {
+		result1 bool
+		result2 error
+	}
+	chainExistsReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	ClearChainStub        func(string, string) error
 	clearChainMutex       sync.RWMutex
 	clearChainArgsForCall []struct {
@@ -124,6 +138,19 @@ type IPTables struct {
 	newChainReturnsOnCall map[int]struct {
 		result1 error
 	}
+	RenameChainStub        func(string, string, string) error
+	renameChainMutex       sync.RWMutex
+	renameChainArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}
+	renameChainReturns struct {
+		result1 error
+	}
+	renameChainReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -189,6 +216,71 @@ func (fake *IPTables) AppendUniqueReturnsOnCall(i int, result1 error) {
 	fake.appendUniqueReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *IPTables) ChainExists(arg1 string, arg2 string) (bool, error) {
+	fake.chainExistsMutex.Lock()
+	ret, specificReturn := fake.chainExistsReturnsOnCall[len(fake.chainExistsArgsForCall)]
+	fake.chainExistsArgsForCall = append(fake.chainExistsArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.ChainExistsStub
+	fakeReturns := fake.chainExistsReturns
+	fake.recordInvocation("ChainExists", []interface{}{arg1, arg2})
+	fake.chainExistsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *IPTables) ChainExistsCallCount() int {
+	fake.chainExistsMutex.RLock()
+	defer fake.chainExistsMutex.RUnlock()
+	return len(fake.chainExistsArgsForCall)
+}
+
+func (fake *IPTables) ChainExistsCalls(stub func(string, string) (bool, error)) {
+	fake.chainExistsMutex.Lock()
+	defer fake.chainExistsMutex.Unlock()
+	fake.ChainExistsStub = stub
+}
+
+func (fake *IPTables) ChainExistsArgsForCall(i int) (string, string) {
+	fake.chainExistsMutex.RLock()
+	defer fake.chainExistsMutex.RUnlock()
+	argsForCall := fake.chainExistsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *IPTables) ChainExistsReturns(result1 bool, result2 error) {
+	fake.chainExistsMutex.Lock()
+	defer fake.chainExistsMutex.Unlock()
+	fake.ChainExistsStub = nil
+	fake.chainExistsReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *IPTables) ChainExistsReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.chainExistsMutex.Lock()
+	defer fake.chainExistsMutex.Unlock()
+	fake.ChainExistsStub = nil
+	if fake.chainExistsReturnsOnCall == nil {
+		fake.chainExistsReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.chainExistsReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *IPTables) ClearChain(arg1 string, arg2 string) error {
@@ -699,11 +791,76 @@ func (fake *IPTables) NewChainReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *IPTables) RenameChain(arg1 string, arg2 string, arg3 string) error {
+	fake.renameChainMutex.Lock()
+	ret, specificReturn := fake.renameChainReturnsOnCall[len(fake.renameChainArgsForCall)]
+	fake.renameChainArgsForCall = append(fake.renameChainArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.RenameChainStub
+	fakeReturns := fake.renameChainReturns
+	fake.recordInvocation("RenameChain", []interface{}{arg1, arg2, arg3})
+	fake.renameChainMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *IPTables) RenameChainCallCount() int {
+	fake.renameChainMutex.RLock()
+	defer fake.renameChainMutex.RUnlock()
+	return len(fake.renameChainArgsForCall)
+}
+
+func (fake *IPTables) RenameChainCalls(stub func(string, string, string) error) {
+	fake.renameChainMutex.Lock()
+	defer fake.renameChainMutex.Unlock()
+	fake.RenameChainStub = stub
+}
+
+func (fake *IPTables) RenameChainArgsForCall(i int) (string, string, string) {
+	fake.renameChainMutex.RLock()
+	defer fake.renameChainMutex.RUnlock()
+	argsForCall := fake.renameChainArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *IPTables) RenameChainReturns(result1 error) {
+	fake.renameChainMutex.Lock()
+	defer fake.renameChainMutex.Unlock()
+	fake.RenameChainStub = nil
+	fake.renameChainReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *IPTables) RenameChainReturnsOnCall(i int, result1 error) {
+	fake.renameChainMutex.Lock()
+	defer fake.renameChainMutex.Unlock()
+	fake.RenameChainStub = nil
+	if fake.renameChainReturnsOnCall == nil {
+		fake.renameChainReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.renameChainReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *IPTables) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.appendUniqueMutex.RLock()
 	defer fake.appendUniqueMutex.RUnlock()
+	fake.chainExistsMutex.RLock()
+	defer fake.chainExistsMutex.RUnlock()
 	fake.clearChainMutex.RLock()
 	defer fake.clearChainMutex.RUnlock()
 	fake.deleteMutex.RLock()
@@ -720,6 +877,8 @@ func (fake *IPTables) Invocations() map[string][][]interface{} {
 	defer fake.listChainsMutex.RUnlock()
 	fake.newChainMutex.RLock()
 	defer fake.newChainMutex.RUnlock()
+	fake.renameChainMutex.RLock()
+	defer fake.renameChainMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/src/code.cloudfoundry.org/lib/fakes/iptables_extended.go
+++ b/src/code.cloudfoundry.org/lib/fakes/iptables_extended.go
@@ -46,6 +46,20 @@ type IPTablesAdapter struct {
 	bulkInsertReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ChainExistsStub        func(string, string) (bool, error)
+	chainExistsMutex       sync.RWMutex
+	chainExistsArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	chainExistsReturns struct {
+		result1 bool
+		result2 error
+	}
+	chainExistsReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	ClearChainStub        func(string, string) error
 	clearChainMutex       sync.RWMutex
 	clearChainArgsForCall []struct {
@@ -172,6 +186,19 @@ type IPTablesAdapter struct {
 		result1 error
 	}
 	newChainReturnsOnCall map[int]struct {
+		result1 error
+	}
+	RenameChainStub        func(string, string, string) error
+	renameChainMutex       sync.RWMutex
+	renameChainArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}
+	renameChainReturns struct {
+		result1 error
+	}
+	renameChainReturnsOnCall map[int]struct {
 		result1 error
 	}
 	RuleCountStub        func(string) (int, error)
@@ -377,6 +404,71 @@ func (fake *IPTablesAdapter) BulkInsertReturnsOnCall(i int, result1 error) {
 	fake.bulkInsertReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *IPTablesAdapter) ChainExists(arg1 string, arg2 string) (bool, error) {
+	fake.chainExistsMutex.Lock()
+	ret, specificReturn := fake.chainExistsReturnsOnCall[len(fake.chainExistsArgsForCall)]
+	fake.chainExistsArgsForCall = append(fake.chainExistsArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.ChainExistsStub
+	fakeReturns := fake.chainExistsReturns
+	fake.recordInvocation("ChainExists", []interface{}{arg1, arg2})
+	fake.chainExistsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *IPTablesAdapter) ChainExistsCallCount() int {
+	fake.chainExistsMutex.RLock()
+	defer fake.chainExistsMutex.RUnlock()
+	return len(fake.chainExistsArgsForCall)
+}
+
+func (fake *IPTablesAdapter) ChainExistsCalls(stub func(string, string) (bool, error)) {
+	fake.chainExistsMutex.Lock()
+	defer fake.chainExistsMutex.Unlock()
+	fake.ChainExistsStub = stub
+}
+
+func (fake *IPTablesAdapter) ChainExistsArgsForCall(i int) (string, string) {
+	fake.chainExistsMutex.RLock()
+	defer fake.chainExistsMutex.RUnlock()
+	argsForCall := fake.chainExistsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *IPTablesAdapter) ChainExistsReturns(result1 bool, result2 error) {
+	fake.chainExistsMutex.Lock()
+	defer fake.chainExistsMutex.Unlock()
+	fake.ChainExistsStub = nil
+	fake.chainExistsReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *IPTablesAdapter) ChainExistsReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.chainExistsMutex.Lock()
+	defer fake.chainExistsMutex.Unlock()
+	fake.ChainExistsStub = nil
+	if fake.chainExistsReturnsOnCall == nil {
+		fake.chainExistsReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.chainExistsReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *IPTablesAdapter) ClearChain(arg1 string, arg2 string) error {
@@ -1010,6 +1102,69 @@ func (fake *IPTablesAdapter) NewChainReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *IPTablesAdapter) RenameChain(arg1 string, arg2 string, arg3 string) error {
+	fake.renameChainMutex.Lock()
+	ret, specificReturn := fake.renameChainReturnsOnCall[len(fake.renameChainArgsForCall)]
+	fake.renameChainArgsForCall = append(fake.renameChainArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.RenameChainStub
+	fakeReturns := fake.renameChainReturns
+	fake.recordInvocation("RenameChain", []interface{}{arg1, arg2, arg3})
+	fake.renameChainMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *IPTablesAdapter) RenameChainCallCount() int {
+	fake.renameChainMutex.RLock()
+	defer fake.renameChainMutex.RUnlock()
+	return len(fake.renameChainArgsForCall)
+}
+
+func (fake *IPTablesAdapter) RenameChainCalls(stub func(string, string, string) error) {
+	fake.renameChainMutex.Lock()
+	defer fake.renameChainMutex.Unlock()
+	fake.RenameChainStub = stub
+}
+
+func (fake *IPTablesAdapter) RenameChainArgsForCall(i int) (string, string, string) {
+	fake.renameChainMutex.RLock()
+	defer fake.renameChainMutex.RUnlock()
+	argsForCall := fake.renameChainArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *IPTablesAdapter) RenameChainReturns(result1 error) {
+	fake.renameChainMutex.Lock()
+	defer fake.renameChainMutex.Unlock()
+	fake.RenameChainStub = nil
+	fake.renameChainReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *IPTablesAdapter) RenameChainReturnsOnCall(i int, result1 error) {
+	fake.renameChainMutex.Lock()
+	defer fake.renameChainMutex.Unlock()
+	fake.RenameChainStub = nil
+	if fake.renameChainReturnsOnCall == nil {
+		fake.renameChainReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.renameChainReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *IPTablesAdapter) RuleCount(arg1 string) (int, error) {
 	fake.ruleCountMutex.Lock()
 	ret, specificReturn := fake.ruleCountReturnsOnCall[len(fake.ruleCountArgsForCall)]
@@ -1083,6 +1238,8 @@ func (fake *IPTablesAdapter) Invocations() map[string][][]interface{} {
 	defer fake.bulkAppendMutex.RUnlock()
 	fake.bulkInsertMutex.RLock()
 	defer fake.bulkInsertMutex.RUnlock()
+	fake.chainExistsMutex.RLock()
+	defer fake.chainExistsMutex.RUnlock()
 	fake.clearChainMutex.RLock()
 	defer fake.clearChainMutex.RUnlock()
 	fake.deleteMutex.RLock()
@@ -1103,6 +1260,8 @@ func (fake *IPTablesAdapter) Invocations() map[string][][]interface{} {
 	defer fake.listChainsMutex.RUnlock()
 	fake.newChainMutex.RLock()
 	defer fake.newChainMutex.RUnlock()
+	fake.renameChainMutex.RLock()
+	defer fake.renameChainMutex.RUnlock()
 	fake.ruleCountMutex.RLock()
 	defer fake.ruleCountMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/src/code.cloudfoundry.org/lib/rules/locked_iptables.go
+++ b/src/code.cloudfoundry.org/lib/rules/locked_iptables.go
@@ -11,6 +11,7 @@ import (
 //go:generate counterfeiter -o ../fakes/iptables.go --fake-name IPTables . iptables
 type iptables interface {
 	Exists(table, chain string, rulespec ...string) (bool, error)
+	ChainExists(table, chain string) (bool, error)
 	Insert(table, chain string, pos int, rulespec ...string) error
 	AppendUnique(table, chain string, rulespec ...string) error
 	Delete(table, chain string, rulespec ...string) error
@@ -19,12 +20,14 @@ type iptables interface {
 	NewChain(table, chain string) error
 	ClearChain(table, chain string) error
 	DeleteChain(table, chain string) error
+	RenameChain(table, oldChain, newChain string) error
 }
 
 //go:generate counterfeiter -o ../fakes/iptables_extended.go --fake-name IPTablesAdapter . IPTablesAdapter
 type IPTablesAdapter interface {
 	FlushAndRestore(rawInput string) error
 	Exists(table, chain string, rulespec IPTablesRule) (bool, error)
+	ChainExists(table, chain string) (bool, error)
 	Delete(table, chain string, rulespec IPTablesRule) error
 	DeleteAfterRuleNum(table, chain string, ruleNum int) error
 	DeleteAfterRuleNumKeepReject(table, chain string, ruleNum int) error
@@ -33,6 +36,7 @@ type IPTablesAdapter interface {
 	NewChain(table, chain string) error
 	ClearChain(table, chain string) error
 	DeleteChain(table, chain string) error
+	RenameChain(table, oldChain, newChain string) error
 	BulkInsert(table, chain string, pos int, rulespec ...IPTablesRule) error
 	BulkAppend(table, chain string, rulespec ...IPTablesRule) error
 	RuleCount(table string) (int, error)
@@ -103,6 +107,19 @@ func (l *LockedIPTables) Exists(table, chain string, rulespec IPTablesRule) (boo
 	}
 
 	b, err := l.IPTables.Exists(table, chain, rulespec...)
+	if err != nil {
+		return false, handleIPTablesError(err, l.Locker.Unlock())
+	}
+
+	return b, l.Locker.Unlock()
+}
+
+func (l *LockedIPTables) ChainExists(table, chain string) (bool, error) {
+	if err := l.Locker.Lock(); err != nil {
+		return false, fmt.Errorf("lock: %s", err)
+	}
+
+	b, err := l.IPTables.ChainExists(table, chain)
 	if err != nil {
 		return false, handleIPTablesError(err, l.Locker.Unlock())
 	}
@@ -229,6 +246,19 @@ func (l *LockedIPTables) ListChains(table string) ([]string, error) {
 	}
 
 	return ret, l.Locker.Unlock()
+}
+
+func (l *LockedIPTables) RenameChain(table string, oldChain string, newChain string) error {
+	if err := l.Locker.Lock(); err != nil {
+		return fmt.Errorf("lock: %s", err)
+	}
+
+	err := l.IPTables.RenameChain(table, oldChain, newChain)
+	if err != nil {
+		return handleIPTablesError(err, l.Locker.Unlock())
+	}
+
+	return l.Locker.Unlock()
 }
 
 func (l *LockedIPTables) RuleCount(table string) (int, error) {

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/vxlan-policy-agent/main.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/vxlan-policy-agent/main.go
@@ -185,16 +185,12 @@ func main() {
 	}
 
 	dynamicPlanner := &planner.VxlanPolicyPlanner{
-		Datastore:     store,
-		PolicyClient:  policyClient,
-		Logger:        logger.Session("rules-updater"),
-		VNI:           conf.VNI,
-		MetricsSender: metricsSender,
-		Chain: enforcer.Chain{
-			Table:       "filter",
-			ParentChain: "FORWARD",
-			Prefix:      "vpa--",
-		},
+		Datastore:                     store,
+		PolicyClient:                  policyClient,
+		Logger:                        logger.Session("rules-updater"),
+		VNI:                           conf.VNI,
+		MetricsSender:                 metricsSender,
+		Chain:                         enforcer.NewPolicyChain(),
 		LoggingState:                  iptablesLoggingState,
 		IPTablesAcceptedUDPLogsPerSec: conf.IPTablesAcceptedUDPLogsPerSec,
 		EnableOverlayIngressRules:     conf.EnableOverlayIngressRules,

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/converger/fakes/rule_enforcer.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/converger/fakes/rule_enforcer.go
@@ -23,6 +23,17 @@ type RuleEnforcer struct {
 		result1 []enforcer.LiveChain
 		result2 error
 	}
+	CleanupChainStub        func(enforcer.LiveChain) error
+	cleanupChainMutex       sync.RWMutex
+	cleanupChainArgsForCall []struct {
+		arg1 enforcer.LiveChain
+	}
+	cleanupChainReturns struct {
+		result1 error
+	}
+	cleanupChainReturnsOnCall map[int]struct {
+		result1 error
+	}
 	EnforceRulesAndChainStub        func(enforcer.RulesWithChain) (string, error)
 	enforceRulesAndChainMutex       sync.RWMutex
 	enforceRulesAndChainArgsForCall []struct {
@@ -110,6 +121,67 @@ func (fake *RuleEnforcer) CleanChainsMatchingReturnsOnCall(i int, result1 []enfo
 	}{result1, result2}
 }
 
+func (fake *RuleEnforcer) CleanupChain(arg1 enforcer.LiveChain) error {
+	fake.cleanupChainMutex.Lock()
+	ret, specificReturn := fake.cleanupChainReturnsOnCall[len(fake.cleanupChainArgsForCall)]
+	fake.cleanupChainArgsForCall = append(fake.cleanupChainArgsForCall, struct {
+		arg1 enforcer.LiveChain
+	}{arg1})
+	stub := fake.CleanupChainStub
+	fakeReturns := fake.cleanupChainReturns
+	fake.recordInvocation("CleanupChain", []interface{}{arg1})
+	fake.cleanupChainMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *RuleEnforcer) CleanupChainCallCount() int {
+	fake.cleanupChainMutex.RLock()
+	defer fake.cleanupChainMutex.RUnlock()
+	return len(fake.cleanupChainArgsForCall)
+}
+
+func (fake *RuleEnforcer) CleanupChainCalls(stub func(enforcer.LiveChain) error) {
+	fake.cleanupChainMutex.Lock()
+	defer fake.cleanupChainMutex.Unlock()
+	fake.CleanupChainStub = stub
+}
+
+func (fake *RuleEnforcer) CleanupChainArgsForCall(i int) enforcer.LiveChain {
+	fake.cleanupChainMutex.RLock()
+	defer fake.cleanupChainMutex.RUnlock()
+	argsForCall := fake.cleanupChainArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *RuleEnforcer) CleanupChainReturns(result1 error) {
+	fake.cleanupChainMutex.Lock()
+	defer fake.cleanupChainMutex.Unlock()
+	fake.CleanupChainStub = nil
+	fake.cleanupChainReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *RuleEnforcer) CleanupChainReturnsOnCall(i int, result1 error) {
+	fake.cleanupChainMutex.Lock()
+	defer fake.cleanupChainMutex.Unlock()
+	fake.CleanupChainStub = nil
+	if fake.cleanupChainReturnsOnCall == nil {
+		fake.cleanupChainReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.cleanupChainReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *RuleEnforcer) EnforceRulesAndChain(arg1 enforcer.RulesWithChain) (string, error) {
 	fake.enforceRulesAndChainMutex.Lock()
 	ret, specificReturn := fake.enforceRulesAndChainReturnsOnCall[len(fake.enforceRulesAndChainArgsForCall)]
@@ -179,6 +251,8 @@ func (fake *RuleEnforcer) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.cleanChainsMatchingMutex.RLock()
 	defer fake.cleanChainsMatchingMutex.RUnlock()
+	fake.cleanupChainMutex.RLock()
+	defer fake.cleanupChainMutex.RUnlock()
 	fake.enforceRulesAndChainMutex.RLock()
 	defer fake.enforceRulesAndChainMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer.go
@@ -4,12 +4,19 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"code.cloudfoundry.org/executor"
 	"code.cloudfoundry.org/lib/rules"
 
 	"code.cloudfoundry.org/lager/v3"
+)
+
+const (
+	TimestampedRegex       = `([0-9]{10,16})`
+	ASGChainRegex          = `^c?asg-[A-Za-z0-9]+`
+	ContainerPrefixToStrip = `check-`
 )
 
 type Timestamper struct{}
@@ -47,11 +54,39 @@ type EnforcerConfig struct {
 const FilterTable = "filter"
 
 type Chain struct {
-	Table              string
-	ParentChain        string
-	Prefix             string
-	ManagedChainsRegex string
-	CleanUpParentChain bool
+	Table       string
+	ParentChain string
+	Name        string
+	Timestamped bool
+}
+
+func NewPolicyChain() Chain {
+	return Chain{
+		Table:       FilterTable,
+		ParentChain: "FORWARD",
+		Name:        "vpa--",
+		Timestamped: true,
+	}
+}
+
+func NewASGChain(parentChain string, containerHandle string) Chain {
+	return Chain{
+		Table:       FilterTable,
+		ParentChain: parentChain,
+		Name:        ASGChainName(containerHandle),
+		Timestamped: false,
+	}
+}
+
+func ASGChainName(handle string) string {
+	prefixStripped := strings.TrimPrefix(handle, ContainerPrefixToStrip)
+	dashesStripped := strings.Replace(prefixStripped, "-", "", -1)
+	name := dashesStripped
+	if len(dashesStripped) > 20 {
+		name = dashesStripped[:20]
+	}
+
+	return fmt.Sprintf("asg-%s", name)
 }
 
 type LiveChain struct {
@@ -101,6 +136,7 @@ func (e *Enforcer) CleanChainsMatching(regex *regexp.Regexp, desiredChains []Liv
 	for _, chain := range desiredChains {
 		if _, ok := desiredMap[chain.Name]; !ok {
 			desiredMap[chain.Name] = struct{}{}
+			desiredMap[e.candidateChainName(chain.Name)] = struct{}{}
 		}
 	}
 
@@ -132,75 +168,174 @@ func (e *Enforcer) CleanChainsMatching(regex *regexp.Regexp, desiredChains []Liv
 	return chainsToDelete, nil
 }
 
+func (e *Enforcer) CleanupChain(chain LiveChain) error {
+	e.Logger.Debug("cleanup-chain", lager.Data{"name": chain.Name, "table": chain.Table})
+	chainExists, _ := e.iptables.ChainExists(chain.Table, chain.Name)
+	if chainExists {
+		e.Logger.Debug("deleting-chain", lager.Data{"name": chain.Name, "table": chain.Table})
+		err := e.deleteChain(e.Logger, LiveChain{Table: chain.Table, Name: chain.Name})
+		if err != nil {
+			e.Logger.Error(fmt.Sprintf("delete-chain-%s-from-%s", chain.Name, chain.Table), err)
+			return fmt.Errorf("deleting chain %s from table %s: %s", chain.Name, chain.Table, err)
+		}
+	}
+	candidateChainName := e.candidateChainName(chain.Name)
+	candidateChainExists, _ := e.iptables.ChainExists(chain.Table, candidateChainName)
+	if candidateChainExists {
+		e.Logger.Debug("deleting-chain", lager.Data{"name": candidateChainName, "table": chain.Table})
+		err := e.deleteChain(e.Logger, LiveChain{Table: chain.Table, Name: candidateChainName})
+		if err != nil {
+			e.Logger.Error(fmt.Sprintf("delete-chain-%s-from-%s", candidateChainName, chain.Table), err)
+			return fmt.Errorf("deleting chain %s from table %s: %s", candidateChainName, chain.Table, err)
+		}
+	}
+
+	return nil
+}
+
 func (e *Enforcer) EnforceRulesAndChain(rulesAndChain RulesWithChain) (string, error) {
 	return e.EnforceOnChain(rulesAndChain.Chain, rulesAndChain.Rules)
 }
 
-func (e *Enforcer) EnforceOnChain(c Chain, rules []rules.IPTablesRule) (string, error) {
-	var managedChainsRegex string
-	if c.ManagedChainsRegex != "" {
-		managedChainsRegex = c.ManagedChainsRegex
-	} else {
-		managedChainsRegex = c.Prefix
+func (e *Enforcer) EnforceOnChain(c Chain, rulesSpec []rules.IPTablesRule) (string, error) {
+	if c.Timestamped {
+		// used for C2C
+		newTime := e.timestamper.CurrentTime()
+		chainName := fmt.Sprintf("%s%d", c.Name, newTime)
+
+		logger := e.Logger.Session(chainName)
+		err := e.enforce(logger, c.Table, c.ParentChain, chainName, rulesSpec...)
+		if err != nil {
+			return "", err
+		}
+
+		logger.Debug("cleaning-up-old-rules", lager.Data{"chain": chainName, "table": c.Table, "rules": rulesSpec, "prefix": c.Name})
+		managedChainsRegex := c.Name + TimestampedRegex
+		err = e.cleanupOldRules(logger, c.Table, c.ParentChain, managedChainsRegex, newTime)
+		if err != nil {
+			logger.Error("cleanup-rules", err)
+			return chainName, &CleanupErr{err}
+		}
+
+		return chainName, nil
 	}
-	return e.Enforce(c.Table, c.ParentChain, c.Prefix, managedChainsRegex, c.CleanUpParentChain, rules...)
+
+	// used for ASGS
+	logger := e.Logger.Session(c.Name)
+
+	err := e.replaceChainRules(logger, c, rulesSpec)
+	if err != nil {
+		logger.Error("replace-chain", err)
+		return "", err
+	}
+
+	// Delete everything after the first rule in the parent chain. Rule 1 should be the jump to the new/desired asg-* chain.
+	// Everything else is either an original rule from before asg-syncing kicked in, or the previous asg-* chain jump rule
+	// Nothing should be modifying the netout-* chains, as the first rule will always end up being a jump to the asg-*
+	// chain after ~60s, and it ends in a blanket REJECT, so no other rules would be effective anyway.
+	err = e.iptables.DeleteAfterRuleNumKeepReject(c.Table, c.ParentChain, 2)
+	if err != nil {
+		return c.Name, &CleanupErr{fmt.Errorf("clean up parent chain: %s", err)}
+	}
+
+	return c.Name, nil
 }
 
-func (e *Enforcer) Enforce(table, parentChain, chainPrefix, managedChainsRegex string, cleanupParentChain bool, rulespec ...rules.IPTablesRule) (string, error) {
-	newTime := e.timestamper.CurrentTime()
-	chain := fmt.Sprintf("%s%d", chainPrefix, newTime)
-	logger := e.Logger.Session(chain)
-
-	logger.Debug("create-chain", lager.Data{"chain": chain, "table": table})
-	err := e.iptables.NewChain(table, chain)
+func (e *Enforcer) enforce(logger lager.Logger, table string, parentChain string, chainName string, rulespec ...rules.IPTablesRule) error {
+	logger.Debug("create-chain", lager.Data{"chain": chainName, "table": table})
+	err := e.iptables.NewChain(table, chainName)
 	if err != nil {
 		logger.Error("create-chain", err)
-		return "", fmt.Errorf("creating chain: %s", err)
+		return fmt.Errorf("creating chain: %s", err)
 	}
 
 	if e.conf.DisableContainerNetworkPolicy {
 		rulespec = append([]rules.IPTablesRule{rules.NewAcceptEverythingRule(e.conf.OverlayNetwork)}, rulespec...)
 	}
 
-	logger.Debug("insert-chain", lager.Data{"chain": parentChain, "table": table, "index": 1, "rule": rules.IPTablesRule{"-j", chain}})
-	err = e.iptables.BulkInsert(table, parentChain, 1, rules.IPTablesRule{"-j", chain})
+	logger.Debug("insert-chain", lager.Data{"parent-chain": parentChain, "table": table, "index": 1, "rule": rules.IPTablesRule{"-j", chainName}})
+	err = e.iptables.BulkInsert(table, parentChain, 1, rules.IPTablesRule{"-j", chainName})
 	if err != nil {
 		logger.Error("insert-chain", err)
-		delErr := e.deleteChain(logger, LiveChain{Table: table, Name: chain})
+		delErr := e.deleteChain(logger, LiveChain{Table: table, Name: chainName})
 		if delErr != nil {
 			logger.Error("cleanup-failed-insert", delErr)
 		}
-		return "", fmt.Errorf("inserting chain: %s", err)
+		return fmt.Errorf("inserting chain: %s", err)
 	}
 
-	logger.Debug("bulk-append", lager.Data{"chain": chain, "table": table, "rules": rulespec})
-	err = e.iptables.BulkAppend(table, chain, rulespec...)
+	logger.Debug("bulk-append", lager.Data{"chain": chainName, "table": table, "rules": rulespec})
+	err = e.iptables.BulkAppend(table, chainName, rulespec...)
 	if err != nil {
 		logger.Error("bulk-append", err)
-		cleanErr := e.cleanupOldChain(logger, LiveChain{Table: table, Name: chain}, parentChain)
+		cleanErr := e.cleanupOldChain(logger, LiveChain{Table: table, Name: chainName}, parentChain)
 		if cleanErr != nil {
 			logger.Error("cleanup-failed-append", cleanErr)
 		}
-		return "", fmt.Errorf("bulk appending: %s", err)
+		return fmt.Errorf("bulk appending: %s", err)
 	}
 
-	logger.Debug("cleaning-up-old-rules", lager.Data{"chain": chain, "table": table, "rules": rulespec})
-	err = e.cleanupOldRules(logger, table, parentChain, managedChainsRegex, cleanupParentChain, newTime)
-	if err != nil {
-		logger.Error("cleanup-rules", err)
-		return chain, &CleanupErr{err}
-	}
-
-	return chain, nil
+	return nil
 }
 
-func (e *Enforcer) cleanupOldRules(logger lager.Logger, table, parentChain, managedChainsRegex string, cleanupParentChain bool, newTime int64) error {
+// Replaces chain if exists with provided rule spec:
+// 1. First it checks if candidate chain exists in case if previos run failed for any reason and cleans it up
+// 2. Creates a temporary candidate chain that is appended to the parent chain
+// 3. Deletes original chain
+// 4. Renames candidate chain to original chain
+func (e *Enforcer) replaceChainRules(logger lager.Logger, c Chain, rulesSpec []rules.IPTablesRule) error {
+	logger.Debug("replace-chain", lager.Data{"chain": c.Name, "table": c.Table, "rulesSpec": rulesSpec})
+
+	candidateName := e.candidateChainName(c.Name)
+	originalChainJumpExists, _ := e.iptables.Exists(c.Table, c.ParentChain, rules.IPTablesRule{"-j", c.Name})
+	candidateChainJumpExists, _ := e.iptables.Exists(c.Table, c.ParentChain, rules.IPTablesRule{"-j", candidateName})
+
+	logger.Debug("replace-chain-exists", lager.Data{"original": originalChainJumpExists, "candidate": candidateChainJumpExists})
+	if !originalChainJumpExists && !candidateChainJumpExists {
+		return e.enforce(logger, c.Table, c.ParentChain, c.Name, rulesSpec...)
+	}
+
+	if candidateChainJumpExists {
+		if originalChainJumpExists {
+			err := e.cleanupOldChain(e.Logger, LiveChain{Table: c.Table, Name: candidateName}, c.ParentChain)
+			if err != nil {
+				return err
+			}
+		} else {
+			logger.Debug("replace-chain-rename-original", lager.Data{"chain": c.Name, "table": c.Table})
+			err := e.iptables.RenameChain(c.Table, candidateName, c.Name)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	err := e.enforce(logger, c.Table, c.ParentChain, candidateName, rulesSpec...)
+	if err != nil {
+		return err
+	}
+
+	err = e.cleanupOldChain(e.Logger, LiveChain{Table: c.Table, Name: c.Name}, c.ParentChain)
+	if err != nil {
+		return err
+	}
+
+	logger.Debug("replace-chain-rename-candidate", lager.Data{"chain": c.Name, "candidate-chain": candidateName, "table": c.Table})
+	err = e.iptables.RenameChain(c.Table, candidateName, c.Name)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *Enforcer) cleanupOldRules(logger lager.Logger, table, parentChain, managedChainsRegex string, newTime int64) error {
 	rulesList, err := e.iptables.List(table, parentChain)
 	if err != nil {
 		return fmt.Errorf("listing forward rules: %s", err)
 	}
 
-	reManagedChain := regexp.MustCompile(managedChainsRegex + "([0-9]{10,16})")
+	reManagedChain := regexp.MustCompile(managedChainsRegex)
 
 	for _, r := range rulesList {
 		matches := reManagedChain.FindStringSubmatch(r)
@@ -218,16 +353,6 @@ func (e *Enforcer) cleanupOldRules(logger lager.Logger, table, parentChain, mana
 					return err
 				}
 			}
-		}
-	}
-	if cleanupParentChain {
-		// Delete everything after the first rule in the parent chain. Rule 1 should be the jump to the new/desired asg-* chain.
-		// Everything else is either an original rule from before asg-syncing kicked in, or the previous asg-* chain jump rule
-		// Nothing should be modifying the netout-* chains, as the first rule will always end up being a jump to the asg-*
-		// chain after ~60s, and it ends in a blanket REJECT, so no other rules would be effective anyway.
-		err := e.iptables.DeleteAfterRuleNumKeepReject(table, parentChain, 2)
-		if err != nil {
-			return fmt.Errorf("clean up parent chain: %s", err)
 		}
 	}
 
@@ -284,4 +409,8 @@ func (e *Enforcer) deleteChain(logger lager.Logger, chain LiveChain) error {
 	}
 
 	return nil
+}
+
+func (e *Enforcer) candidateChainName(name string) string {
+	return fmt.Sprintf("c%s", name)
 }

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
@@ -9,7 +9,6 @@ import (
 	"code.cloudfoundry.org/lib/rules"
 	"code.cloudfoundry.org/vxlan-policy-agent/enforcer"
 	"code.cloudfoundry.org/vxlan-policy-agent/enforcer/fakes"
-	"code.cloudfoundry.org/vxlan-policy-agent/planner"
 
 	"code.cloudfoundry.org/lager/v3/lagertest"
 	. "github.com/onsi/ginkgo/v2"
@@ -18,7 +17,7 @@ import (
 )
 
 var _ = Describe("Enforcer", func() {
-	Describe("Enforce", func() {
+	Describe("EnforceOnChain", func() {
 		var (
 			fakeRule     rules.IPTablesRule
 			fakeRule2    rules.IPTablesRule
@@ -40,310 +39,628 @@ var _ = Describe("Enforcer", func() {
 			ruleEnforcer = enforcer.NewEnforcer(logger, timestamper, iptables, enforcer.EnforcerConfig{DisableContainerNetworkPolicy: false, OverlayNetwork: "10.10.0.0/16"})
 		})
 
-		It("enforces all the rules it receives on the correct chain", func() {
-			rulesToAppend := []rules.IPTablesRule{fakeRule, fakeRule2}
-			_, err := ruleEnforcer.Enforce("some-table", "some-chain", "foo", "foo", true, rulesToAppend...)
-			Expect(err).NotTo(HaveOccurred())
+		Context("when chain is not timestamped", func() {
+			var rulesToAppend []rules.IPTablesRule
+			var enforceErr error
 
-			Expect(iptables.BulkAppendCallCount()).To(Equal(1))
-			tbl, chain, rules := iptables.BulkAppendArgsForCall(0)
-			Expect(tbl).To(Equal("some-table"))
-			Expect(chain).To(Equal("foo42"))
-			Expect(rules).To(Equal(rulesToAppend))
-		})
-
-		Context("when the bulk append fails", func() {
-			BeforeEach(func() {
-				iptables.BulkAppendReturns(errors.New("banana"))
-			})
-			It("returns an error", func() {
-				rulesToAppend := []rules.IPTablesRule{fakeRule, fakeRule2}
-				_, err := ruleEnforcer.Enforce("some-table", "some-chain", "foo", "foo", false, rulesToAppend...)
-				Expect(err).To(MatchError("bulk appending: banana"))
-			})
-		})
-
-		It("creates a timestamped chain", func() {
-			_, err := ruleEnforcer.Enforce("some-table", "some-chain", "foo", "foo", false, []rules.IPTablesRule{fakeRule}...)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(iptables.NewChainCallCount()).To(Equal(1))
-			tableName, chainName := iptables.NewChainArgsForCall(0)
-			Expect(tableName).To(Equal("some-table"))
-			Expect(chainName).To(Equal("foo42"))
-		})
-
-		It("returns the chain it created", func() {
-
-			chain, err := ruleEnforcer.Enforce("some-table", "some-chain", "foo", "foo", false, []rules.IPTablesRule{fakeRule}...)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(iptables.NewChainCallCount()).To(Equal(1))
-			tableName, chainName := iptables.NewChainArgsForCall(0)
-			Expect(tableName).To(Equal("some-table"))
-			Expect(chainName).To(Equal("foo42"))
-			Expect(chain).To(Equal("foo42"))
-		})
-		It("inserts the new chain into the chain", func() {
-			_, err := ruleEnforcer.Enforce("some-table", "some-chain", "foo", "foo", false, []rules.IPTablesRule{fakeRule}...)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(iptables.BulkInsertCallCount()).To(Equal(1))
-			tableName, chainName, pos, ruleSpec := iptables.BulkInsertArgsForCall(0)
-			Expect(tableName).To(Equal("some-table"))
-			Expect(chainName).To(Equal("some-chain"))
-			Expect(pos).To(Equal(1))
-			Expect(ruleSpec).To(Equal([]rules.IPTablesRule{{"-j", "foo42"}}))
-		})
-
-		Context("when there is an older timestamped chain", func() {
-			BeforeEach(func() {
-				timestamper.CurrentTimeReturns(9999999999111111)
-				iptables.ListReturns([]string{
-					"-A some-chain -j foo9999999999111110",
-					"-A some-chain -j foo9999999999111116",
-				}, nil)
-			})
-
-			It("gets deleted", func() {
-				_, err := ruleEnforcer.Enforce("some-table", "some-chain", "foo", "foo", false, []rules.IPTablesRule{fakeRule}...)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(iptables.DeleteCallCount()).To(Equal(1))
-				table, chain, ruleSpec := iptables.DeleteArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("some-chain"))
-				Expect(ruleSpec).To(Equal(rules.IPTablesRule{"-j", "foo9999999999111110"}))
-				Expect(iptables.ClearChainCallCount()).To(Equal(1))
-				table, chain = iptables.ClearChainArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("foo9999999999111110"))
-				Expect(iptables.DeleteChainCallCount()).To(Equal(1))
-				table, chain = iptables.DeleteChainArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("foo9999999999111110"))
-			})
-		})
-
-		Context("when there is an older timestamped chain with a different prefix", func() {
-			BeforeEach(func() {
-				timestamper.CurrentTimeReturns(9999999999111111)
-				iptables.ListReturns([]string{
-					"-A some-chain -j asg-000-9999999999111110",
-					"-A some-chain -j asg-001-9999999999111116",
-				}, nil)
-			})
-
-			It("gets deleted", func() {
-				_, err := ruleEnforcer.Enforce("some-table", "some-chain", "asg-001-", "asg-\\d\\d\\d-", false, []rules.IPTablesRule{fakeRule}...)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(iptables.DeleteCallCount()).To(Equal(1))
-				table, chain, ruleSpec := iptables.DeleteArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("some-chain"))
-				Expect(ruleSpec).To(Equal(rules.IPTablesRule{"-j", "asg-000-9999999999111110"}))
-				Expect(iptables.ClearChainCallCount()).To(Equal(1))
-				table, chain = iptables.ClearChainArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("asg-000-9999999999111110"))
-				Expect(iptables.DeleteChainCallCount()).To(Equal(1))
-				table, chain = iptables.DeleteChainArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("asg-000-9999999999111110"))
-			})
-		})
-
-		Context("when parent chain has other rules", func() {
-			BeforeEach(func() {
-				timestamper.CurrentTimeReturns(9999999999111111)
-				iptables.ListReturns([]string{
-					"-A some-chain -j asg-000-9999999999111110",
-					"-A some-chain -j asg-001-9999999999111116",
-					"-A some-chain -j some-chain--log",
-					"-A some-chain -m state --state RELATED,ESTABLISHED -j ACCEPT",
-					"-A some-chain -p tcp -m state --state INVALID -j DROP",
-					"-A some-chain -m iprange --dst-range 0.0.0.0-9.255.255.255 -j ACCEPT",
-					"-A some-chain -j REJECT --reject-with icmp-port-unreachable",
-					`-A some-chain -j LOG --log-prefix "DENY_ee8fd40b "`,
-				}, nil)
-			})
-
-			It("deletes other rules in parent chain after the current chain and keeps the reject rule if parent chain cleanup requested", func() {
-				_, err := ruleEnforcer.Enforce("some-table", "some-chain", "asg-001-", "asg-\\d\\d\\d-", true, []rules.IPTablesRule{fakeRule}...)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(iptables.DeleteAfterRuleNumKeepRejectCallCount()).To(Equal(1))
-				table, chain, ruleSpec := iptables.DeleteAfterRuleNumKeepRejectArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("some-chain"))
-				Expect(ruleSpec).To(Equal(2))
-				Expect(iptables.BulkAppendCallCount()).To(Equal(1))
-
-				Expect(iptables.ClearChainCallCount()).To(Equal(1))
-				table, chain = iptables.ClearChainArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("asg-000-9999999999111110"))
-				Expect(iptables.DeleteChainCallCount()).To(Equal(1))
-				table, chain = iptables.DeleteChainArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("asg-000-9999999999111110"))
-			})
-
-			It("does not delete other rules in parent chain if parent chain cleanup is not requested", func() {
-				_, err := ruleEnforcer.Enforce("some-table", "some-chain", "asg-001-", "asg-\\d\\d\\d-", false, []rules.IPTablesRule{fakeRule}...)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(iptables.DeleteCallCount()).To(Equal(1))
-				table, chain, ruleSpec := iptables.DeleteArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("some-chain"))
-				Expect(ruleSpec).To(Equal(rules.IPTablesRule{"-j", "asg-000-9999999999111110"}))
-				Expect(iptables.ClearChainCallCount()).To(Equal(1))
-				table, chain = iptables.ClearChainArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("asg-000-9999999999111110"))
-				Expect(iptables.DeleteChainCallCount()).To(Equal(1))
-				table, chain = iptables.DeleteChainArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("asg-000-9999999999111110"))
-			})
-		})
-
-		Context("when inserting the new chain fails", func() {
-			BeforeEach(func() {
-				iptables.BulkInsertReturns(errors.New("banana"))
-			})
-
-			It("it logs, deletes the new chain and returns a useful error", func() {
-				_, err := ruleEnforcer.Enforce("some-table", "some-chain", "foo", "foo", false, []rules.IPTablesRule{fakeRule}...)
-				Expect(err).To(MatchError("inserting chain: banana"))
-
-				Expect(iptables.ClearChainCallCount()).To(Equal(1))
-				Expect(iptables.DeleteChainCallCount()).To(Equal(1))
-
-				table, chain := iptables.ClearChainArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("foo42"))
-
-				table, chain = iptables.DeleteChainArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("foo42"))
-
-				Expect(logger).To(gbytes.Say("insert-chain.*banana"))
-			})
-		})
-
-		Context("when appending the new chain fails", func() {
-			BeforeEach(func() {
-				iptables.BulkAppendReturns(errors.New("banana"))
-			})
-
-			It("it logs, cleans up the new chain and returns a useful error", func() {
-				_, err := ruleEnforcer.Enforce("some-table", "some-chain", "foo", "foo", false, []rules.IPTablesRule{fakeRule}...)
-				Expect(err).To(MatchError("bulk appending: banana"))
-
-				Expect(iptables.ClearChainCallCount()).To(Equal(1))
-				Expect(iptables.DeleteChainCallCount()).To(Equal(1))
-				Expect(iptables.DeleteCallCount()).To(Equal(1))
-
-				table, parentChain, ruleSpec := iptables.DeleteArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
-				Expect(parentChain).To(Equal("some-chain"))
-				Expect(ruleSpec).To(Equal(rules.IPTablesRule{"-j", "foo42"}))
-
-				table, chain := iptables.ClearChainArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("foo42"))
-
-				table, chain = iptables.DeleteChainArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
-				Expect(chain).To(Equal("foo42"))
-
-				Expect(logger).To(gbytes.Say("bulk-append.*banana"))
-			})
-		})
-
-		Context("when there are errors cleaning up old rules", func() {
-			BeforeEach(func() {
-				iptables.ListReturns(nil, errors.New("blueberry"))
-			})
-
-			It("it logs and returns a cleanup error in addition to the chain name", func() {
-				chainName, err := ruleEnforcer.Enforce("some-table", "some-chain", "foo", "foo", false, []rules.IPTablesRule{fakeRule}...)
-				Expect(err).To(MatchError("cleaning up: listing forward rules: blueberry"))
-				_, isCleanupErr := err.(*enforcer.CleanupErr)
-				Expect(chainName).To(MatchRegexp("^foo.*"))
-				Expect(isCleanupErr).To(BeTrue())
-				Expect(logger).To(gbytes.Say("cleanup-rules.*blueberry"))
-			})
-		})
-
-		Context("when there are errors cleaning up old chains", func() {
-			BeforeEach(func() {
-				iptables.DeleteReturns(errors.New("banana"))
-				iptables.ListReturns([]string{"-A some-chain -j foo0000000001"}, nil)
-			})
-
-			It("returns a CleanupErr in addition to the chain name", func() {
-				chainName, err := ruleEnforcer.Enforce("some-table", "some-chain", "foo", "foo", false, []rules.IPTablesRule{fakeRule}...)
-				Expect(err).To(MatchError("cleaning up: remove reference to old chain: banana"))
-				_, isCleanupErr := err.(*enforcer.CleanupErr)
-				Expect(chainName).To(MatchRegexp("^foo.*"))
-				Expect(isCleanupErr).To(BeTrue())
-			})
-		})
-
-		Context("when creating the new chain fails", func() {
-			BeforeEach(func() {
-				iptables.NewChainReturns(errors.New("banana"))
-			})
-
-			It("it logs and returns a useful error", func() {
-				_, err := ruleEnforcer.Enforce("some-table", "some-chain", "foo", "foo", false, []rules.IPTablesRule{fakeRule}...)
-				Expect(err).To(MatchError("creating chain: banana"))
-
-				Expect(logger).To(gbytes.Say("create-chain.*banana"))
-			})
-		})
-
-		Context("when network policy is disabled", func() {
-			BeforeEach(func() {
-				ruleEnforcer = enforcer.NewEnforcer(
-					logger,
-					timestamper,
-					iptables,
-					enforcer.EnforcerConfig{
-						DisableContainerNetworkPolicy: true,
-						OverlayNetwork:                "10.10.0.0/16",
+			JustBeforeEach(func() {
+				rulesToAppend = []rules.IPTablesRule{fakeRule, fakeRule2}
+				_, enforceErr = ruleEnforcer.EnforceOnChain(
+					enforcer.Chain{
+						Table:       "some-table",
+						ParentChain: "some-chain",
+						Name:        "asg-handle",
+						Timestamped: false,
 					},
+					rulesToAppend,
 				)
 			})
 
-			It("allows all container connections", func() {
-				_, err := ruleEnforcer.Enforce("some-table", "some-chain", "foo", "foo", false, []rules.IPTablesRule{fakeRule}...)
+			Context("when parent chain has candidate chain, but not original chain", func() {
+				BeforeEach(func() {
+					iptables.ExistsStub = func(table string, parentChan string, ruleSpec rules.IPTablesRule) (bool, error) {
+						switch ruleSpec[1] {
+						case "casg-handle":
+							return true, nil
+						case "asg-handle":
+							return false, nil
+						default:
+							return false, errors.New("unexpected Exists call")
+						}
+					}
+				})
+
+				It("renames the candidate chain to new chain", func() {
+					Expect(enforceErr).NotTo(HaveOccurred())
+					Expect(iptables.RenameChainCallCount()).To(Equal(2))
+					table, oldChain, newChain := iptables.RenameChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(oldChain).To(Equal("casg-handle"))
+					Expect(newChain).To(Equal("asg-handle"))
+				})
+
+				Context("when renaming candidate chain fails", func() {
+					BeforeEach(func() {
+						iptables.RenameChainReturns(errors.New("failed-to-rename"))
+					})
+
+					It("does not apply the candidate chain", func() {
+						Expect(enforceErr).To(HaveOccurred())
+						Expect(enforceErr).To(MatchError("failed-to-rename"))
+						Expect(iptables.BulkInsertCallCount()).To(Equal(0))
+						Expect(iptables.BulkAppendCallCount()).To(Equal(0))
+						Expect(iptables.DeleteCallCount()).To(Equal(0))
+						Expect(iptables.ClearChainCallCount()).To(Equal(0))
+					})
+				})
+			})
+
+			Context("when parent chain has candidate chain and original chain", func() {
+				BeforeEach(func() {
+					iptables.ExistsStub = func(table string, parentChan string, ruleSpec rules.IPTablesRule) (bool, error) {
+						switch ruleSpec[1] {
+						case "casg-handle":
+							return true, nil
+						case "asg-handle":
+							return true, nil
+						default:
+							return false, errors.New("unexpected Exists call")
+						}
+					}
+				})
+
+				It("deletes candidate chain", func() {
+					Expect(iptables.ClearChainCallCount()).To(Equal(2))
+					table, chain := iptables.ClearChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("casg-handle"))
+					Expect(iptables.DeleteChainCallCount()).To(Equal(2))
+					table, chain = iptables.DeleteChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("casg-handle"))
+				})
+
+				Context("when deleting candidate chain fails", func() {
+					BeforeEach(func() {
+						iptables.DeleteReturns(errors.New("failed-to-delete"))
+					})
+
+					It("does not apply the candidate chain", func() {
+						Expect(enforceErr).To(HaveOccurred())
+						Expect(enforceErr).To(MatchError("remove reference to old chain: failed-to-delete"))
+						Expect(iptables.BulkInsertCallCount()).To(Equal(0))
+						Expect(iptables.BulkAppendCallCount()).To(Equal(0))
+						Expect(iptables.ClearChainCallCount()).To(Equal(0))
+					})
+				})
+			})
+
+			Context("when parent does not have candidate chain and only has original chain", func() {
+				BeforeEach(func() {
+					iptables.ExistsStub = func(table string, parentChan string, ruleSpec rules.IPTablesRule) (bool, error) {
+						switch ruleSpec[1] {
+						case "casg-handle":
+							return false, nil
+						case "asg-handle":
+							return true, nil
+						default:
+							return false, errors.New("unexpected Exists call")
+						}
+					}
+				})
+
+				It("creates candidate chain with specified rule set", func() {
+					Expect(iptables.NewChainCallCount()).To(Equal(1))
+					table, chain := iptables.NewChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("casg-handle"))
+					Expect(iptables.BulkAppendCallCount()).To(Equal(1))
+					table, chain, ruleSpec := iptables.BulkAppendArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("casg-handle"))
+					Expect(ruleSpec).To(Equal(rulesToAppend))
+				})
+
+				It("appends candidate chain to parent chain", func() {
+					Expect(iptables.BulkInsertCallCount()).To(Equal(1))
+					table, parentChain, position, ruleSpec := iptables.BulkInsertArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(parentChain).To(Equal("some-chain"))
+					Expect(position).To(Equal(1))
+					Expect(ruleSpec).To(Equal([]rules.IPTablesRule{{"-j", "casg-handle"}}))
+				})
+
+				It("deletes old chain", func() {
+					Expect(iptables.DeleteCallCount()).To(Equal(1))
+					table, parentChain, ruleSpec := iptables.DeleteArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(parentChain).To(Equal("some-chain"))
+					Expect(ruleSpec).To(Equal(rules.IPTablesRule{"-j", "asg-handle"}))
+
+					Expect(iptables.ClearChainCallCount()).To(Equal(1))
+					table, chain := iptables.ClearChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("asg-handle"))
+
+					Expect(iptables.DeleteChainCallCount()).To(Equal(1))
+					table, chain = iptables.DeleteChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("asg-handle"))
+				})
+
+				It("renames candidate chain to new chain", func() {
+					Expect(iptables.RenameChainCallCount()).To(Equal(1))
+					table, oldChain, newChain := iptables.RenameChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(oldChain).To(Equal("casg-handle"))
+					Expect(newChain).To(Equal("asg-handle"))
+				})
+			})
+
+			Context("when parent chain does not have candidate nor original chain", func() {
+				BeforeEach(func() {
+					iptables.ExistsStub = func(table string, parentChan string, ruleSpec rules.IPTablesRule) (bool, error) {
+						switch ruleSpec[1] {
+						case "casg-handle":
+							return false, nil
+						case "asg-handle":
+							return false, nil
+						default:
+							return false, errors.New("unexpected Exists call")
+						}
+					}
+				})
+
+				It("creates original chain with specified rule set", func() {
+					Expect(iptables.NewChainCallCount()).To(Equal(1))
+					table, chain := iptables.NewChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("asg-handle"))
+					Expect(iptables.BulkAppendCallCount()).To(Equal(1))
+					table, chain, ruleSpec := iptables.BulkAppendArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("asg-handle"))
+					Expect(ruleSpec).To(Equal(rulesToAppend))
+				})
+
+				It("does not apply rename or clean up anything", func() {
+					Expect(iptables.RenameChainCallCount()).To(Equal(0))
+					Expect(iptables.ClearChainCallCount()).To(Equal(0))
+				})
+			})
+
+			It("deletes other rules in parent chain after the current chain time and keeps the reject rule if parent chain cleanup requested", func() {
+				Expect(iptables.DeleteAfterRuleNumKeepRejectCallCount()).To(Equal(1))
+				table, chain, ruleNum := iptables.DeleteAfterRuleNumKeepRejectArgsForCall(0)
+				Expect(table).To(Equal("some-table"))
+				Expect(chain).To(Equal("some-chain"))
+				Expect(ruleNum).To(Equal(2))
+			})
+		})
+
+		Context("when chain is timestamped", func() {
+			// Use timestamped chain name
+			It("enforces all the rules it receives on the correct chain", func() {
+				rulesToAppend := []rules.IPTablesRule{fakeRule, fakeRule2}
+				_, err := ruleEnforcer.EnforceOnChain(
+					enforcer.Chain{
+						Table:       "some-table",
+						ParentChain: "some-chain",
+						Name:        "foo",
+						Timestamped: true,
+					},
+					rulesToAppend,
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(iptables.BulkAppendCallCount()).To(Equal(1))
+				tbl, chain, rules := iptables.BulkAppendArgsForCall(0)
+				Expect(tbl).To(Equal("some-table"))
+				Expect(chain).To(Equal("foo42"))
+				Expect(rules).To(Equal(rulesToAppend))
+			})
+
+			Context("when the bulk append fails", func() {
+				BeforeEach(func() {
+					iptables.BulkAppendReturns(errors.New("banana"))
+				})
+
+				It("returns an error", func() {
+					rulesToAppend := []rules.IPTablesRule{fakeRule, fakeRule2}
+					_, err := ruleEnforcer.EnforceOnChain(
+						enforcer.Chain{
+							Table:       "some-table",
+							ParentChain: "some-chain",
+							Name:        "foo",
+							Timestamped: true,
+						},
+						rulesToAppend,
+					)
+					Expect(err).To(MatchError("bulk appending: banana"))
+				})
+			})
+
+			It("creates a timestamped chain", func() {
+				_, err := ruleEnforcer.EnforceOnChain(
+					enforcer.Chain{
+						Table:       "some-table",
+						ParentChain: "some-chain",
+						Name:        "foo",
+						Timestamped: true,
+					},
+					[]rules.IPTablesRule{fakeRule},
+				)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(iptables.NewChainCallCount()).To(Equal(1))
-				Expect(iptables.BulkInsertCallCount()).To(Equal(1))
-				_, _, position, _ := iptables.BulkInsertArgsForCall(0)
-				Expect(position).To(Equal(1))
+				tableName, chainName := iptables.NewChainArgsForCall(0)
+				Expect(tableName).To(Equal("some-table"))
+				Expect(chainName).To(Equal("foo42"))
+			})
 
-				table, chain, rulespec := iptables.BulkAppendArgsForCall(0)
-				Expect(table).To(Equal("some-table"))
+			It("returns the chain it created", func() {
+				chain, err := ruleEnforcer.EnforceOnChain(
+					enforcer.Chain{
+						Table:       "some-table",
+						ParentChain: "some-chain",
+						Name:        "foo",
+						Timestamped: true,
+					},
+					[]rules.IPTablesRule{fakeRule},
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(iptables.NewChainCallCount()).To(Equal(1))
+				tableName, chainName := iptables.NewChainArgsForCall(0)
+				Expect(tableName).To(Equal("some-table"))
+				Expect(chainName).To(Equal("foo42"))
 				Expect(chain).To(Equal("foo42"))
-				Expect(rulespec).To(Equal([]rules.IPTablesRule{{"-s", "10.10.0.0/16", "-d", "10.10.0.0/16", "-j", "ACCEPT"}, {"rule1"}}))
+			})
+
+			It("inserts the new chain into the chain", func() {
+				_, err := ruleEnforcer.EnforceOnChain(
+					enforcer.Chain{
+						Table:       "some-table",
+						ParentChain: "some-chain",
+						Name:        "foo",
+						Timestamped: true,
+					},
+					[]rules.IPTablesRule{fakeRule},
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(iptables.BulkInsertCallCount()).To(Equal(1))
+				tableName, chainName, pos, ruleSpec := iptables.BulkInsertArgsForCall(0)
+				Expect(tableName).To(Equal("some-table"))
+				Expect(chainName).To(Equal("some-chain"))
+				Expect(pos).To(Equal(1))
+				Expect(ruleSpec).To(Equal([]rules.IPTablesRule{{"-j", "foo42"}}))
+			})
+
+			Context("when there is an older timestamped chain", func() {
+				BeforeEach(func() {
+					timestamper.CurrentTimeReturns(9999999999111111)
+					iptables.ListReturns([]string{
+						"-A some-chain -j foo9999999999111110",
+						"-A some-chain -j foo9999999999111116",
+					}, nil)
+				})
+
+				It("gets deleted", func() {
+					_, err := ruleEnforcer.EnforceOnChain(
+						enforcer.Chain{
+							Table:       "some-table",
+							ParentChain: "some-chain",
+							Name:        "foo",
+							Timestamped: true,
+						},
+						[]rules.IPTablesRule{fakeRule},
+					)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(iptables.DeleteCallCount()).To(Equal(1))
+					table, chain, ruleSpec := iptables.DeleteArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("some-chain"))
+					Expect(ruleSpec).To(Equal(rules.IPTablesRule{"-j", "foo9999999999111110"}))
+					Expect(iptables.ClearChainCallCount()).To(Equal(1))
+					table, chain = iptables.ClearChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("foo9999999999111110"))
+					Expect(iptables.DeleteChainCallCount()).To(Equal(1))
+					table, chain = iptables.DeleteChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("foo9999999999111110"))
+				})
+			})
+
+			Context("when there is an older timestamped chain with a different prefix", func() {
+				BeforeEach(func() {
+					timestamper.CurrentTimeReturns(9999999999111111)
+					iptables.ListReturns([]string{
+						"-A some-chain -j vpa-9999999999111110",
+						"-A some-chain -j vpb-9999999999111116",
+					}, nil)
+				})
+
+				It("does not get deleted", func() {
+					_, err := ruleEnforcer.EnforceOnChain(
+						enforcer.Chain{
+							Table:       "some-table",
+							ParentChain: "some-chain",
+							Name:        "vpa-",
+							Timestamped: true,
+						},
+						[]rules.IPTablesRule{fakeRule},
+					)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(iptables.DeleteCallCount()).To(Equal(1))
+					table, chain, ruleSpec := iptables.DeleteArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("some-chain"))
+					Expect(ruleSpec).To(Equal(rules.IPTablesRule{"-j", "vpa-9999999999111110"}))
+					Expect(iptables.ClearChainCallCount()).To(Equal(1))
+					table, chain = iptables.ClearChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("vpa-9999999999111110"))
+					Expect(iptables.DeleteChainCallCount()).To(Equal(1))
+					table, chain = iptables.DeleteChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("vpa-9999999999111110"))
+				})
+			})
+
+			Context("when parent chain has other rules", func() {
+				BeforeEach(func() {
+					timestamper.CurrentTimeReturns(9999999999111111)
+					iptables.ListReturns([]string{
+						"-A some-chain -j vpa-9999999999111110",
+						"-A some-chain -j vpa-9999999999111116",
+						"-A some-chain -j some-chain--log",
+						"-A some-chain -m state --state RELATED,ESTABLISHED -j ACCEPT",
+						"-A some-chain -p tcp -m state --state INVALID -j DROP",
+						"-A some-chain -m iprange --dst-range 0.0.0.0-9.255.255.255 -j ACCEPT",
+						"-A some-chain -j REJECT --reject-with icmp-port-unreachable",
+						`-A some-chain -j LOG --log-prefix "DENY_ee8fd40b "`,
+					}, nil)
+				})
+
+				It("deletes other rules in parent chain after the current chain time and keeps the reject rule if parent chain cleanup requested", func() {
+					_, err := ruleEnforcer.EnforceOnChain(
+						enforcer.Chain{
+							Table:       "some-table",
+							ParentChain: "some-chain",
+							Name:        "vpa-",
+							Timestamped: true,
+						},
+						[]rules.IPTablesRule{fakeRule},
+					)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(iptables.BulkAppendCallCount()).To(Equal(1))
+
+					Expect(iptables.ClearChainCallCount()).To(Equal(1))
+					table, chain := iptables.ClearChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("vpa-9999999999111110"))
+					Expect(iptables.DeleteChainCallCount()).To(Equal(1))
+					table, chain = iptables.DeleteChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("vpa-9999999999111110"))
+				})
+
+				It("does not delete other rules in parent chain if parent chain cleanup is not requested", func() {
+					_, err := ruleEnforcer.EnforceOnChain(
+						enforcer.Chain{
+							Table:       "some-table",
+							ParentChain: "some-chain",
+							Name:        "vpa-",
+							Timestamped: true,
+						},
+						[]rules.IPTablesRule{fakeRule},
+					)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(iptables.DeleteCallCount()).To(Equal(1))
+					table, chain, ruleSpec := iptables.DeleteArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("some-chain"))
+					Expect(ruleSpec).To(Equal(rules.IPTablesRule{"-j", "vpa-9999999999111110"}))
+					Expect(iptables.ClearChainCallCount()).To(Equal(1))
+					table, chain = iptables.ClearChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("vpa-9999999999111110"))
+					Expect(iptables.DeleteChainCallCount()).To(Equal(1))
+					table, chain = iptables.DeleteChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("vpa-9999999999111110"))
+				})
+			})
+
+			Context("when inserting the new chain fails", func() {
+				BeforeEach(func() {
+					iptables.BulkInsertReturns(errors.New("banana"))
+				})
+
+				It("it logs, deletes the new chain and returns a useful error", func() {
+					_, err := ruleEnforcer.EnforceOnChain(
+						enforcer.Chain{
+							Table:       "some-table",
+							ParentChain: "some-chain",
+							Name:        "foo",
+							Timestamped: true,
+						},
+						[]rules.IPTablesRule{fakeRule},
+					)
+					Expect(err).To(MatchError("inserting chain: banana"))
+
+					Expect(iptables.ClearChainCallCount()).To(Equal(1))
+					Expect(iptables.DeleteChainCallCount()).To(Equal(1))
+
+					table, chain := iptables.ClearChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("foo42"))
+
+					table, chain = iptables.DeleteChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("foo42"))
+
+					Expect(logger).To(gbytes.Say("insert-chain.*banana"))
+				})
+			})
+
+			Context("when appending the new chain fails", func() {
+				BeforeEach(func() {
+					iptables.BulkAppendReturns(errors.New("banana"))
+				})
+
+				It("it logs, cleans up the new chain and returns a useful error", func() {
+					_, err := ruleEnforcer.EnforceOnChain(
+						enforcer.Chain{
+							Table:       "some-table",
+							ParentChain: "some-chain",
+							Name:        "foo",
+							Timestamped: true,
+						},
+						[]rules.IPTablesRule{fakeRule},
+					)
+					Expect(err).To(MatchError("bulk appending: banana"))
+
+					Expect(iptables.ClearChainCallCount()).To(Equal(1))
+					Expect(iptables.DeleteChainCallCount()).To(Equal(1))
+					Expect(iptables.DeleteCallCount()).To(Equal(1))
+
+					table, parentChain, ruleSpec := iptables.DeleteArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(parentChain).To(Equal("some-chain"))
+					Expect(ruleSpec).To(Equal(rules.IPTablesRule{"-j", "foo42"}))
+
+					table, chain := iptables.ClearChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("foo42"))
+
+					table, chain = iptables.DeleteChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("foo42"))
+
+					Expect(logger).To(gbytes.Say("bulk-append.*banana"))
+				})
+			})
+
+			Context("when there are errors cleaning up old rules", func() {
+				BeforeEach(func() {
+					iptables.ListReturns(nil, errors.New("blueberry"))
+				})
+
+				It("it logs and returns a cleanup error in addition to the chain name", func() {
+					chainName, err := ruleEnforcer.EnforceOnChain(
+						enforcer.Chain{
+							Table:       "some-table",
+							ParentChain: "some-chain",
+							Name:        "foo",
+							Timestamped: true,
+						},
+						[]rules.IPTablesRule{fakeRule},
+					)
+					Expect(err).To(MatchError("cleaning up: listing forward rules: blueberry"))
+					_, isCleanupErr := err.(*enforcer.CleanupErr)
+					Expect(chainName).To(MatchRegexp("^foo.*"))
+					Expect(isCleanupErr).To(BeTrue())
+					Expect(logger).To(gbytes.Say("cleanup-rules.*blueberry"))
+				})
+			})
+
+			Context("when there are errors cleaning up old chains", func() {
+				BeforeEach(func() {
+					iptables.DeleteReturns(errors.New("banana"))
+					iptables.ListReturns([]string{"-A some-chain -j foo0000000001"}, nil)
+				})
+
+				It("returns a CleanupErr in addition to the chain name", func() {
+					chainName, err := ruleEnforcer.EnforceOnChain(
+						enforcer.Chain{
+							Table:       "some-table",
+							ParentChain: "some-chain",
+							Name:        "foo",
+							Timestamped: true,
+						},
+						[]rules.IPTablesRule{fakeRule},
+					)
+					Expect(err).To(MatchError("cleaning up: remove reference to old chain: banana"))
+					_, isCleanupErr := err.(*enforcer.CleanupErr)
+					Expect(chainName).To(MatchRegexp("^foo.*"))
+					Expect(isCleanupErr).To(BeTrue())
+				})
+			})
+
+			Context("when creating the new chain fails", func() {
+				BeforeEach(func() {
+					iptables.NewChainReturns(errors.New("banana"))
+				})
+
+				It("it logs and returns a useful error", func() {
+					_, err := ruleEnforcer.EnforceOnChain(
+						enforcer.Chain{
+							Table:       "some-table",
+							ParentChain: "some-chain",
+							Name:        "foo",
+							Timestamped: false,
+						},
+						[]rules.IPTablesRule{fakeRule},
+					)
+					Expect(err).To(MatchError("creating chain: banana"))
+
+					Expect(logger).To(gbytes.Say("create-chain.*banana"))
+				})
+			})
+
+			Context("when network policy is disabled", func() {
+				BeforeEach(func() {
+					ruleEnforcer = enforcer.NewEnforcer(
+						logger,
+						timestamper,
+						iptables,
+						enforcer.EnforcerConfig{
+							DisableContainerNetworkPolicy: true,
+							OverlayNetwork:                "10.10.0.0/16",
+						},
+					)
+				})
+
+				It("allows all container connections", func() {
+					_, err := ruleEnforcer.EnforceOnChain(
+						enforcer.Chain{
+							Table:       "some-table",
+							ParentChain: "some-chain",
+							Name:        "foo",
+							Timestamped: true,
+						},
+						[]rules.IPTablesRule{fakeRule},
+					)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(iptables.NewChainCallCount()).To(Equal(1))
+					Expect(iptables.BulkInsertCallCount()).To(Equal(1))
+					_, _, position, _ := iptables.BulkInsertArgsForCall(0)
+					Expect(position).To(Equal(1))
+
+					table, chain, rulespec := iptables.BulkAppendArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("foo42"))
+					Expect(rulespec).To(Equal([]rules.IPTablesRule{{"-s", "10.10.0.0/16", "-d", "10.10.0.0/16", "-j", "ACCEPT"}, {"rule1"}}))
+				})
 			})
 		})
 	})
-	Describe("EnforceChainMatching", func() {
 
+	Describe("CleanChainMatching", func() {
 		var (
-			iptables     *libfakes.IPTablesAdapter
-			timestamper  *fakes.TimeStamper
-			logger       *lagertest.TestLogger
-			ruleEnforcer *enforcer.Enforcer
-			fakeChain    []enforcer.LiveChain
+			iptables      *libfakes.IPTablesAdapter
+			timestamper   *fakes.TimeStamper
+			logger        *lagertest.TestLogger
+			ruleEnforcer  *enforcer.Enforcer
+			desiredChains []enforcer.LiveChain
 		)
 		BeforeEach(func() {
 
@@ -354,7 +671,7 @@ var _ = Describe("Enforcer", func() {
 			timestamper.CurrentTimeReturns(42)
 			ruleEnforcer = enforcer.NewEnforcer(logger, timestamper, iptables, enforcer.EnforcerConfig{DisableContainerNetworkPolicy: false, OverlayNetwork: "10.10.0.0/16"})
 
-			fakeChain = []enforcer.LiveChain{
+			desiredChains = []enforcer.LiveChain{
 				{
 					Table: "filter",
 					Name:  "asg-bbbbb01645708469990518",
@@ -363,10 +680,14 @@ var _ = Describe("Enforcer", func() {
 					Table: "mangle",
 					Name:  "asg-aaaaa01645708469990518",
 				},
+				{
+					Table: "filter",
+					Name:  "asg-ddddd01645708469990518",
+				},
 			}
 
 			chainsForTable := map[string][]string{
-				"filter": []string{"asg-bbbbb01645708469990518", "asg-ccccc01645708469990518", "donttouchme"},
+				"filter": []string{"asg-bbbbb01645708469990518", "asg-ccccc01645708469990518", "casg-ddddd01645708469990518", "donttouchme"},
 				"mangle": []string{"reallydonttouchme", "asg-aaaaa01645708469990518"},
 			}
 			rulesForChain := map[string][]string{
@@ -382,7 +703,7 @@ var _ = Describe("Enforcer", func() {
 		})
 
 		It("deletes orphaned chains on filter table", func() {
-			deletedChains, err := ruleEnforcer.CleanChainsMatching(regexp.MustCompile(planner.ASGManagedChainsRegex), fakeChain)
+			deletedChains, err := ruleEnforcer.CleanChainsMatching(regexp.MustCompile(enforcer.ASGChainRegex), desiredChains)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(iptables.ListChainsCallCount()).To(Equal(1))
@@ -400,9 +721,9 @@ var _ = Describe("Enforcer", func() {
 			By("not deleting desired chains", func() {
 				for i := 0; i < iptables.DeleteCallCount(); i++ {
 					_, chain := iptables.DeleteChainArgsForCall(i)
-					Expect(chain).ToNot(BeElementOf([]string{"asg-aaaaa01645708469990518", "asg-bbbbb01645708469990518"}))
+					Expect(chain).ToNot(BeElementOf([]string{"asg-aaaaa01645708469990518", "asg-bbbbb01645708469990518", "casg-ddddd01645708469990518"}))
 				}
-				Expect(deletedChains).ToNot(ContainElements([]string{"asg-aaaaa01645708469990518", "asg-bbbbb01645708469990518"}))
+				Expect(deletedChains).ToNot(ContainElements([]string{"asg-aaaaa01645708469990518", "asg-bbbbb01645708469990518", "casg-ddddd01645708469990518"}))
 			})
 			By("not deleting chains outside the scope of our regex", func() {
 				for i := 0; i < iptables.DeleteCallCount(); i++ {
@@ -420,11 +741,12 @@ var _ = Describe("Enforcer", func() {
 
 		Context("when there are no desired chains", func() {
 			It("deletes alls chains on filter table matching pattern", func() {
-				deletedChains, err := ruleEnforcer.CleanChainsMatching(regexp.MustCompile(planner.ASGManagedChainsRegex), []enforcer.LiveChain{})
+				deletedChains, err := ruleEnforcer.CleanChainsMatching(regexp.MustCompile(enforcer.ASGChainRegex), []enforcer.LiveChain{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(deletedChains).To(ConsistOf([]enforcer.LiveChain{
 					{Table: "filter", Name: "asg-bbbbb01645708469990518"},
 					{Table: "filter", Name: "asg-ccccc01645708469990518"},
+					{Table: "filter", Name: "casg-ddddd01645708469990518"},
 				}))
 			})
 		})
@@ -434,7 +756,7 @@ var _ = Describe("Enforcer", func() {
 				iptables.ListChainsReturnsOnCall(0, []string{""}, fmt.Errorf("iptables list error"))
 			})
 			It("returns an error", func() {
-				_, err := ruleEnforcer.CleanChainsMatching(regexp.MustCompile(planner.ASGManagedChainsRegex), fakeChain[0:1])
+				_, err := ruleEnforcer.CleanChainsMatching(regexp.MustCompile(enforcer.ASGChainRegex), desiredChains)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(fmt.Errorf("listing chains in filter: iptables list error")))
 			})
@@ -444,7 +766,7 @@ var _ = Describe("Enforcer", func() {
 				iptables.ListReturns([]string{}, fmt.Errorf("iptables list error"))
 			})
 			It("returns an error", func() {
-				_, err := ruleEnforcer.CleanChainsMatching(regexp.MustCompile(planner.ASGManagedChainsRegex), fakeChain[0:1])
+				_, err := ruleEnforcer.CleanChainsMatching(regexp.MustCompile(enforcer.ASGChainRegex), desiredChains)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(fmt.Errorf("deleting chain asg-ccccc01645708469990518 from table filter: list rules for chain: iptables list error")))
 			})
@@ -454,7 +776,7 @@ var _ = Describe("Enforcer", func() {
 				iptables.DeleteChainReturns(fmt.Errorf("iptables delete chain error"))
 			})
 			It("returns an error", func() {
-				_, err := ruleEnforcer.CleanChainsMatching(regexp.MustCompile(planner.ASGManagedChainsRegex), fakeChain[0:1])
+				_, err := ruleEnforcer.CleanChainsMatching(regexp.MustCompile(enforcer.ASGChainRegex), desiredChains)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(fmt.Errorf("deleting chain asg-ccccc01645708469990518 from table filter: delete old chain: iptables delete chain error")))
 			})
@@ -464,7 +786,7 @@ var _ = Describe("Enforcer", func() {
 				iptables.DeleteChainReturnsOnCall(1, fmt.Errorf("iptables delete chain error"))
 			})
 			It("returns an error", func() {
-				_, err := ruleEnforcer.CleanChainsMatching(regexp.MustCompile(planner.ASGManagedChainsRegex), fakeChain[0:1])
+				_, err := ruleEnforcer.CleanChainsMatching(regexp.MustCompile(enforcer.ASGChainRegex), desiredChains)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(fmt.Errorf("deleting chain asg-ccccc01645708469990518 from table filter: cleanup jump target log-chain: iptables delete chain error")))
 			})
@@ -480,7 +802,7 @@ var _ = Describe("Enforcer", func() {
 					Chain: enforcer.Chain{
 						Table:       "table",
 						ParentChain: "parent",
-						Prefix:      "prefix",
+						Name:        "prefix",
 					},
 					Rules: []rules.IPTablesRule{[]string{"rule1"}},
 				}
@@ -488,7 +810,7 @@ var _ = Describe("Enforcer", func() {
 					Chain: enforcer.Chain{
 						Table:       "table",
 						ParentChain: "parent",
-						Prefix:      "prefix",
+						Name:        "prefix",
 					},
 					Rules: []rules.IPTablesRule{[]string{"rule1"}},
 				}
@@ -537,6 +859,18 @@ var _ = Describe("Enforcer", func() {
 					Expect(ruleSet.Equals(otherRuleSet)).To(BeFalse())
 				})
 			})
+		})
+	})
+
+	Describe("ASGChainName", func() {
+		It("truncates the handle to fit 28 characters of iptables table name limit", func() {
+			handle := "32a7bfc2-699f-495b-51b6-3e18"
+			asgChainName := enforcer.ASGChainName(handle)
+			Expect(asgChainName).To(Equal("asg-32a7bfc2699f495b51b6"))
+
+			handle = "check-65708531-85b6-4e27-4435-eacf293475c7"
+			asgChainName = enforcer.ASGChainName(handle)
+			Expect(asgChainName).To(Equal("asg-6570853185b64e274435"))
 		})
 	})
 })

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/integration/linux/linux_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/integration/linux/linux_test.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 
 	"code.cloudfoundry.org/vxlan-policy-agent/config"
-	"code.cloudfoundry.org/vxlan-policy-agent/planner"
+	"code.cloudfoundry.org/vxlan-policy-agent/enforcer"
 
 	"code.cloudfoundry.org/cf-networking-helpers/mutualtls"
 	"code.cloudfoundry.org/cf-networking-helpers/testsupport/metrics"
@@ -334,19 +334,19 @@ var _ = Describe("VXLAN Policy Agent", func() {
 					})
 
 					It("sets rules for asgs", func() {
-						Eventually(iptablesFilterRules, "4s", "1s").Should(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -m state --state RELATED,ESTABLISHED -j ACCEPT`))
-						Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -p tcp -m state --state INVALID -j DROP`))
-						Expect(iptablesFilterRules()).To(MatchRegexp(`-A netout--some-handle -j asg-\d+`))
-						Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -p icmp -m iprange --dst-range 0.0.0.0-255.255.255.255 -m icmp --icmp-type 0/0 -j ACCEPT`))
-						Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -m iprange --dst-range 11.0.0.0-169.253.255.255 -j ACCEPT`))
-						Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -m iprange --dst-range 0.0.0.0-9.255.255.255 -j ACCEPT`))
-						Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -j REJECT --reject-with icmp-port-unreachable`))
+						Eventually(iptablesFilterRules, "4s", "1s").Should(MatchRegexp(`-A asg-.+ -m state --state RELATED,ESTABLISHED -j ACCEPT`))
+						Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-.+ -p tcp -m state --state INVALID -j DROP`))
+						Expect(iptablesFilterRules()).To(MatchRegexp(`-A netout--some-handle -j asg-.+`))
+						Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-.+ -p icmp -m iprange --dst-range 0.0.0.0-255.255.255.255 -m icmp --icmp-type 0/0 -j ACCEPT`))
+						Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-.+ -m iprange --dst-range 11.0.0.0-169.253.255.255 -j ACCEPT`))
+						Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-.+ -m iprange --dst-range 0.0.0.0-9.255.255.255 -j ACCEPT`))
+						Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-.+ -j REJECT --reject-with icmp-port-unreachable`))
 					})
 
 					It("cleans up the parent asg keeping the reject rule", func() {
 						Eventually(iptablesFilterRules, "4s", "1s").ShouldNot(MatchRegexp(`-A netout--some-handle -m state --state RELATED,ESTABLISHED -j ACCEPT`))
 						Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -p tcp -m state --state INVALID -j DROP`))
-						Expect(iptablesFilterRules()).To(MatchRegexp(`-A netout--some-handle -j asg-\d+`))
+						Expect(iptablesFilterRules()).To(MatchRegexp(`-A netout--some-handle -j asg-.+`))
 						Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -p icmp -m iprange --dst-range 0.0.0.0-255.255.255.255 -m icmp --icmp-type 0/0 -j ACCEPT`))
 						Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -m iprange --dst-range 11.0.0.0-169.253.255.255 -j ACCEPT`))
 						Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -m iprange --dst-range 0.0.0.0-9.255.255.255 -j ACCEPT`))
@@ -372,10 +372,10 @@ var _ = Describe("VXLAN Policy Agent", func() {
 						})
 
 						It("enforces the ASG policies for staging", func() {
-							Eventually(iptablesFilterRules, "4s", "1s").Should(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -p tcp -m iprange --dst-range 10.0.11.0-10.0.11.255 -m tcp --dport 443 -g netout--some-handle--log`))
-							Consistently(iptablesFilterRules, "2s", "1s").Should(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -p tcp -m iprange --dst-range 10.0.11.0-10.0.11.255 -m tcp --dport 80 -g netout--some-handle--log`))
-							Consistently(iptablesFilterRules, "2s", "1s").Should(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -m iprange --dst-range 11.0.0.0-169.253.255.255 -j ACCEPT`))
-							Consistently(iptablesFilterRules, "2s", "1s").Should(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -m iprange --dst-range 0.0.0.0-9.255.255.255 -j ACCEPT`))
+							Eventually(iptablesFilterRules, "4s", "1s").Should(MatchRegexp(`-A asg-.+ -p tcp -m iprange --dst-range 10.0.11.0-10.0.11.255 -m tcp --dport 443 -g netout--some-handle--log`))
+							Consistently(iptablesFilterRules, "2s", "1s").Should(MatchRegexp(`-A asg-.+ -p tcp -m iprange --dst-range 10.0.11.0-10.0.11.255 -m tcp --dport 80 -g netout--some-handle--log`))
+							Consistently(iptablesFilterRules, "2s", "1s").Should(MatchRegexp(`-A asg-.+ -m iprange --dst-range 11.0.0.0-169.253.255.255 -j ACCEPT`))
+							Consistently(iptablesFilterRules, "2s", "1s").Should(MatchRegexp(`-A asg-.+ -m iprange --dst-range 0.0.0.0-9.255.255.255 -j ACCEPT`))
 						})
 					})
 
@@ -392,13 +392,13 @@ var _ = Describe("VXLAN Policy Agent", func() {
 								return resp.StatusCode, nil
 							}).Should(Equal(http.StatusOK))
 
-							Eventually(iptablesFilterRules, "4s", "1s").Should(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -m state --state RELATED,ESTABLISHED -j ACCEPT`))
-							Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -p tcp -m state --state INVALID -j DROP`))
-							Expect(iptablesFilterRules()).To(MatchRegexp(`-A netout--some-handle -j asg-\d+`))
-							Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -p icmp -m iprange --dst-range 0.0.0.0-255.255.255.255 -m icmp --icmp-type 0/0 -j ACCEPT`))
-							Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -m iprange --dst-range 11.0.0.0-169.253.255.255 -j ACCEPT`))
-							Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -m iprange --dst-range 0.0.0.0-9.255.255.255 -j ACCEPT`))
-							Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -j REJECT --reject-with icmp-port-unreachable`))
+							Eventually(iptablesFilterRules, "4s", "1s").Should(MatchRegexp(`-A asg-.+ -m state --state RELATED,ESTABLISHED -j ACCEPT`))
+							Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-.+ -p tcp -m state --state INVALID -j DROP`))
+							Expect(iptablesFilterRules()).To(MatchRegexp(`-A netout--some-handle -j asg-.+`))
+							Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-.+ -p icmp -m iprange --dst-range 0.0.0.0-255.255.255.255 -m icmp --icmp-type 0/0 -j ACCEPT`))
+							Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-.+ -m iprange --dst-range 11.0.0.0-169.253.255.255 -j ACCEPT`))
+							Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-.+ -m iprange --dst-range 0.0.0.0-9.255.255.255 -j ACCEPT`))
+							Expect(iptablesFilterRules()).To(MatchRegexp(`-A asg-.+ -j REJECT --reject-with icmp-port-unreachable`))
 						})
 						Context("when EnableASGSyncing is disabled", func() {
 							BeforeEach(func() {
@@ -413,13 +413,13 @@ var _ = Describe("VXLAN Policy Agent", func() {
 									return resp.StatusCode, nil
 								}).Should(Equal(http.StatusOK))
 
-								Eventually(iptablesFilterRules, "1s", "100ms").ShouldNot(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -m state --state RELATED,ESTABLISHED -j ACCEPT`))
-								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -p tcp -m state --state INVALID -j DROP`))
-								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -j asg-\d+`))
-								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -p icmp -m iprange --dst-range 0.0.0.0-255.255.255.255 -m icmp --icmp-type 0/0 -j ACCEPT`))
-								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -m iprange --dst-range 11.0.0.0-169.253.255.255 -j ACCEPT`))
-								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -m iprange --dst-range 0.0.0.0-9.255.255.255 -j ACCEPT`))
-								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -j REJECT --reject-with icmp-port-unreachable`))
+								Eventually(iptablesFilterRules, "1s", "100ms").ShouldNot(MatchRegexp(`-A asg-.+ -m state --state RELATED,ESTABLISHED -j ACCEPT`))
+								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A asg-.+ -p tcp -m state --state INVALID -j DROP`))
+								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -j asg-.+`))
+								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A asg-.+ -p icmp -m iprange --dst-range 0.0.0.0-255.255.255.255 -m icmp --icmp-type 0/0 -j ACCEPT`))
+								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A asg-.+ -m iprange --dst-range 11.0.0.0-169.253.255.255 -j ACCEPT`))
+								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A asg-.+ -m iprange --dst-range 0.0.0.0-9.255.255.255 -j ACCEPT`))
+								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A asg-.+ -j REJECT --reject-with icmp-port-unreachable`))
 
 							})
 						})
@@ -427,7 +427,7 @@ var _ = Describe("VXLAN Policy Agent", func() {
 
 					Describe("the force orphaned asgs cleanup endpoint", func() {
 						It("should not delete the asg chain referenced in netout chain", func() {
-							Eventually(iptablesFilterRules, "4s", "1s").Should(MatchRegexp(`-A asg-[a-zA-Z0-9]+ -m state --state RELATED,ESTABLISHED -j ACCEPT`))
+							Eventually(iptablesFilterRules, "4s", "1s").Should(MatchRegexp(`-A asg-.+ -m state --state RELATED,ESTABLISHED -j ACCEPT`))
 
 							Eventually(func() (int, error) {
 								resp, err := http.Get(fmt.Sprintf("http://%s:%d/force-orphaned-asgs-cleanup?container=some-handle", conf.ForcePolicyPollCycleHost, conf.ForcePolicyPollCyclePort))
@@ -437,13 +437,13 @@ var _ = Describe("VXLAN Policy Agent", func() {
 								return resp.StatusCode, nil
 							}).Should(Equal(http.StatusInternalServerError))
 
-							Consistently(iptablesFilterRules, "4s", "1s").Should(MatchRegexp(`-A netout--some-handle -j asg-\d+`))
+							Consistently(iptablesFilterRules, "4s", "1s").Should(MatchRegexp(`-A netout--some-handle -j asg-.+`))
 						})
 
 						Context("when EnableASGSyncing is disabled", func() {
 							BeforeEach(func() {
 								conf.EnableASGSyncing = false
-								runIptablesCommand("-N", planner.ASGChainPrefix("some-handle")+"11111111")
+								runIptablesCommand("-N", enforcer.ASGChainName("some-handle"))
 							})
 
 							It("doesn't clean up iptables", func() {
@@ -455,7 +455,7 @@ var _ = Describe("VXLAN Policy Agent", func() {
 									return resp.StatusCode, nil
 								}).Should(Equal(http.StatusMethodNotAllowed))
 
-								Consistently(iptablesFilterRules, "4s", "1s").Should(MatchRegexp(`-N asg-[a-zA-Z0-9]+`))
+								Consistently(iptablesFilterRules, "4s", "1s").Should(MatchRegexp(`-N asg-.+`))
 							})
 						})
 					})
@@ -464,13 +464,13 @@ var _ = Describe("VXLAN Policy Agent", func() {
 				Context("when netout chain does not exist", func() {
 					It("does not create asg chain", func() {
 						Eventually(iptablesFilterRules, "4s", "1s").ShouldNot(MatchRegexp(`-N netout--some-handle`))
-						Consistently(iptablesFilterRules, "2s", "1s").ShouldNot(MatchRegexp(`-A netout--some-handle -j asg-\d+`))
+						Consistently(iptablesFilterRules, "2s", "1s").ShouldNot(MatchRegexp(`-A netout--some-handle -j asg-.+`))
 						Consistently(iptablesFilterRules, "2s", "1s").ShouldNot(MatchRegexp(`-A FORWARD -s \d+\.\d+\.\d+.\d+/\d+ -o eth0 -j netout--some-handle`))
 					})
 
 					Context("when there is an asg chain", func() {
 						BeforeEach(func() {
-							runIptablesCommand("-N", planner.ASGChainPrefix("some-handle")+"11111111")
+							runIptablesCommand("-N", enforcer.ASGChainName("some-handle"))
 						})
 
 						It("forcing orphaned chains cleanup deletes the chain", func() {
@@ -482,7 +482,8 @@ var _ = Describe("VXLAN Policy Agent", func() {
 								return resp.StatusCode, nil
 							}).Should(Equal(http.StatusOK))
 
-							Eventually(iptablesFilterRules, "4s", "1s").ShouldNot(MatchRegexp(`-A asg-[a-zA-Z0-9]+`))
+							Eventually(iptablesFilterRules, "4s", "1s").ShouldNot(MatchRegexp(`-N asg-.+`))
+							Eventually(iptablesFilterRules, "4s", "1s").ShouldNot(MatchRegexp(`-A asg-.+`))
 						})
 					})
 				})

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner.go
@@ -1,9 +1,7 @@
 package planner
 
 import (
-	"crypto/sha1"
 	"encoding/json"
-	"fmt"
 	"sort"
 	"time"
 
@@ -72,14 +70,6 @@ type netOutChain interface {
 const metricContainerMetadata = "containerMetadataTime"
 const metricPolicyServerPoll = "policyServerPollTime"
 const metricPolicyServerASGPoll = "policyServerASGPollTime"
-
-func ASGChainPrefix(handle string) string {
-	h := sha1.New()
-	h.Write([]byte(handle))
-	smallHash := h.Sum(nil)
-
-	return fmt.Sprintf("asg-%x", smallHash[0:3]) //only need 6 digits so we use 3.
-}
 
 func (p *VxlanPolicyPlanner) readFile(specifiedContainers ...string) ([]container, error) {
 	containerMetadataStartTime := time.Now()

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner_linux.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner_linux.go
@@ -118,8 +118,6 @@ func (s ingressSlice) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-const ASGManagedChainsRegex = `asg-[a-z0-9]{6}`
-
 func (p *VxlanPolicyPlanner) GetPolicyRulesAndChain() (enforcer.RulesWithChain, error) {
 	allContainers, err := p.readFile()
 	if err != nil {
@@ -206,13 +204,7 @@ func (p *VxlanPolicyPlanner) GetASGRulesAndChains(specifiedContainers ...string)
 		}
 
 		rulesWithChains = append(rulesWithChains, enforcer.RulesWithChain{
-			Chain: enforcer.Chain{
-				Table:              enforcer.FilterTable,
-				ParentChain:        parentChainName,
-				Prefix:             ASGChainPrefix(container.Handle),
-				ManagedChainsRegex: ASGManagedChainsRegex,
-				CleanUpParentChain: true,
-			},
+			Chain:     enforcer.NewASGChain(parentChainName, container.Handle),
 			Rules:     reverseOrderIptablesRules(iptablesRules, defaultRules),
 			LogConfig: container.LogConfig,
 		})

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner_linux_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner_linux_test.go
@@ -152,7 +152,7 @@ var _ = Describe("Planner", func() {
 		chain = enforcer.Chain{
 			Table:       "some-table",
 			ParentChain: "INPUT",
-			Prefix:      "some-prefix",
+			Name:        "some-prefix",
 		}
 
 		policyPlanner = &planner.VxlanPolicyPlanner{
@@ -876,9 +876,8 @@ var _ = Describe("Planner", func() {
 					Expect(containerRules1.Rules).To(Equal([]rules.IPTablesRule{{"rule-2"}, {"rule-1"}}))
 					Expect(containerRules2.Rules).To(Equal([]rules.IPTablesRule{{"rule-4"}, {"rule-3"}}))
 
-					Expect([]string{containerRules1.Chain.Prefix, containerRules2.Chain.Prefix}).To(ConsistOf("asg-498471", "asg-2a07ad"))
-					Expect([]string{containerRules1.Chain.ManagedChainsRegex, containerRules2.Chain.ManagedChainsRegex}).To(ConsistOf(planner.ASGManagedChainsRegex, planner.ASGManagedChainsRegex))
-					Expect([]bool{containerRules1.Chain.CleanUpParentChain, containerRules2.Chain.CleanUpParentChain}).To(ConsistOf(true, true))
+					Expect([]string{containerRules1.Chain.Name, containerRules2.Chain.Name}).To(ConsistOf("asg-containerid1", "asg-containerid2"))
+					Expect([]bool{containerRules1.Chain.Timestamped, containerRules2.Chain.Timestamped}).To(ConsistOf(false, false))
 
 					Expect(netOutChain.IPTablesRulesCallCount()).To(Equal(2))
 
@@ -959,8 +958,8 @@ var _ = Describe("Planner", func() {
 						Expect(containerRules2.Rules).To(Equal([]rules.IPTablesRule{{"rule-4"}, {"rule-3"}}))
 
 						By("assigning unique prefixes to each container")
-						Expect([]string{containerRules1.Chain.Prefix, containerRules2.Chain.Prefix}).To(ConsistOf("asg-498471", "asg-2a07ad"))
-						Expect([]string{containerRules1.Chain.ManagedChainsRegex, containerRules2.Chain.ManagedChainsRegex}).To(ConsistOf(planner.ASGManagedChainsRegex, planner.ASGManagedChainsRegex))
+						Expect([]string{containerRules1.Chain.Name, containerRules2.Chain.Name}).To(ConsistOf("asg-containerid1", "asg-containerid2"))
+						Expect([]bool{containerRules1.Chain.Timestamped, containerRules2.Chain.Timestamped}).To(ConsistOf(false, false))
 
 						Expect(netOutChain.IPTablesRulesCallCount()).To(Equal(2))
 


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
Using shortened sha1 is prone to collisions.

Instead of using sha1 of container guids, getting 6 characters and adding timestamp use container guid up to 24 characters. Similar to how netout and overlay chains are created. The new format:

asg-{container-guid[:20]}

In this case container-guid is stripped from dashes and `check` prefix used in health check containers.

To replace ASG chain, a temporary chain is created with prefix `casg-` (candidate ASG chain). It is populated with new rules and appened to parent chain (netout). Then original ASG chain is deleted. And `casg-` chain is renamed to `asg-` chain. This is done to avoid incorrect state if any of operations fail.

force-orphaned-asgs-cleanup endpoint now will be deleting ASG chain by container guid looking specifically for chain name and candidate chain name instead of using regex. Since we are not using timestamps and regex is not needed.


Backward Compatibility
---------------
Breaking Change? **No**

