### PR TITLE
Address integer overflows when downcasting for G115

### DIFF
--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/security_group_rule.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/security_group_rule.go
@@ -62,20 +62,22 @@ func (r *securityGroupRule) Ports() []PortRange {
 	for _, portRangeStr := range portRangeStrs {
 		ports := strings.Split(portRangeStr, "-")
 		if len(ports) == 1 {
-			port, err := strconv.Atoi(strings.TrimSpace(ports[0]))
+			port, err := strconv.ParseUint(strings.TrimSpace(ports[0]), 10, 16)
 			if err != nil {
 				continue
 			}
+			// #nosec G115 - ParseUint above validates the int range here
 			portRanges = append(portRanges, PortRange{Start: uint16(port), End: uint16(port)})
 		} else if len(ports) == 2 {
-			startPort, err := strconv.Atoi(strings.TrimSpace(ports[0]))
+			startPort, err := strconv.ParseUint(strings.TrimSpace(ports[0]), 10, 16)
 			if err != nil {
 				continue
 			}
-			endPort, err := strconv.Atoi(strings.TrimSpace(ports[1]))
+			endPort, err := strconv.ParseUint(strings.TrimSpace(ports[1]), 10, 16)
 			if err != nil {
 				continue
 			}
+			// #nosec G115 - ParseUint above validates the int range here
 			portRanges = append(portRanges, PortRange{Start: uint16(startPort), End: uint16(endPort)})
 		}
 	}
@@ -84,7 +86,9 @@ func (r *securityGroupRule) Ports() []PortRange {
 
 func (r *securityGroupRule) ICMPInfo() *ICMPInfo {
 	return &ICMPInfo{
+		// #nosec G115 - CAPI validates these as -1 to 255, and we make use of -1 as a short-hand for "all" types/codes (255)
 		Type: garden.ICMPType(r.rule.Type),
+		// #nosec G115 - CAPI validates these as -1 to 255, and we make use of -1 as a short-hand for "all" types/codes (255)
 		Code: garden.ICMPCode(r.rule.Code),
 	}
 }

--- a/src/code.cloudfoundry.org/silk/controller/leaser/cidrpool.go
+++ b/src/code.cloudfoundry.org/silk/controller/leaser/cidrpool.go
@@ -20,8 +20,17 @@ func NewCIDRPool(subnetRange string, subnetMask int) *CIDRPool {
 	}
 	cidrMask, _ := ipCIDR.Mask.Size()
 
+	if cidrMask > 32 || cidrMask < 0 {
+		panic(fmt.Errorf("subnet range's CIDR mask must be between [0-32]"))
+	}
+	if subnetMask > 32 || subnetMask < 0 {
+		panic(fmt.Errorf("subnet mask must be between [0-32]"))
+	}
+
 	return &CIDRPool{
-		blockPool:  generateBlockPool(ipCIDR.IP, uint(cidrMask), uint(subnetMask)),
+		// #nosec - G115 - we check valid values above for IPv4 subnet masks
+		blockPool: generateBlockPool(ipCIDR.IP, uint(cidrMask), uint(subnetMask)),
+		// #nosec - G115 - we check valid values above for IPv4 subnet masks
 		singlePool: generateSingleIPPool(ipCIDR.IP, uint(subnetMask)),
 	}
 }


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Some additional error checking, and some ignoring of the alert on a case by case basis since we want to handle "-1" as valid icmp codes/types.

Backward Compatibility
---------------
Breaking Change? yes