### PR TITLE
Revert "Support IP addresses with leading zeros"

### DIFF
--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/security_group_rule_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/security_group_rule_test.go
@@ -21,15 +21,6 @@ var _ = Describe("SecurityGroupRule", func() {
 			Expect(rule.Networks()).To(Equal([]netrules.IPRange{{Start: net.IPv4(10, 0, 0, 1), End: net.IPv4(10, 0, 0, 1)}}))
 		})
 
-		It("parses an ip address with leading zeros", func() {
-			securityGroupRule := policy_client.SecurityGroupRule{
-				Destination: "010.001.000.1",
-			}
-			rule, err := netrules.NewRuleFromSecurityGroupRule(securityGroupRule)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(rule.Networks()).To(Equal([]netrules.IPRange{{Start: net.IPv4(10, 1, 0, 1), End: net.IPv4(10, 1, 0, 1)}}))
-		})
-
 		It("parses a cidr", func() {
 			securityGroupRule := policy_client.SecurityGroupRule{
 				Destination: "10.0.0.0/24",
@@ -39,27 +30,9 @@ var _ = Describe("SecurityGroupRule", func() {
 			Expect(rule.Networks()).To(Equal([]netrules.IPRange{{Start: net.IPv4(10, 0, 0, 0).To4(), End: net.IPv4(10, 0, 0, 255).To4()}}))
 		})
 
-		It("parses a cidr with leading zeros", func() {
-			securityGroupRule := policy_client.SecurityGroupRule{
-				Destination: "010.001.000.0/24",
-			}
-			rule, err := netrules.NewRuleFromSecurityGroupRule(securityGroupRule)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(rule.Networks()).To(Equal([]netrules.IPRange{{Start: net.IPv4(10, 1, 0, 0).To4(), End: net.IPv4(10, 1, 0, 255).To4()}}))
-		})
-
 		It("parses an ip range", func() {
 			securityGroupRule := policy_client.SecurityGroupRule{
 				Destination: "10.0.0.1-10.0.1.10",
-			}
-			rule, err := netrules.NewRuleFromSecurityGroupRule(securityGroupRule)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(rule.Networks()).To(Equal([]netrules.IPRange{{Start: net.IPv4(10, 0, 0, 1), End: net.IPv4(10, 0, 1, 10)}}))
-		})
-
-		It("parses an ip range with leading zeros", func() {
-			securityGroupRule := policy_client.SecurityGroupRule{
-				Destination: "10.00.000.01-10.000.001.010",
 			}
 			rule, err := netrules.NewRuleFromSecurityGroupRule(securityGroupRule)
 			Expect(err).NotTo(HaveOccurred())
@@ -106,33 +79,9 @@ var _ = Describe("SecurityGroupRule", func() {
 				}))
 			})
 
-			It("parses two ip addresses with leading zeros", func() {
-				securityGroupRule := policy_client.SecurityGroupRule{
-					Destination: "10.0.00.01,192.168.000.001",
-				}
-				rule, err := netrules.NewRuleFromSecurityGroupRule(securityGroupRule)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(rule.Networks()).To(Equal([]netrules.IPRange{
-					{Start: net.IPv4(10, 0, 0, 1), End: net.IPv4(10, 0, 0, 1)},
-					{Start: net.IPv4(192, 168, 0, 1), End: net.IPv4(192, 168, 0, 1)},
-				}))
-			})
-
 			It("parses all three possible destinations together: address, cidr, and range", func() {
 				securityGroupRule := policy_client.SecurityGroupRule{
 					Destination: "1.1.1.1,192.168.0.0/24,10.0.0.1-10.0.1.10",
-				}
-				rule, err := netrules.NewRuleFromSecurityGroupRule(securityGroupRule)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(rule.Networks()).To(Equal([]netrules.IPRange{
-					{Start: net.IPv4(1, 1, 1, 1), End: net.IPv4(1, 1, 1, 1)},
-					{Start: net.IPv4(192, 168, 0, 0).To4(), End: net.IPv4(192, 168, 0, 255).To4()},
-					{Start: net.IPv4(10, 0, 0, 1), End: net.IPv4(10, 0, 1, 10)},
-				}))
-			})
-			It("parses all three possible destinations together: address, cidr, and range with leading zeros", func() {
-				securityGroupRule := policy_client.SecurityGroupRule{
-					Destination: "1.1.1.001,192.168.0000.0/24,10.0.0.1-10.000.01.010",
 				}
 				rule, err := netrules.NewRuleFromSecurityGroupRule(securityGroupRule)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

### Summary

This reverts commit d350e6f134d078bad5cc3e83aecd668fac773aac.

Originally we were going to support leading zeros on the gorouter side of things. Instead, we are choosing to prevent any leading zeros from making it into the system.

See new PR to cloud controller: https://github.com/cloudfoundry/cloud_controller_ng/pull/3829

[#187494337](https://www.pivotaltracker.com/story/show/187494337)

### Backward Compatibility
Breaking Change? No

This never worked to begin with.