### PR TITLE
Add retry logic for LinkList and AddrList netlink calls in cni

### DIFF
--- a/src/code.cloudfoundry.org/lib/common/common.go
+++ b/src/code.cloudfoundry.org/lib/common/common.go
@@ -2,10 +2,53 @@ package common
 
 import (
 	"code.cloudfoundry.org/lager/v3/lagerflags"
+	"fmt"
+	"math"
+	"syscall"
+	"time"
 )
+
+type RetryableFunc[T any] func() (T, error)
 
 func GetLagerConfig() lagerflags.LagerConfig {
 	lagerConfig := lagerflags.DefaultLagerConfig()
 	lagerConfig.TimeFormat = lagerflags.FormatRFC3339
 	return lagerConfig
+}
+
+// RetryWithBackoff retries a given function up to maxRetries times, with exponential backoff between attempts.
+// interval is the initial interval between retries in milliseconds.
+// T is a generic type parameter representing the return type of the function being retried.
+// fn is the function to be retried, which returns a value of type T and an error.
+func RetryWithBackoff[T any](interval int, maxRetries int, fn RetryableFunc[T]) (T, error) {
+	var result T
+	var err error
+	retryInterval := time.Duration(interval) * time.Millisecond
+
+	for retry := 0; retry < maxRetries; retry++ {
+		// Attempt the operation
+		result, err = fn()
+		if err == nil {
+			return result, nil // Success
+		}
+
+		// If the error is retryable, wait and retry
+		if isRetryableError(err) {
+			time.Sleep(time.Duration(math.Pow(2, float64(retry))) * retryInterval)
+			continue
+		}
+
+		// If error is not retryable, return it immediately
+		return result, err
+	}
+
+	// Retries exhausted, return the last error
+	return result, fmt.Errorf("failed after %d maxRetries: %w", maxRetries, err)
+}
+
+func isRetryableError(err error) bool {
+	if errno, ok := err.(syscall.Errno); ok {
+		return errno.Temporary()
+	}
+	return false
 }

--- a/src/code.cloudfoundry.org/lib/common/common_suite_test.go
+++ b/src/code.cloudfoundry.org/lib/common/common_suite_test.go
@@ -1,0 +1,13 @@
+package common_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommon(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Common Suite")
+}

--- a/src/code.cloudfoundry.org/lib/common/common_test.go
+++ b/src/code.cloudfoundry.org/lib/common/common_test.go
@@ -1,0 +1,110 @@
+package common_test
+
+import (
+	"code.cloudfoundry.org/lib/common"
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"time"
+)
+
+// Mock retryable error that implements temporaryError
+type mockTemporaryError struct {
+	msg string
+}
+
+func (e *mockTemporaryError) Error() string   { return e.msg }
+func (e *mockTemporaryError) Temporary() bool { return true }
+
+// Mock non-retryable error that does not implement temporaryError
+type mockNonRetryableError struct {
+	msg string
+}
+
+func (e *mockNonRetryableError) Error() string { return e.msg }
+
+var _ = Describe("Retry With Backoff", func() {
+	var (
+		callCount int
+	)
+
+	BeforeEach(func() {
+		callCount = 0
+	})
+
+	Context("when function succeeds the first try", func() {
+		It("returns result without retries", func() {
+			fn := func() (int, error) {
+				callCount++
+				return 42, nil
+			}
+
+			result, err := common.RetryWithBackoff(100, 3, fn)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(42))
+			Expect(callCount).To(Equal(1))
+		})
+	})
+
+	Context("when function fails with a non-retryable error", func() {
+		It("returns the error immediately", func() {
+			fn := func() (int, error) {
+				callCount++
+				return 0, &mockNonRetryableError{"non-retryable error"}
+			}
+
+			result, err := common.RetryWithBackoff(100, 3, fn)
+			Expect(err).To(MatchError("non-retryable error"))
+			Expect(result).To(Equal(0))
+			Expect(callCount).To(Equal(1))
+		})
+	})
+
+	Context("when function fails with a retryable error", func() {
+		It("retries the function up to maxRetries times and eventually succeeds", func() {
+			fn := func() (int, error) {
+				callCount++
+				if callCount == 3 {
+					return 42, nil
+				}
+				return 0, &mockTemporaryError{"retryable error"}
+			}
+
+			result, err := common.RetryWithBackoff(100, 3, fn)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(42))
+			Expect(callCount).To(Equal(3))
+		})
+	})
+
+	Context("when the maxRetries are exhausted", func() {
+		It("returns the last error", func() {
+			fn := func() (int, error) {
+				callCount++
+				return 0, &mockTemporaryError{fmt.Sprintf("retryable error %d", callCount)}
+			}
+
+			result, err := common.RetryWithBackoff(100, 3, fn)
+			Expect(err).To(MatchError(fmt.Sprintf("failed after 3 maxRetries: retryable error %d", 3)))
+			Expect(result).To(Equal(0))
+			Expect(callCount).To(Equal(3))
+		})
+	})
+
+	Context("exponential backoff timing", func() {
+		It("should do exponential backoff each retry", func() {
+			start := time.Now()
+
+			fn := func() (int, error) {
+				return 0, &mockTemporaryError{msg: "temporary error"}
+			}
+
+			common.RetryWithBackoff(50, 3, fn)
+			elapsed := time.Since(start)
+
+			// 50ms * (2^0 + 2^1 + 2^2) = 350ms
+			expectedTime := 350 * time.Millisecond
+			Expect(elapsed).To(BeNumerically(">=", expectedTime))
+		})
+	})
+})


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Add retry logic for LinkList and AddrList netlink calls.
This is needed because the latest netlink go lib(v1.3.0) handles NLM_F_DUMP_INTR when executing requests and returns error if that flag is returned, which wasn't happening in the previous version and thus the networking setup for containers fails in some cases which results in LRPs in crashed state.

Issue: https://github.com/cloudfoundry/silk-release/issues/146

Backward Compatibility
---------------
Breaking Change? No
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
