### PR TITLE
retry VPA's pre-start up to 15 times on failure FlushingAndRestoring

### DIFF
--- a/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/pre-start/main.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/pre-start/main.go
@@ -17,6 +17,7 @@ const (
 	IngressChainName = "istio-ingress"
 	jobPrefix        = "silk-daemon-bootstrap"
 	logPrefix        = "cfnetworking"
+	MAX_RETRIES      = 15
 )
 
 func main() {
@@ -27,15 +28,17 @@ func main() {
 	if err != nil {
 		log.Fatalf("Could not initialize iptables adapter: %s", err)
 	}
+
 	err = PreStart(ipTablesAdapter)
 	if err != nil {
-		log.Fatalf("pre-start error: %s", err)
+		log.Fatalf("pre-start failed after %d attempts - giving up", MAX_RETRIES)
 	}
 }
 
 func PreStart(ipTablesAdapter rules.IPTablesAdapter) error {
-
-	return ipTablesAdapter.FlushAndRestore(`*filter
+	var err error
+	for i := 0; i < MAX_RETRIES; i++ {
+		err = ipTablesAdapter.FlushAndRestore(`*filter
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
@@ -47,6 +50,13 @@ COMMIT
 :POSTROUTING ACCEPT [0:0]
 COMMIT
 `)
+		if err != nil {
+			log.Printf("pre-start error: %s", err)
+		} else {
+			break
+		}
+	}
+	return err
 }
 
 func createIpTablesAdapter(iptablesLockFile string) (rules.IPTablesAdapter, error) {

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/pre-start/main_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/pre-start/main_test.go
@@ -23,11 +23,37 @@ var _ = Describe("Pre-Start", func() {
 		Expect(fakeIpTables.FlushAndRestoreCallCount()).To(Equal(1))
 		Expect(fakeIpTables.FlushAndRestoreArgsForCall(0)).To(Equal("*filter\n:INPUT ACCEPT [0:0]\n:FORWARD ACCEPT [0:0]\n:OUTPUT ACCEPT [0:0]\nCOMMIT\n*nat\n:PREROUTING ACCEPT [0:0]\n:INPUT ACCEPT [0:0]\n:OUTPUT ACCEPT [0:0]\n:POSTROUTING ACCEPT [0:0]\nCOMMIT\n"))
 	})
-	It("propagates errors up when encountered", func() {
-		fakeIpTables.FlushAndRestoreReturns(fmt.Errorf("iptables borked"))
-		err := main.PreStart(fakeIpTables)
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(MatchError("iptables borked"))
+	Context("when the PreStart() iptables flush and restore fails", func() {
+		BeforeEach(func() {
+			fakeIpTables.FlushAndRestoreReturns(fmt.Errorf("iptables borked"))
+		})
 
+		It("retries up to MAX_RETRIES times", func() {
+			err := main.PreStart(fakeIpTables)
+			Expect(err).To(HaveOccurred())
+			Expect(fakeIpTables.FlushAndRestoreCallCount()).To(Equal(main.MAX_RETRIES))
+
+		})
+
+		It("propagates errors up when encountered", func() {
+			err := main.PreStart(fakeIpTables)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("iptables borked"))
+		})
+
+		Context("and eventually succeeds", func() {
+			BeforeEach(func() {
+				fakeIpTables.FlushAndRestoreReturnsOnCall(0, fmt.Errorf("iptables borked"))
+				fakeIpTables.FlushAndRestoreReturnsOnCall(1, fmt.Errorf("iptables borked"))
+				fakeIpTables.FlushAndRestoreReturnsOnCall(2, fmt.Errorf("iptables borked"))
+				fakeIpTables.FlushAndRestoreReturnsOnCall(3, nil)
+			})
+
+			It("retries and then clears the iptables rules", func() {
+				err := main.PreStart(fakeIpTables)
+				Expect(fakeIpTables.FlushAndRestoreCallCount()).To(Equal(4))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
 	})
 })


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Retries VPA's pre-start iptables FlushAndRestore so that intermittent failures encountered by iptables or while obtaining the iptables lock do not cause deployment failures for CF.


Backward Compatibility
---------------
Breaking Change? **NOPE**