### PR TITLE
Skip deleting MARK jump target

### DIFF
--- a/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer.go
@@ -435,7 +435,7 @@ func (e *Enforcer) candidateChainName(name string) string {
 
 func (e *Enforcer) isChainJumpTarget(jumpTargetName string) bool {
 	switch jumpTargetName {
-	case "ACCEPT", "REJECT", "LOG", "DROP":
+	case "ACCEPT", "REJECT", "LOG", "DROP", "MARK":
 		return false
 	default:
 		return true


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
iptables extension we use adds MARK as a special jump target that we should ignore to clean up when deleting the chain


Backward Compatibility
---------------
Breaking Change? **No**
