### PR TITLE
Multiple network overlay cidrs

### DIFF
--- a/jobs/silk-cni/spec
+++ b/jobs/silk-cni/spec
@@ -10,8 +10,6 @@ packages:
   - silk-cni
 
 consumes:
-- name: cf_network
-  type: cf_network
 - name: vpa
   type: policy-agent
 
@@ -31,7 +29,10 @@ provides:
 
 properties:
   no_masquerade_cidr_range:
-    description: "CIDR address block that should not be masqueraded.  Fallsback to cf_network.network link property if property is not provided."
+    description: |
+        When set, app traffic sent to this CIDR will not be masqueraded. If this
+        property is not set, then silk-cni will not masquerade traffic sent to the
+        overlay network, which allows container-to-container networking to work.
     default: ""
 
   mtu:

--- a/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
+++ b/jobs/silk-cni/templates/cni-wrapper-plugin.conflist.erb
@@ -31,16 +31,12 @@
   end
 
   def no_masquerade_cidr_range
-    if_p('no_masquerade_cidr_range') do |no_masquerade_cidr_range|
-      if no_masquerade_cidr_range.empty?
-        if_link('cf_network') do |link|
-          return link.p('network')
-        end
-      else
-        parse_ip(no_masquerade_cidr_range, 'no_masquerade_cidr_range')
+    if_p('no_masquerade_cidr_range') do |cidr|
+      if !cidr.empty?
+        parse_ip(cidr, 'no_masquerade_cidr_range')
       end
 
-      return no_masquerade_cidr_range
+      return p('no_masquerade_cidr_range')
     end
   end
 

--- a/jobs/silk-controller/spec
+++ b/jobs/silk-controller/spec
@@ -29,8 +29,12 @@ provides:
 
 properties:
   network:
-    description: "CIDR address block for overlay network.  Subnets for each diego cell are allocated out of this network."
-    default: "10.255.0.0/16"
+    description: |
+      A single CIDR address block as a string, or an array of CIDR address
+      blocks for overlay network as an array of strings. Subnets for each diego
+      cell are allocated out of this network. The "subnet_prefix_length"
+      property must be smaller than the smallest CIDR address block.
+    default: ["10.255.0.0/16"]
 
   subnet_prefix_length:
     description: "Length, in bits, of the prefix for subnets allocated per Diego cell, e.g. '24' for a '/24' subnet."

--- a/jobs/silk-controller/templates/silk-controller.json.erb
+++ b/jobs/silk-controller/templates/silk-controller.json.erb
@@ -50,25 +50,65 @@
       raise 'subnet_prefix_length must be a value between 1-30'
     end
 
-    network = p('network')
-    if IPAddr.new(network).prefix >= size
-      raise "subnet_prefix_length '#{size}' must be smaller than the network '#{network.to_s}'"
+    network = network_array
+
+    network.each do |entry|
+      if IPAddr.new(entry).prefix >= size
+        raise "subnet_prefix_length '#{size}' must be smaller than the network '#{entry.to_s}'"
+      end
     end
 
-    size
+    return size
   end
 
-  def parse_ip (ip, var_name)
-    unless ip.empty?
-        begin
-          parsed = IPAddr.new ip
-        rescue  => e
-          raise "Invalid #{var_name} '#{ip}': #{e}"
+  # parse_ips requres ips to be an array
+  def parse_ips (ips, var_name)
+    if ips.empty? == false
+
+      # first check that each ip in the array is valid
+      ips.each_with_index do |entry, i|
+          parse_ip(entry, var_name)
+      end
+
+      # then check that none of the cidrs overlap
+      ips.each_with_index do |ip1, i|
+        ips.each_with_index do |ip2, j|
+          next if i == j
+          overlap?(ip1, ip2)
         end
+      end
     end
   end
 
-  parse_ip(p('network'), 'network')
+  def parse_ip(ip, var_name)
+    begin
+      parsed = IPAddr.new(ip)
+    rescue  => e
+      raise "Invalid #{var_name} '#{ip}': #{e}"
+    end
+  end
+
+  def overlap?(a, b)
+    cidr1 = IPAddr.new(a)
+    cidr2 = IPAddr.new(b)
+
+    range = cidr2.to_range
+    starting_ip = range.first
+    ending_ip = range.last
+
+    if cidr1.include?(starting_ip) || cidr1.include?(ending_ip)
+      raise "'network' must not contain overlapping cidrs: '#{a}' and '#{b}'"
+    end
+  end
+
+  def network_array
+    network = p('network')
+    return [network] if network.class != Array
+    return network
+  end
+
+
+  parse_ips(network_array, 'network')
   parse_ip(p('listen_ip'), 'listen_ip')
 
   toRender = {
@@ -79,7 +119,7 @@
     'ca_cert_file' => '/var/vcap/jobs/silk-controller/config/certs/ca.crt',
     'server_cert_file' => '/var/vcap/jobs/silk-controller/config/certs/server.crt',
     'server_key_file' => '/var/vcap/jobs/silk-controller/config/certs/server.key',
-    'network' => p('network'),
+    'network' => network_array,
     'subnet_prefix_length' => subnet_prefix_length,
     'database' => {
       'type' => driver,

--- a/jobs/silk-daemon/spec
+++ b/jobs/silk-daemon/spec
@@ -88,7 +88,13 @@ properties:
     default: false
 
   single_ip_only:
-    description: "When true, this VM will get assigned exactly one IP address on the Silk network.  Use this to connect this VM to the Silk network without acquiring a whole block of addresses (as would be required for a Diego Cell)."
+    description: |
+        When true, this VM will get assigned exactly one IP address on the Silk
+        network.  Use this to connect this VM to the Silk network without
+        acquiring a whole block of addresses (as would be required for a Diego
+        Cell). WARNING: Do not use single_ip_only mode when the overylay network has
+        more than one CIDR. The overlay network is set on the silk-controller
+        job via the "network" bosh property.
     default: false
 
   policy_server_url:

--- a/jobs/silk-daemon/templates/client-config.json.erb
+++ b/jobs/silk-daemon/templates/client-config.json.erb
@@ -1,6 +1,12 @@
 <%=
   require 'json'
 
+  def network_array
+    network = link('cf_network').p('network')
+    return [network] if network.class != Array
+    return network
+  end
+
   def subnet_prefix_length
     size = link('cf_network').p('subnet_prefix_length')
     if size < 1 || size > 30
@@ -36,7 +42,7 @@
   toRender = {
     'underlay_ip' => underlay_ip,
     'subnet_prefix_length' => subnet_prefix_length,
-    'overlay_network' => link('cf_network').p('network'),
+    'overlay_network' => network_array,
     'health_check_port' => p('listen_port'),
     'vtep_name' => 'silk-vtep',
     'connectivity_server_url' => silk_controller_url,

--- a/jobs/vxlan-policy-agent/templates/vxlan-policy-agent.json.erb
+++ b/jobs/vxlan-policy-agent/templates/vxlan-policy-agent.json.erb
@@ -1,6 +1,12 @@
 <%=
     require 'json'
 
+  def network_array
+    network = link('cf_network').p('network')
+    return [network] if network.class != Array
+    return network
+  end
+
     toRender = {
       'log_level' => p('log_level'),
       'log_prefix' => 'cfnetworking',
@@ -30,7 +36,7 @@
       'force_policy_poll_cycle_port' => p('force_policy_poll_cycle_port'),
       'enable_overlay_ingress_rules' => p('enable_overlay_ingress_rules'),
       "disable_container_network_policy" => p("disable_container_network_policy"),
-      'overlay_network' => link('cf_network').p('network'),
+      'overlay_network' => network_array,
 
       # hard-coded values, not exposed as bosh spec properties
       'ca_cert_file' => '/var/vcap/jobs/vxlan-policy-agent/config/certs/ca.crt',

--- a/packages/silk-controller/spec
+++ b/packages/silk-controller/spec
@@ -20,6 +20,7 @@ files:
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/v3/*.go # gosub-main-module
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/v3/internal/truncate/*.go # gosub-main-module
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/v3/lagerflags/*.go # gosub-main-module
+  - code.cloudfoundry.org/lib/multiple-cidr-network/*.go # gosub-main-module
   - code.cloudfoundry.org/silk/cmd/silk-controller/*.go # gosub-main-module
   - code.cloudfoundry.org/silk/controller/*.go # gosub-main-module
   - code.cloudfoundry.org/silk/controller/config/*.go # gosub-main-module

--- a/packages/silk-daemon/spec
+++ b/packages/silk-daemon/spec
@@ -23,6 +23,7 @@ files:
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/lager/v3/lagerflags/*.go # gosub-main-module
   - code.cloudfoundry.org/lib/common/*.go # gosub-main-module
   - code.cloudfoundry.org/lib/datastore/*.go # gosub-main-module
+  - code.cloudfoundry.org/lib/multiple-cidr-network/*.go # gosub-main-module
   - code.cloudfoundry.org/lib/rules/*.go # gosub-main-module
   - code.cloudfoundry.org/lib/serial/*.go # gosub-main-module
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/policy_client/*.go # gosub-main-module

--- a/packages/vxlan-policy-agent/spec
+++ b/packages/vxlan-policy-agent/spec
@@ -40,6 +40,7 @@ files:
   - code.cloudfoundry.org/lib/serial/*.go # gosub-main-module
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/policy_client/*.go # gosub-main-module
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/routing-info/internalroutes/*.go # gosub-main-module
+  - code.cloudfoundry.org/silk/daemon/*.go # gosub-main-module
   - code.cloudfoundry.org/vendor/code.cloudfoundry.org/tlsconfig/*.go # gosub-main-module
   - code.cloudfoundry.org/vxlan-policy-agent/cmd/pre-start/*.go # gosub-main-module
   - code.cloudfoundry.org/vxlan-policy-agent/cmd/vxlan-policy-agent/*.go # gosub-main-module

--- a/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
+++ b/spec/silk-cni/cni_wrapper_plugin_conf_spec.rb
@@ -166,28 +166,6 @@ module Bosh::Template::Test
           clientConfig = JSON.parse(template.render(merged_manifest_properties, spec: spec, consumes: links))
           expect(clientConfig['plugins'][0]['no_masquerade_cidr_range']).to eq('')
         end
-
-        context 'when a cf_network.network link exists' do
-          let(:links) {[
-            Link.new(
-              name: 'cf_network',
-              properties: {
-                'network' => '10.255.0.0/16'
-              }
-            ),
-            Link.new(
-              name: 'vpa',
-              properties: {
-                'force_policy_poll_cycle_port' => 5555
-              }
-            )
-          ]}
-
-          it 'fallsback to the cf_network.network link property' do
-            clientConfig = JSON.parse(template.render(merged_manifest_properties, spec: spec, consumes: links))
-            expect(clientConfig['plugins'][0]['no_masquerade_cidr_range']).to eq('10.255.0.0/16')
-          end
-        end
       end
 
       context 'when mtu is greater than 0' do

--- a/spec/vxlan-policy-agent/vxlan-policy-agent_spec.rb
+++ b/spec/vxlan-policy-agent/vxlan-policy-agent_spec.rb
@@ -91,7 +91,7 @@ module Bosh::Template::Test
               'force_policy_poll_cycle_host' => '127.0.0.1',
               'force_policy_poll_cycle_port' => 8722,
               'disable_container_network_policy' => false,
-              'overlay_network' => '10.255.0.0/16',
+              'overlay_network' => ['10.255.0.0/16'],
               'iptables_asg_logging' => true,
               'iptables_denied_logs_per_sec' => 2,
               'deny_networks' => {
@@ -158,6 +158,17 @@ module Bosh::Template::Test
               expect(rendered_client_key).to eq("\nsome-client-key\n\n")
             end
           end
+          
+          context 'when the network is a single IP and not an array' do
+            before do
+              links.first.properties['network'] = '10.234.0.0/16'
+            end
+
+            it 'turns it into an array' do
+              rendered_config = JSON.parse(template.render(merged_manifest_properties, consumes: links))
+              expect(rendered_config['overlay_network']).to eq(['10.234.0.0/16'])
+            end
+          end 
         end
       end
     end

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/masquerader.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/masquerader.go
@@ -1,0 +1,77 @@
+package netrules
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"code.cloudfoundry.org/cf-networking-helpers/json_client"
+	"code.cloudfoundry.org/cni-wrapper-plugin/lib"
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/silk/daemon"
+)
+
+type Masquerader struct {
+	ContainerIP                 string
+	CustomNoMasqueradeCIDRRange string
+	DaemonPort                  string
+	VTEPName                    string
+	PluginController            *lib.PluginController
+	lease                       string
+}
+
+func (m *Masquerader) AddIPMasq() error {
+	noMasqCidr, err := m.getNoMasqueradeCIDRRange()
+	if err != nil {
+		return err
+	}
+	return m.PluginController.AddIPMasq(m.ContainerIP, noMasqCidr, m.VTEPName)
+}
+
+func (m *Masquerader) DelIPMasq() error {
+	noMasqCidr, err := m.getNoMasqueradeCIDRRange()
+	if err != nil {
+		return err
+	}
+	return m.PluginController.DelIPMasq(m.ContainerIP, noMasqCidr, m.VTEPName)
+}
+
+func (m *Masquerader) getNoMasqueradeCIDRRange() (string, error) {
+	if m.CustomNoMasqueradeCIDRRange != "" {
+		return m.CustomNoMasqueradeCIDRRange, nil
+	}
+	return m.getLease()
+}
+
+func (m *Masquerader) getLease() (string, error) {
+	if m.lease == "" {
+		lease, err := m.getLeaseFromDaemon()
+		if err == nil {
+			m.lease = lease
+		}
+		return lease, err
+	}
+
+	return m.lease, nil
+}
+
+func (m *Masquerader) getLeaseFromDaemon() (string, error) {
+	daemonClient := json_client.New(lager.NewLogger("masquerader"), http.DefaultClient, fmt.Sprintf("http://127.0.0.1:%s", m.DaemonPort))
+	maxAttempts := 5
+	attemptDelay := 500 * time.Millisecond
+	respData := daemon.NetworkInfo{}
+	var err error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		err = daemonClient.Do("GET", "/", nil, &respData, "")
+		if err == nil {
+			break
+		}
+
+		if attempt == maxAttempts {
+			return "", fmt.Errorf("failed to get lease from silk daemon after %d attempts: %s", attempt, err)
+		}
+
+		time.Sleep(attemptDelay)
+	}
+	return respData.OverlaySubnet, nil
+}

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/masquerader_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/masquerader_test.go
@@ -1,0 +1,329 @@
+package netrules_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"code.cloudfoundry.org/cni-wrapper-plugin/fakes"
+	"code.cloudfoundry.org/cni-wrapper-plugin/lib"
+	"code.cloudfoundry.org/cni-wrapper-plugin/netrules"
+	lib_fakes "code.cloudfoundry.org/lib/fakes"
+	"code.cloudfoundry.org/lib/rules"
+	"code.cloudfoundry.org/silk/daemon"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("Masquerader", func() {
+
+	var (
+		fakeIPTables     *lib_fakes.IPTablesAdapter
+		masquerader      *netrules.Masquerader
+		pluginController *lib.PluginController
+
+		containerIP string
+		daemonPort  string
+		leaseCIDR   string
+		vtepName    string
+	)
+
+	BeforeEach(func() {
+		containerIP = "10.255.11.11"
+		daemonPort = "8787"
+		leaseCIDR = "10.255.11.0/24"
+		vtepName = "meow-vtep"
+
+		fakeDelegator := &fakes.Delegator{}
+		fakeIPTables = &lib_fakes.IPTablesAdapter{}
+		pluginController = &lib.PluginController{
+			Delegator: fakeDelegator,
+			IPTables:  fakeIPTables,
+		}
+		masquerader = &netrules.Masquerader{
+			PluginController: pluginController,
+			VTEPName:         vtepName,
+			DaemonPort:       daemonPort,
+			ContainerIP:      containerIP,
+		}
+	})
+
+	Describe("AddIPMasq", func() {
+		Context("when customNoMasqueradeCIDRRange is NOT set", func() {
+			var (
+				fakeSilkDaemonServer    *ghttp.Server
+				silkDaemonResponseBytes []byte
+			)
+
+			BeforeEach(func() {
+				fakeSilkDaemonServer = ghttp.NewServer()
+
+				daemonPort := strings.Split(fakeSilkDaemonServer.Addr(), ":")[1]
+				masquerader.DaemonPort = daemonPort
+
+				silkDaemonResponse := daemon.NetworkInfo{
+					OverlaySubnet: leaseCIDR,
+				}
+
+				var err error
+				silkDaemonResponseBytes, err = json.Marshal(silkDaemonResponse)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				fakeSilkDaemonServer.Close()
+			})
+
+			Context("when the silk daemon is available", func() {
+				BeforeEach(func() {
+					fakeSilkDaemonServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/"),
+							ghttp.RespondWith(http.StatusOK, silkDaemonResponseBytes),
+						),
+					)
+				})
+
+				It("calls silk daemon to get the lease and uses that instead", func() {
+					expectedRule := rules.IPTablesRule{"--source", containerIP, "!", "-o", vtepName, "!", "--destination", leaseCIDR, "--jump", "MASQUERADE"}
+					err := masquerader.AddIPMasq()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeIPTables.BulkAppendCallCount()).To(Equal(1))
+					table, chain, rules := fakeIPTables.BulkAppendArgsForCall(0)
+					Expect(table).To(Equal("nat"))
+					Expect(chain).To(Equal("POSTROUTING"))
+					Expect(rules).To(HaveLen(1))
+					Expect(rules[0]).To(Equal(expectedRule))
+				})
+
+				Context("when IPtables errors", func() {
+					BeforeEach(func() {
+						fakeIPTables.BulkAppendReturns(errors.New("meow-bad"))
+					})
+
+					It("returns an error and doesn't call the silk-daemon twice", func() {
+						err := masquerader.AddIPMasq()
+						Expect(err).To(MatchError("meow-bad"))
+
+						// Only one handler is set on the daemon server, so if
+						// it was called again it would have failed above with a
+						// different error. The test below validates that there
+						// is only one handler.
+						thisShouldNotPanic := func() {
+							fakeSilkDaemonServer.GetHandler(0)
+						}
+						thisShouldPanic := func() {
+							fakeSilkDaemonServer.GetHandler(1)
+						}
+						Expect(thisShouldNotPanic).ToNot(Panic())
+						Expect(thisShouldPanic).To(Panic())
+					})
+				})
+			})
+
+			Context("when the silk-daemon is not available", func() {
+				BeforeEach(func() {
+					fakeSilkDaemonServer.Close()
+				})
+
+				It("returns an error and logs", func() {
+					err := masquerader.AddIPMasq()
+					Expect(err).To(MatchError(ContainSubstring("failed to get lease from silk daemon")))
+				})
+			})
+
+			Context("when it fails initially but eventually becomes available within 5 attempts", func() {
+				BeforeEach(func() {
+					fakeSilkDaemonServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/"),
+							ghttp.RespondWith(http.StatusInternalServerError, []byte{}),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/"),
+							ghttp.RespondWith(http.StatusInternalServerError, []byte{}),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/"),
+							ghttp.RespondWith(http.StatusInternalServerError, []byte{}),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/"),
+							ghttp.RespondWith(http.StatusOK, silkDaemonResponseBytes),
+						),
+					)
+				})
+
+				It("eventually succeeds", func() {
+					expectedRule := rules.IPTablesRule{"--source", containerIP, "!", "-o", vtepName, "!", "--destination", leaseCIDR, "--jump", "MASQUERADE"}
+					err := masquerader.AddIPMasq()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeIPTables.BulkAppendCallCount()).To(Equal(1))
+					table, chain, rules := fakeIPTables.BulkAppendArgsForCall(0)
+					Expect(table).To(Equal("nat"))
+					Expect(chain).To(Equal("POSTROUTING"))
+					Expect(rules).To(HaveLen(1))
+					Expect(rules[0]).To(Equal(expectedRule))
+				})
+			})
+		})
+
+		Context("when customNoMasqueradeCIDRRange is set", func() {
+			var customNoMasqueradeCIDRRange string
+
+			BeforeEach(func() {
+				customNoMasqueradeCIDRRange = "10.33.0.0/16"
+				masquerader.CustomNoMasqueradeCIDRRange = customNoMasqueradeCIDRRange
+			})
+
+			It("makes a masq rule with the customNoMasqueradeCIDRRange", func() {
+				expectedRule := rules.IPTablesRule{"--source", containerIP, "!", "-o", vtepName, "!", "--destination", customNoMasqueradeCIDRRange, "--jump", "MASQUERADE"}
+				err := masquerader.AddIPMasq()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(fakeIPTables.BulkAppendCallCount()).To(Equal(1))
+				table, chain, rules := fakeIPTables.BulkAppendArgsForCall(0)
+				Expect(table).To(Equal("nat"))
+				Expect(chain).To(Equal("POSTROUTING"))
+				Expect(rules).To(HaveLen(1))
+				Expect(rules[0]).To(Equal(expectedRule))
+			})
+
+			Context("when IPtables errors", func() {
+				BeforeEach(func() {
+					fakeIPTables.BulkAppendReturns(errors.New("meow-bad"))
+				})
+
+				It("returns an error", func() {
+					err := masquerader.AddIPMasq()
+					Expect(err).To(MatchError("meow-bad"))
+				})
+			})
+		})
+	})
+
+	Describe("DelIPMasq", func() {
+		Context("when customNoMasqueradeCIDRRange is NOT set", func() {
+			var fakeSilkDaemonServer *ghttp.Server
+			var silkDaemonResponseBytes []byte
+
+			BeforeEach(func() {
+				fakeSilkDaemonServer = ghttp.NewServer()
+				daemonPort := strings.Split(fakeSilkDaemonServer.Addr(), ":")[1]
+				masquerader.DaemonPort = daemonPort
+
+				silkDaemonResponse := daemon.NetworkInfo{
+					OverlaySubnet: leaseCIDR,
+				}
+
+				var err error
+				silkDaemonResponseBytes, err = json.Marshal(silkDaemonResponse)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				fakeSilkDaemonServer.Close()
+			})
+
+			Context("when the silk daemon responds with the lease", func() {
+				BeforeEach(func() {
+					fakeSilkDaemonServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/"),
+							ghttp.RespondWith(http.StatusOK, silkDaemonResponseBytes),
+						),
+					)
+				})
+
+				It("calls silk daemon to get the lease and uses that instead", func() {
+					expectedRule := rules.IPTablesRule{"--source", containerIP, "!", "-o", vtepName, "!", "--destination", leaseCIDR, "--jump", "MASQUERADE"}
+					err := masquerader.DelIPMasq()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeIPTables.DeleteCallCount()).To(Equal(1))
+					table, chain, rule := fakeIPTables.DeleteArgsForCall(0)
+					Expect(table).To(Equal("nat"))
+					Expect(chain).To(Equal("POSTROUTING"))
+					Expect(rule).To(Equal(expectedRule))
+				})
+			})
+
+			Context("when the silk-daemon is not available", func() {
+				BeforeEach(func() {
+					fakeSilkDaemonServer.Close()
+				})
+
+				It("returns an error and logs", func() {
+					err := masquerader.DelIPMasq()
+					Expect(err).To(MatchError(ContainSubstring("failed to get lease from silk daemon")))
+				})
+			})
+
+			Context("when it fails initially but eventually becomes available within 5 attempts", func() {
+				BeforeEach(func() {
+					fakeSilkDaemonServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/"),
+							ghttp.RespondWith(http.StatusInternalServerError, []byte{}),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/"),
+							ghttp.RespondWith(http.StatusInternalServerError, []byte{}),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/"),
+							ghttp.RespondWith(http.StatusInternalServerError, []byte{}),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/"),
+							ghttp.RespondWith(http.StatusOK, silkDaemonResponseBytes),
+						),
+					)
+				})
+
+				It("eventually succeeds", func() {
+					expectedRule := rules.IPTablesRule{"--source", containerIP, "!", "-o", vtepName, "!", "--destination", leaseCIDR, "--jump", "MASQUERADE"}
+					err := masquerader.DelIPMasq()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeIPTables.DeleteCallCount()).To(Equal(1))
+					table, chain, rule := fakeIPTables.DeleteArgsForCall(0)
+					Expect(table).To(Equal("nat"))
+					Expect(chain).To(Equal("POSTROUTING"))
+					Expect(rule).To(Equal(expectedRule))
+				})
+			})
+		})
+
+		Context("when customNoMasqueradeCIDRRange is set", func() {
+			var customNoMasqueradeCIDRRange string
+
+			BeforeEach(func() {
+				customNoMasqueradeCIDRRange = "10.33.0.0/16"
+				masquerader.CustomNoMasqueradeCIDRRange = customNoMasqueradeCIDRRange
+			})
+
+			It("makes a masq rule with the customNoMasqueradeCIDRRange", func() {
+				expectedRule := rules.IPTablesRule{"--source", containerIP, "!", "-o", vtepName, "!", "--destination", customNoMasqueradeCIDRRange, "--jump", "MASQUERADE"}
+				err := masquerader.DelIPMasq()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(fakeIPTables.DeleteCallCount()).To(Equal(1))
+				table, chain, rule := fakeIPTables.DeleteArgsForCall(0)
+				Expect(table).To(Equal("nat"))
+				Expect(chain).To(Equal("POSTROUTING"))
+				Expect(rule).To(Equal(expectedRule))
+			})
+
+			Context("when IPtables errors", func() {
+				BeforeEach(func() {
+					fakeIPTables.DeleteReturns(errors.New("meow-bad"))
+				})
+
+				It("returns an error", func() {
+					err := masquerader.DelIPMasq()
+					Expect(err).To(MatchError("meow-bad"))
+				})
+			})
+		})
+	})
+})

--- a/src/code.cloudfoundry.org/lib/multiple-cidr-network/multiple_cidr_network.go
+++ b/src/code.cloudfoundry.org/lib/multiple-cidr-network/multiple_cidr_network.go
@@ -1,0 +1,57 @@
+package multiple_cidr_network
+
+import (
+	"net"
+)
+
+type MultipleCIDRNetwork struct {
+	Networks     []*net.IPNet
+	SmallestMask int
+}
+
+func NewMultipleCIDRNetwork(cidrs []string) (MultipleCIDRNetwork, error) {
+	var networks []*net.IPNet
+	smallestMask := 0
+	for i, c := range cidrs {
+		_, n, err := net.ParseCIDR(c)
+		if err != nil {
+			return MultipleCIDRNetwork{}, err
+		}
+		networks = append(networks, n)
+
+		maskSize, _ := n.Mask.Size()
+		if i == 0 {
+			smallestMask = maskSize
+		} else if maskSize > smallestMask { // because masks are backwards 32 is smaller than 24
+			smallestMask = maskSize
+		}
+	}
+
+	return MultipleCIDRNetwork{
+		Networks:     networks,
+		SmallestMask: smallestMask,
+	}, nil
+}
+
+func (m *MultipleCIDRNetwork) Contains(ip net.IP) bool {
+	for _, n := range m.Networks {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (m *MultipleCIDRNetwork) Length() int {
+	return len(m.Networks)
+}
+
+func (m *MultipleCIDRNetwork) WhichNetworkContains(ip net.IP) *net.IPNet {
+	for _, n := range m.Networks {
+		if n.Contains(ip) {
+			return n
+		}
+	}
+	return nil
+}

--- a/src/code.cloudfoundry.org/lib/multiple-cidr-network/multiple_cidr_network_suite_test.go
+++ b/src/code.cloudfoundry.org/lib/multiple-cidr-network/multiple_cidr_network_suite_test.go
@@ -1,0 +1,13 @@
+package multiple_cidr_network_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMultipleCidrNetwork(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MultipleCidrNetwork Suite")
+}

--- a/src/code.cloudfoundry.org/lib/multiple-cidr-network/multiple_cidr_network_test.go
+++ b/src/code.cloudfoundry.org/lib/multiple-cidr-network/multiple_cidr_network_test.go
@@ -1,0 +1,146 @@
+package multiple_cidr_network_test
+
+import (
+	. "code.cloudfoundry.org/lib/multiple-cidr-network"
+	"net"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MultipleCIDRNetwork", func() {
+	var (
+		network                            MultipleCIDRNetwork
+		validCIDR1, validCIDR2, validCIDR3 string
+	)
+
+	BeforeEach(func() {
+		validCIDR1 = "10.20.0.0/16"  // 10.20.0.0 - 10.20.255.255
+		validCIDR2 = "10.50.50.0/24" // 10.50.50.0 - 10.50.50.255
+		validCIDR3 = "10.255.0.0/16" // 10.255.0.0 - 10.255.255.255
+	})
+
+	Context("NewMultipleCIDRNetwork", func() {
+		DescribeTable("when the cidrs provided are invalid",
+			func(cidrs []string) {
+				_, err := NewMultipleCIDRNetwork(cidrs)
+				Expect(err).To(HaveOccurred())
+			},
+			Entry("When the 'CIDR' isn't remotely even a CIDR", []string{"meow"}),
+			Entry("When the 'CIDR' has an invalid IP", []string{"10.999.0.0/16"}),
+			Entry("When the 'CIDR' has an invalid mask", []string{"10.99.0.0/99"}),
+			Entry("When the second 'CIDR' is invalid", []string{"10.255.0.0/24, 10.99.0.0/99"}),
+		)
+
+		Context("when the cidrs provided are valid", func() {
+			BeforeEach(func() {
+				var err error
+				cidr1 := "10.20.0.0/16"  // 10.20.0.0 - 10.20.255.255
+				cidr2 := "10.50.50.0/24" // 10.50.50.0 - 10.50.50.255
+				cidr3 := "10.255.0.0/16" // 10.255.0.0 - 10.255.255.255
+				network, err = NewMultipleCIDRNetwork([]string{cidr1, cidr2, cidr3})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("creates an array of net.IPNet's", func() {
+				Expect(network.Length()).To(Equal(3))
+				Expect(network.Networks[0].IP).To(Equal(net.IP{10, 20, 0, 0}))
+				Expect(network.Networks[0].Mask).To(Equal(net.IPv4Mask(255, 255, 0, 0)))
+				Expect(network.Networks[1].IP).To(Equal(net.IP{10, 50, 50, 0}))
+				Expect(network.Networks[1].Mask).To(Equal(net.IPv4Mask(255, 255, 255, 0)))
+				Expect(network.Networks[2].IP).To(Equal(net.IP{10, 255, 0, 0}))
+				Expect(network.Networks[2].Mask).To(Equal(net.IPv4Mask(255, 255, 0, 0)))
+			})
+		})
+	})
+
+	Context("SmallestMask", func() {
+		DescribeTable("it returns the size of the smallest mask",
+			func(cidrs []string, expectedSize int) {
+				n, err := NewMultipleCIDRNetwork(cidrs)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(n.SmallestMask).To(Equal(expectedSize))
+			},
+			Entry("When the cidrs have different masks", []string{"10.255.0.0/16", "10.255.0.0/24", "10.255.0.0/32"}, 32),
+			Entry("When the cidrs have the same masks", []string{"10.255.0.0/24", "10.255.0.0/24", "10.255.0.0/24"}, 24),
+		)
+	})
+
+	Context("Contains", func() {
+		BeforeEach(func() {
+			var err error
+			network, err = NewMultipleCIDRNetwork([]string{validCIDR1, validCIDR2, validCIDR3})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when the IP is contained in a network", func() {
+			DescribeTable("it returns true",
+				func(check string) {
+					ip := net.ParseIP(check)
+					Expect(ip).ToNot(BeNil())
+
+					found := network.Contains(ip)
+					Expect(found).To(BeTrue())
+				},
+				Entry("When it is in the first network", "10.20.0.0"),
+				Entry("When it is in the second network", "10.50.50.50"),
+				Entry("When it is in the third network", "10.255.255.255"),
+			)
+		})
+
+		Context("when the IP is not contained in a network", func() {
+			DescribeTable("it returns false",
+				func(check string) {
+					ip := net.ParseIP(check)
+					Expect(ip).ToNot(BeNil())
+
+					found := network.Contains(ip)
+					Expect(found).To(BeFalse())
+				},
+				Entry("When it is not in any network", "10.10.0.0"),
+				Entry("When it is not in any network", "10.30.50.50"),
+				Entry("When it is not in any network", "10.200.255.255"),
+			)
+		})
+	})
+
+	Context("WhichNetworkContains", func() {
+		BeforeEach(func() {
+			var err error
+			network, err = NewMultipleCIDRNetwork([]string{validCIDR1, validCIDR2, validCIDR3})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when the IP is contained in a network", func() {
+			DescribeTable("it returns the single network it is in",
+				func(check string, firstIPOfExpectedNetwork net.IP) {
+					ip := net.ParseIP(check)
+					Expect(ip).ToNot(BeNil())
+
+					n := network.WhichNetworkContains(ip)
+					Expect(n).ToNot(BeNil())
+					Expect(n.IP).To(Equal(firstIPOfExpectedNetwork))
+
+				},
+				Entry("When it is in the first network", "10.20.0.0", net.IP{10, 20, 0, 0}),
+				Entry("When it is in the second network", "10.50.50.50", net.IP{10, 50, 50, 0}),
+				Entry("When it is in the third network", "10.255.255.255", net.IP{10, 255, 0, 0}),
+			)
+		})
+
+		Context("when the IP is NOT contained in a network", func() {
+			DescribeTable("it returns nil",
+				func(check string) {
+					ip := net.ParseIP(check)
+					Expect(ip).ToNot(BeNil())
+
+					network := network.WhichNetworkContains(ip)
+					Expect(network).To(BeNil())
+				},
+				Entry("When it is not in any network", "10.10.0.0"),
+				Entry("When it is not in any network", "10.30.50.50"),
+				Entry("When it is not in any network", "10.200.255.255"),
+			)
+		})
+	})
+})

--- a/src/code.cloudfoundry.org/lib/rules/locked_iptables_integration_test.go
+++ b/src/code.cloudfoundry.org/lib/rules/locked_iptables_integration_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Locked IPTables Integration Test", func() {
 
 	It("writes a single rule to allow all traffic on a given IP range", func() {
 		onlyRunOnLinux()
-		err := lockedIPT.AllowTrafficForRange([]rules.IPTablesRule{rules.NewAcceptEverythingRule("10.255.0.0/16")}...)
+		err := lockedIPT.AllowTrafficForRange([]rules.IPTablesRule{rules.NewAcceptEverythingRule("10.255.0.0/16", "10.255.0.0/16")}...)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(AllIPTablesRules("filter")).To(ContainElement(`-A FORWARD -s 10.255.0.0/16 -d 10.255.0.0/16 -j ACCEPT`))

--- a/src/code.cloudfoundry.org/lib/rules/rules.go
+++ b/src/code.cloudfoundry.org/lib/rules/rules.go
@@ -240,9 +240,9 @@ func NewAcceptRule() IPTablesRule {
 	}
 }
 
-func NewAcceptEverythingRule(ipRange string) IPTablesRule {
+func NewAcceptEverythingRule(srcIPRange, dstIPRange string) IPTablesRule {
 	return IPTablesRule{
-		"-s", ipRange, "-d", ipRange, "-j", "ACCEPT",
+		"-s", srcIPRange, "-d", dstIPRange, "-j", "ACCEPT",
 	}
 }
 

--- a/src/code.cloudfoundry.org/silk/client/config/config.go
+++ b/src/code.cloudfoundry.org/silk/client/config/config.go
@@ -9,27 +9,27 @@ import (
 )
 
 type Config struct {
-	UnderlayIP                string `json:"underlay_ip" validate:"nonzero"`
-	VxlanInterfaceName        string `json:"vxlan_interface_name"`
-	SubnetPrefixLength        int    `json:"subnet_prefix_length" validate:"nonzero"`
-	OverlayNetwork            string `json:"overlay_network" validate:"nonzero"`
-	HealthCheckPort           uint16 `json:"health_check_port" validate:"nonzero"`
-	VTEPName                  string `json:"vtep_name" validate:"nonzero"`
-	ConnectivityServerURL     string `json:"connectivity_server_url" validate:"nonzero"`
-	ServerCACertFile          string `json:"ca_cert_file" validate:"nonzero"`
-	ClientCertFile            string `json:"client_cert_file" validate:"nonzero"`
-	ClientKeyFile             string `json:"client_key_file" validate:"nonzero"`
-	VNI                       int    `json:"vni" validate:"nonzero"`
-	VTEPPort                  int    `json:"vtep_port" validate:"min=1"`
-	PollInterval              int    `json:"poll_interval" validate:"nonzero"`
-	DebugServerPort           int    `json:"debug_server_port" validate:"nonzero"`
-	Datastore                 string `json:"datastore" validate:"nonzero"`
-	PartitionToleranceSeconds int    `json:"partition_tolerance_seconds" validate:"nonzero"`
-	ClientTimeoutSeconds      int    `json:"client_timeout_seconds" validate:"nonzero"`
-	MetronPort                int    `json:"metron_port" validate:"min=1"`
-	LogPrefix                 string `json:"log_prefix" validate:"nonzero"`
-	LogLevel                  string `json:"log_level"`
-	SingleIPOnly              bool   `json:"single_ip_only"`
+	UnderlayIP                string   `json:"underlay_ip" validate:"nonzero"`
+	VxlanInterfaceName        string   `json:"vxlan_interface_name"`
+	SubnetPrefixLength        int      `json:"subnet_prefix_length" validate:"nonzero"`
+	OverlayNetworks           []string `json:"overlay_network" validate:"nonzero"`
+	HealthCheckPort           uint16   `json:"health_check_port" validate:"nonzero"`
+	VTEPName                  string   `json:"vtep_name" validate:"nonzero"`
+	ConnectivityServerURL     string   `json:"connectivity_server_url" validate:"nonzero"`
+	ServerCACertFile          string   `json:"ca_cert_file" validate:"nonzero"`
+	ClientCertFile            string   `json:"client_cert_file" validate:"nonzero"`
+	ClientKeyFile             string   `json:"client_key_file" validate:"nonzero"`
+	VNI                       int      `json:"vni" validate:"nonzero"`
+	VTEPPort                  int      `json:"vtep_port" validate:"min=1"`
+	PollInterval              int      `json:"poll_interval" validate:"nonzero"`
+	DebugServerPort           int      `json:"debug_server_port" validate:"nonzero"`
+	Datastore                 string   `json:"datastore" validate:"nonzero"`
+	PartitionToleranceSeconds int      `json:"partition_tolerance_seconds" validate:"nonzero"`
+	ClientTimeoutSeconds      int      `json:"client_timeout_seconds" validate:"nonzero"`
+	MetronPort                int      `json:"metron_port" validate:"min=1"`
+	LogPrefix                 string   `json:"log_prefix" validate:"nonzero"`
+	LogLevel                  string   `json:"log_level"`
+	SingleIPOnly              bool     `json:"single_ip_only"`
 }
 
 func LoadConfig(filePath string) (Config, error) {

--- a/src/code.cloudfoundry.org/silk/client/config/config_test.go
+++ b/src/code.cloudfoundry.org/silk/client/config/config_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Config.LoadConfig", func() {
 		requiredFields = map[string]interface{}{
 			"underlay_ip":                 "1.2.3.4",
 			"subnet_prefix_length":        24,
-			"overlay_network":             "10.255.0.0/16",
+			"overlay_network":             []string{"10.255.0.0/16"},
 			"health_check_port":           22222,
 			"vtep_name":                   "silk-vxlan",
 			"connectivity_server_url":     "https://silk-controller.something",
@@ -104,6 +104,23 @@ var _ = Describe("Config.LoadConfig", func() {
 			loadedConfig, err := config.LoadConfig(file.Name())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(loadedConfig.VxlanInterfaceName).To(Equal("something"))
+		})
+	})
+
+	Context("when multiple overlay networks are provided", func() {
+		It("sets all of them", func() {
+			overlayNets := []string{"10.255.0.0/16", "10.2.0.0/16"}
+			cfg := cloneMap(requiredFields)
+			cfg["overlay_network"] = overlayNets
+
+			file, err := os.CreateTemp(os.TempDir(), "config-")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(json.NewEncoder(file).Encode(cfg)).To(Succeed())
+
+			loadedConfig, err := config.LoadConfig(file.Name())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(loadedConfig.OverlayNetworks).To(Equal(overlayNets))
 		})
 	})
 })

--- a/src/code.cloudfoundry.org/silk/cni/integration/integration_test.go
+++ b/src/code.cloudfoundry.org/silk/cni/integration/integration_test.go
@@ -383,7 +383,7 @@ var _ = Describe("Silk CNI Integration", func() {
 
 			By("installing the requisite iptables rule")
 			iptablesRule := func(action string) []string {
-				return []string{"-t", "nat", action, "POSTROUTING", "-s", sourceIP, "!", "-d", "10.255.0.0/16", "-j", "MASQUERADE"}
+				return []string{"-t", "nat", action, "POSTROUTING", "-s", sourceIP, "!", "-d", "10.255.30.0/24", "-j", "MASQUERADE"}
 			}
 			mustSucceed("iptables", iptablesRule("-A")...)
 

--- a/src/code.cloudfoundry.org/silk/controller/config/config.go
+++ b/src/code.cloudfoundry.org/silk/controller/config/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	CACertFile                    string    `json:"ca_cert_file" validate:"nonzero"`
 	ServerCertFile                string    `json:"server_cert_file" validate:"nonzero"`
 	ServerKeyFile                 string    `json:"server_key_file" validate:"nonzero"`
-	Network                       string    `json:"network" validate:"nonzero"`
+	Network                       []string  `json:"network" validate:"nonzero"`
 	SubnetPrefixLength            int       `json:"subnet_prefix_length" validate:"nonzero"`
 	Database                      db.Config `json:"database" validate:"nonzero"`
 	LeaseExpirationSeconds        int       `json:"lease_expiration_seconds" validate:"min=1"`

--- a/src/code.cloudfoundry.org/silk/controller/config/config_test.go
+++ b/src/code.cloudfoundry.org/silk/controller/config/config_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Config.ReadFromFile", func() {
 			"ca_cert_file":         "/some/cert/file",
 			"server_cert_file":     "/some/other/cert/file",
 			"server_key_file":      "/some/key/file",
-			"network":              "10.255.0.0/16",
+			"network":              []string{"10.255.0.0/16"},
 			"subnet_prefix_length": 24,
 			"database": db.Config{
 				Type:         "mysql",
@@ -113,5 +113,6 @@ var _ = Describe("Config.ReadFromFile", func() {
 		Entry("invalid max_open_connections", "max_open_connections", -2, "MaxOpenConnections: less than min"),
 		Entry("invalid max_idle_connections", "max_idle_connections", -2, "MaxIdleConnections: less than min"),
 		Entry("invalid connections_max_lifetime_seconds", "connections_max_lifetime_seconds", -2, "MaxConnectionsLifetimeSeconds: less than min"),
+		Entry("invalid network", "network", []string{}, "Network: zero value"),
 	)
 })

--- a/src/code.cloudfoundry.org/silk/controller/integration/helpers/helpers.go
+++ b/src/code.cloudfoundry.org/silk/controller/integration/helpers/helpers.go
@@ -31,7 +31,7 @@ func DefaultTestConfig(dbConf db.Config, fixturesPath string) config.Config {
 		CACertFile:                filepath.Join(fixturesPath, "ca.crt"),
 		ServerCertFile:            filepath.Join(fixturesPath, "server.crt"),
 		ServerKeyFile:             filepath.Join(fixturesPath, "server.key"),
-		Network:                   "10.255.0.0/16",
+		Network:                   []string{"10.255.0.0/16", "10.250.0.0/16"},
 		SubnetPrefixLength:        24,
 		Database:                  dbConf,
 		LeaseExpirationSeconds:    60,

--- a/src/code.cloudfoundry.org/silk/controller/leaser/cidrpool_test.go
+++ b/src/code.cloudfoundry.org/silk/controller/leaser/cidrpool_test.go
@@ -9,193 +9,282 @@ import (
 )
 
 var _ = Describe("CIDRPool", func() {
+
+	Describe("NewCIDRPool", func() {
+		DescribeTable("panics when invalid CIDRs are provided",
+			func(subnetRange []string, subnetMask, expectedSize int) {
+				shouldPanic := func() {
+					leaser.NewCIDRPool(subnetRange, subnetMask)
+				}
+				Expect(shouldPanic).To(PanicWith(MatchError(ContainSubstring("invalid CIDR address"))))
+			},
+			Entry("when the first ip is invalid", []string{"10.255.999.0/16"}, 24, 255),
+			Entry("when an ip in the array is invalid", []string{"10.255.99.0/16", "10.250.999.0/16"}, 24, 255),
+			Entry("when the first ip has an invalid mask", []string{"10.255.99.0/60", "10.250.99.0/16"}, 24, 255),
+			Entry("when an ip in the array has an invalid mask", []string{"10.255.99.0/16", "10.250.99.0/199"}, 24, 255),
+		)
+
+		DescribeTable("panics when invalid subnetMask is provided",
+			func(subnetRange []string, subnetMask, expectedSize int) {
+				shouldPanic := func() {
+					leaser.NewCIDRPool(subnetRange, subnetMask)
+				}
+				Expect(shouldPanic).To(PanicWith(MatchError(ContainSubstring("subnet mask must be between [0-32]"))))
+			},
+			Entry("when subnet mask is > 32", []string{"10.255.99.0/16"}, 40, 255),
+			Entry("when subnet mask is < 0 ", []string{"10.255.99.0/16"}, -1, 255),
+		)
+
+		Context("when there are no networks provided", func() {
+			It("panics", func() {
+				shouldPanic := func() {
+					leaser.NewCIDRPool([]string{}, 24)
+				}
+				Expect(shouldPanic).To(PanicWith(MatchError(ContainSubstring("network must be provided"))))
+			})
+		})
+	})
+
 	Describe("BlockPoolSize", func() {
 		DescribeTable("returns the number of subnets that can be allocated",
-			func(subnetRange string, subnetMask, expectedSize int) {
+			func(subnetRange []string, subnetMask, expectedSize int) {
 				cidrPool := leaser.NewCIDRPool(subnetRange, subnetMask)
 				Expect(cidrPool.BlockPoolSize()).To(Equal(expectedSize))
 			},
-			Entry("when the range is /16 and mask is /24", "10.255.0.0/16", 24, 255),
-			Entry("when the range is /16 and mask is /20", "10.255.0.0/16", 20, 15),
-			Entry("when the range is /16 and mask is /16", "10.255.0.0/16", 16, 0),
+			// /16 = 65536 ; /24 = 256 ; 65536 / 256 = 256 ; 256 - 1 (first block is excluded) = 255
+			Entry("when the range is /16 and mask is /24", []string{"10.255.0.0/16"}, 24, 255),
+
+			// /16 = 65536 ; /20 = 4096 ; 65536 / 4096 = 16 ; 16 - 1 (first block is excluded) = 15
+			Entry("when the range is /16 and mask is /20", []string{"10.255.0.0/16"}, 20, 15),
+
+			// /16 = 65536 ; /16 = 65536 ; 65536 / 65536 = 1 ; 1 - 1 (first block is excluded) = 0
+			Entry("when the range is /16 and mask is /16", []string{"10.255.0.0/16"}, 16, 0),
+
+			// /16 x2 = 65536 x2 = 131072 ; /24 = 256 ; 131072 / 256 = 512
+			// 512 - 2 (first block of each network is excluded) = 510
+			Entry("when there are multiple /16 ranges and mask is /24", []string{"10.255.0.0/16", "10.250.0.0/16"}, 24, 510),
+
+			// /16 = 65536 ; /23 = 512 ; 65536 + 512 = 66048 ; /24 = 256 ;
+			// 66048 / 256 = 258 ; 258 - 2 (first block of each network is excluded) = 256
+			Entry("when there are multiple different sized ranges and mask is /24", []string{"10.255.0.0/16", "10.250.0.0/23"}, 24, 256),
 		)
 
 		DescribeTable("produces valid subnets within the correct range",
-			func(overlayCIDR string, subnetMask int) {
-				_, overlayNetwork, _ := net.ParseCIDR(overlayCIDR)
+			func(overlayCIDR []string, subnetMask, expectedNumBlockPools int) {
+				networks := getNetworks(overlayCIDR)
 				cidrPool := leaser.NewCIDRPool(overlayCIDR, subnetMask)
 
+				numCheckedBlockPools := 0
 				for blockDividedCIDR := range cidrPool.GetBlockPool() {
+					numCheckedBlockPools++
 					_, blockNetwork, _ := net.ParseCIDR(blockDividedCIDR)
-					Expect(overlayNetwork.Contains(blockNetwork.IP)).Should(BeTrue())
+					Expect(oneNetworkContains(networks, blockNetwork.IP)).Should(BeTrue())
 				}
+
+				Expect(numCheckedBlockPools).To(Equal(expectedNumBlockPools))
 			},
-			Entry("when ip is in the start of the cidr range", "10.240.0.0/12", 24),
-			Entry("when ip is in the middle of the cidr range", "10.255.0.0/12", 24),
-			Entry("when ip is in the end of the cidr range", "10.255.255.255/12", 24),
+
+			// /12 = 1048576 ; /24 = 256 ; 1048576 / 256 = 4096 ; 4096 - 1 (first block is excluded) = 4095
+			Entry("when ip is in the start of the cidr range", []string{"10.240.0.0/12"}, 24, 4095),
+			Entry("when ip is in the middle of the cidr range", []string{"10.255.0.0/12"}, 24, 4095),
+			Entry("when ip is in the end of the cidr range", []string{"10.255.255.255/12"}, 24, 4095),
+
+			// /16 x2 = 65536 x2 = 131072 ; /24 = 256 ; 131072 / 256 = 512
+			// 512 - 2 (first block of each network is excluded) = 510
+			Entry("when there is an array of networks", []string{"10.255.0.0/16", "10.250.0.0/16"}, 24, 510),
 		)
 	})
 
 	Describe("SingleIPPoolSize", func() {
 		DescribeTable("returns the number of subnets that can be allocated",
-			func(subnetRange string, subnetMask, expectedSize int) {
+			func(subnetRange []string, subnetMask, expectedSize int) {
 				cidrPool := leaser.NewCIDRPool(subnetRange, subnetMask)
 				Expect(cidrPool.SingleIPPoolSize()).To(Equal(expectedSize))
 			},
-			Entry("when the range is /16 and mask is /25", "10.255.0.0/16", 25, 127),
-			Entry("when the range is /16 and mask is /26", "10.255.0.0/16", 26, 63),
-			Entry("when the range is /16 and mask is /27", "10.255.0.0/16", 27, 31),
+			// /25 = 128, -1 for the first IP which is never allocated.
+			Entry("when the range is /16 and mask is /25", []string{"10.255.0.0/16"}, 25, 127),
+
+			// /26 = 64, -1 for the first IP which is never allocated.
+			Entry("when the range is /16 and mask is /26", []string{"10.255.0.0/16"}, 26, 63),
+
+			// /27 = 32, -1 for the first IP which is never allocated.
+			Entry("when the range is /16 and mask is /27", []string{"10.255.0.0/16"}, 27, 31),
+
+			// /27 = 32, because we get one single IP subnet block from the first overlay network.
+			// -1 for the first IP of the single IP subnet block which is never allocated.
+			Entry("when there are multiple ranges and mask is /27", []string{"10.255.0.0/24", "10.250.0.0/16"}, 27, 31),
 		)
 
-		It("produces valid subnet starting with the first IP of the cidr", func() {
-			overlayCIDR := "10.255.0.0/12"
+		It("produces valid subnet starting with the first IP of the first provided cidr", func() {
+			firstNetwork := "10.240.0.0/12" // 10.240.0.0 - 10.255.255.255
+			secondNetwork := "10.20.0.0/16" // 10.20.0.0 - 10.20.255.255
+			overlayCIDR := []string{firstNetwork, secondNetwork}
 			subnetMask := 24
-			firstSubnet := "10.240.0.0/24"
+			firstSubnetOfFirstNetwork := "10.240.0.0/24"
+			firstSubnetOfSecondNetwork := "10.20.0.0/24"
 
 			cidrPool := leaser.NewCIDRPool(overlayCIDR, subnetMask)
-			_, expectedSingleIPNetwork, _ := net.ParseCIDR(firstSubnet)
+			_, expectedSingleIPNetworkPart1, _ := net.ParseCIDR(firstSubnetOfFirstNetwork)
+			_, expectedSingleIPNetworkPart2, _ := net.ParseCIDR(firstSubnetOfSecondNetwork)
+
 			for singleIPCIDR := range cidrPool.GetSinglePool() {
 				_, singleIPNetwork, _ := net.ParseCIDR(singleIPCIDR)
-				Expect(expectedSingleIPNetwork.Contains(singleIPNetwork.IP)).Should(BeTrue())
+
+				inFirstSubnetOfFirstNetwork := expectedSingleIPNetworkPart1.Contains(singleIPNetwork.IP)
+				inFirstSubnetOfSecondNetwork := expectedSingleIPNetworkPart2.Contains(singleIPNetwork.IP)
+
+				Expect(inFirstSubnetOfFirstNetwork).To(BeTrue())
+				Expect(inFirstSubnetOfSecondNetwork).To(BeFalse())
 			}
 		})
 	})
 
-	Describe("GetAvailableBlock", func() {
-		It("returns a subnet from the pool that is not taken", func() {
-			subnetRange := "10.255.0.0/16"
-			_, network, _ := net.ParseCIDR(subnetRange)
-			cidrPool := leaser.NewCIDRPool(subnetRange, 24)
+	DescribeTable("GetAvailableBlock",
+		func(subnetMaskSize, expectedNumBlockLeases int, expectedLeaseMask net.IPMask) {
 
-			results := map[string]int{}
+			overlayNetwork1String := "10.255.0.0/16"
+			overlayNetwork2String := "10.250.0.0/16"
+			overlayNetworkStrings := []string{overlayNetwork1String, overlayNetwork2String}
+			overlayNetwork1 := getNetworks(overlayNetworkStrings)[0]
+			overlayNetwork2 := getNetworks(overlayNetworkStrings)[1]
+			cidrPool := leaser.NewCIDRPool(overlayNetworkStrings, subnetMaskSize)
 
 			var taken []string
-			for i := 0; i < 255; i++ {
-				s := cidrPool.GetAvailableBlock(taken)
-				results[s]++
-				taken = append(taken, s)
-			}
-			Expect(len(results)).To(Equal(255))
+			for i := 1; i <= expectedNumBlockLeases; i++ {
+				By("testing that there are still leases left")
+				lease := cidrPool.GetAvailableBlock(taken)
+				Expect(lease).ToNot(Equal(""))
 
-			for result := range results {
-				_, subnet, err := net.ParseCIDR(result)
+				By("testing that the lease is a valid subnet")
+				leaseIP, leaseSubnet, err := net.ParseCIDR(lease)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(network.Contains(subnet.IP)).To(BeTrue())
-				Expect(subnet.Mask).To(Equal(net.IPMask{255, 255, 255, 0}))
-				// first subnet from range is never allocated
-				Expect(subnet.IP.To4()).NotTo(Equal(network.IP.To4()))
+
+				By("testing that the leaseIP is in the first or second overlayNetwork")
+				inOverlayNetwork1 := overlayNetwork1.Contains(leaseIP)
+				inOverlayNetwork2 := overlayNetwork2.Contains(leaseIP)
+				Expect([]bool{inOverlayNetwork1, inOverlayNetwork2}).To(ContainElements([]bool{true, false}))
+
+				By("testing the mask size")
+				Expect(leaseSubnet.Mask).To(Equal(expectedLeaseMask))
+
+				By("testing that the first IP is never allocated")
+				Expect(leaseIP.To4()).NotTo(Equal(overlayNetwork1.IP.To4()))
+				Expect(leaseIP.To4()).NotTo(Equal(overlayNetwork2.IP.To4()))
+
+				taken = append(taken, lease)
 			}
-		})
 
-		Context("when no subnets are available", func() {
-			It("returns an empty string", func() {
-				subnetRange := "10.255.0.0/16"
-				cidrPool := leaser.NewCIDRPool(subnetRange, 24)
-				var taken []string
-				for i := 0; i < 255; i++ {
-					s := cidrPool.GetAvailableBlock(taken)
-					taken = append(taken, s)
+			By("double checking that there are the correct number of leases")
+			Expect(taken).To(HaveLen(expectedNumBlockLeases))
+
+			By("testing that there are no more leases left")
+			lease := cidrPool.GetAvailableBlock(taken)
+			Expect(lease).To(Equal(""))
+
+			By("testing that all of the leases are unique")
+			for index1, i := range taken {
+				for index2, j := range taken {
+					if index1 == index2 {
+						continue
+					}
+					Expect(i).ToNot(Equal(j))
 				}
-				s := cidrPool.GetAvailableBlock(taken)
-				Expect(s).To(Equal(""))
-			})
-		})
-	})
+			}
+		},
+		// /16 x2 = 65536 x2 = 131072 ; /24 = 256 ; 131072 / 256 = 512
+		// 512 - 2 (first block of each network is excluded) = 510
+		Entry("When the subnet mask is 24", 24, 510, net.IPMask{255, 255, 255, 0}),
+		// /16 x2 = 65536 x2 = 131072 ; /20 = 4096 ; 131072 / 4096 = 32
+		// 32 - 2 (first block of each network is excluded) = 30
+		Entry("When the subnet mask is 20", 20, 30, net.IPMask{255, 255, 240, 0}),
+	)
 
-	Describe("GetAvailableSingleIP", func() {
-		It("returns a single ip that is not taken", func() {
-			subnetRange := "10.255.0.0/16"
-			_, network, _ := net.ParseCIDR(subnetRange)
-			cidrPool := leaser.NewCIDRPool(subnetRange, 24)
+	DescribeTable("GetAvailableSingleIP",
+		func(subnetMaskSize, expectedNumSingleIPLeases int) {
 
-			results := map[string]int{}
+			overlayNetwork1String := "10.255.0.0/16"
+			overlayNetwork2String := "10.250.0.0/16"
+			overlayNetworkStrings := []string{overlayNetwork1String, overlayNetwork2String}
+			overlayNetwork1 := getNetworks(overlayNetworkStrings)[0]
+			overlayNetwork2 := getNetworks(overlayNetworkStrings)[1]
+			cidrPool := leaser.NewCIDRPool(overlayNetworkStrings, subnetMaskSize)
 
 			var taken []string
-			for i := 0; i < 255; i++ {
-				s := cidrPool.GetAvailableSingleIP(taken)
-				results[s]++
-				taken = append(taken, s)
-			}
-			Expect(len(results)).To(Equal(255))
+			for i := 1; i <= expectedNumSingleIPLeases; i++ {
+				By("testing that there are still leases left")
+				lease := cidrPool.GetAvailableSingleIP(taken)
+				Expect(lease).ToNot(Equal(""))
 
-			for result := range results {
-				_, subnet, err := net.ParseCIDR(result)
+				By("testing that the lease is a valid subnet")
+				leaseIP, leaseSubnet, err := net.ParseCIDR(lease)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(network.Contains(subnet.IP)).To(BeTrue())
-				Expect(subnet.Mask).To(Equal(net.IPMask{255, 255, 255, 255}))
-				// 10.255.0.0 should never be allocated? Maybe?
-				Expect(subnet.IP.To4()).NotTo(Equal(network.IP.To4()))
+
+				By("testing that the leaseIP is in the first overlayNetwork")
+				Expect(overlayNetwork1.Contains(leaseIP)).To(BeTrue())
+
+				By("testing that the leaseIP is not in the second overlayNetwork")
+				Expect(overlayNetwork2.Contains(leaseIP)).To(BeFalse())
+
+				By("testing that the mask is always /32")
+				Expect(leaseSubnet.Mask).To(Equal(net.IPMask{255, 255, 255, 255}))
+
+				By("testing that the first IP is never allocated")
+				Expect(leaseIP.To4()).NotTo(Equal(overlayNetwork1.IP.To4()))
+
+				taken = append(taken, lease)
 			}
-		})
 
-		Context("when the subnet mask is 29", func() {
-			It("returns ips containing only .1-.7", func() {
-				subnetRange := "10.255.0.0/16"
-				_, network, _ := net.ParseCIDR(subnetRange)
-				cidrPool := leaser.NewCIDRPool(subnetRange, 29)
+			By("double checking that there are the correct number of leases")
+			Expect(taken).To(HaveLen(expectedNumSingleIPLeases))
 
-				results := map[string]int{}
+			By("testing that there are no more leases left")
+			lease := cidrPool.GetAvailableSingleIP(taken)
+			Expect(lease).To(Equal(""))
 
-				var taken []string
-				for i := 0; i < 7; i++ {
-					s := cidrPool.GetAvailableSingleIP(taken)
-					results[s]++
-					taken = append(taken, s)
+			By("testing that all of the leases are unique")
+			for index1, i := range taken {
+				for index2, j := range taken {
+					if index1 == index2 {
+						continue
+					}
+					Expect(i).ToNot(Equal(j))
 				}
-				Expect(len(results)).To(Equal(7))
-
-				Expect(results).To(Equal(map[string]int{
-					"10.255.0.1/32": 1,
-					"10.255.0.2/32": 1,
-					"10.255.0.3/32": 1,
-					"10.255.0.4/32": 1,
-					"10.255.0.5/32": 1,
-					"10.255.0.6/32": 1,
-					"10.255.0.7/32": 1,
-				}))
-
-				for result := range results {
-					_, subnet, err := net.ParseCIDR(result)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(network.Contains(subnet.IP)).To(BeTrue())
-					Expect(subnet.Mask).To(Equal(net.IPMask{255, 255, 255, 255}))
-					// 10.255.0.0 should never be allocated? Maybe?
-					Expect(subnet.IP.To4()).NotTo(Equal(network.IP.To4()))
-				}
-			})
-		})
-
-		Context("when no subnets are available", func() {
-			It("returns an empty string", func() {
-				subnetRange := "10.255.0.0/16"
-				cidrPool := leaser.NewCIDRPool(subnetRange, 24)
-				var taken []string
-				for i := 0; i < 255; i++ {
-					s := cidrPool.GetAvailableSingleIP(taken)
-					taken = append(taken, s)
-				}
-				s := cidrPool.GetAvailableSingleIP(taken)
-				Expect(s).To(Equal(""))
-			})
-		})
-	})
+			}
+		},
+		Entry("When the subnet mask is 24", 24, 255),
+		Entry("When the subnet mask is 29", 29, 7),
+	)
 
 	Describe("IsMember", func() {
 		var cidrPool *leaser.CIDRPool
 		BeforeEach(func() {
-			subnetRange := "10.255.0.0/16"
+			subnetRange := []string{"10.255.0.0/16", "10.250.0.0/16"}
 			cidrPool = leaser.NewCIDRPool(subnetRange, 24)
 		})
 
 		Context("when the subnet is in the block pool and not in the single pool", func() {
-			It("returns true", func() {
-				Expect(cidrPool.IsMember("10.255.30.0/24")).To(BeTrue())
+			Context("when it is in the first cidr", func() {
+				It("returns true", func() {
+					Expect(cidrPool.IsMember("10.255.30.0/24")).To(BeTrue())
+				})
+			})
+
+			Context("when it is in the second cidr", func() {
+				It("returns true", func() {
+					Expect(cidrPool.IsMember("10.250.30.0/24")).To(BeTrue())
+				})
 			})
 		})
 
-		Context("when the subnet is in the single pool and not in the block pool", func() {
-			It("returns true", func() {
+		Context("when the IP is in the first subnet of the first overlayNetwork", func() {
+			It("is in the singleIP pool and returns true", func() {
 				Expect(cidrPool.IsMember("10.255.0.5/32")).To(BeTrue())
+			})
+		})
+
+		Context("when the IP is in the first subnet of the 2nd+ overlayNetwork", func() {
+			It("is not in either the singleIP pool or block pool and returns false", func() {
+				Expect(cidrPool.IsMember("10.250.0.5/32")).To(BeFalse())
 			})
 		})
 
@@ -212,3 +301,27 @@ var _ = Describe("CIDRPool", func() {
 		})
 	})
 })
+
+func getNetworks(cidrStrings []string) []*net.IPNet {
+	networks := []*net.IPNet{}
+	for _, c := range cidrStrings {
+		_, overlayNetwork, _ := net.ParseCIDR(c)
+		networks = append(networks, overlayNetwork)
+	}
+	return networks
+}
+
+func oneNetworkContains(networks []*net.IPNet, ip net.IP) bool {
+	found := false
+
+	for _, network := range networks {
+		if network.Contains(ip) {
+			if found == true {
+				panic("ip should not be in multipe blocks")
+			}
+			found = true
+		}
+	}
+
+	return found
+}

--- a/src/code.cloudfoundry.org/silk/daemon/vtep/converger_test.go
+++ b/src/code.cloudfoundry.org/silk/daemon/vtep/converger_test.go
@@ -2,127 +2,228 @@ package vtep_test
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"syscall"
 
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagertest"
+	mcn "code.cloudfoundry.org/lib/multiple-cidr-network"
 	"code.cloudfoundry.org/silk/controller"
 	"code.cloudfoundry.org/silk/daemon/vtep"
 	"code.cloudfoundry.org/silk/daemon/vtep/fakes"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 var _ = Describe("Converger", func() {
 	var (
-		fakeNetlink *fakes.NetlinkAdapter
-		converger   *vtep.Converger
-		leases      []controller.Lease
-		overlayNet  *net.IPNet
-		logger      *lagertest.TestLogger
-		localMac    net.HardwareAddr
-		remoteMac   net.HardwareAddr
+		fakeNetlink                                                  *fakes.NetlinkAdapter
+		converger                                                    *vtep.Converger
+		leases                                                       []controller.Lease
+		overlayNetworks                                              mcn.MultipleCIDRNetwork
+		logger                                                       *lagertest.TestLogger
+		localMac                                                     net.HardwareAddr
+		remoteMac                                                    net.HardwareAddr
+		remoteMacOnSecondNetwork                                     net.HardwareAddr
+		singleIPMacOnFirstNetwork                                    net.HardwareAddr
+		singleIPMacOnSecondNetwork                                   net.HardwareAddr
+		localVTEP                                                    net.Interface
+		remoteLeaseOnNetwork1, remoteLeaseOnNetwork2                 controller.Lease
+		remoteSingleIPLeaseOnNetwork1, remoteSingleIPLeaseOnNetwork2 controller.Lease
 	)
 
 	Describe("Converge", func() {
 		BeforeEach(func() {
+			var err error
 			fakeNetlink = &fakes.NetlinkAdapter{}
-			_, localSubnet, _ := net.ParseCIDR("10.255.32.0/24")
-			_, overlayNet, _ = net.ParseCIDR("10.255.0.0/16")
+
+			overlayNetworks, err = mcn.NewMultipleCIDRNetwork([]string{"10.255.0.0/16", "10.250.0.0/16"})
+			Expect(err).ToNot(HaveOccurred())
+
 			logger = lagertest.NewTestLogger("test")
-			localVTEP := net.Interface{
+			localVTEP = net.Interface{
 				Index: 42,
 				Name:  "silk-vtep",
 			}
-			converger = &vtep.Converger{
-				OverlayNetwork: overlayNet,
-				LocalSubnet:    localSubnet,
-				LocalVTEP:      localVTEP,
-				NetlinkAdapter: fakeNetlink,
-				Logger:         logger,
-			}
+
 			localMac, _ = net.ParseMAC("ee:ee:aa:bb:cc:dd")
 			remoteMac, _ = net.ParseMAC("ee:ee:aa:aa:aa:ff")
-			leases = []controller.Lease{
-				controller.Lease{
-					UnderlayIP:          "10.10.0.4",
-					OverlaySubnet:       "10.255.32.0/24",
-					OverlayHardwareAddr: localMac.String(),
-				},
-				controller.Lease{
-					UnderlayIP:          "10.10.0.5",
-					OverlaySubnet:       "10.255.19.0/24",
-					OverlayHardwareAddr: remoteMac.String(),
-				},
+			remoteMacOnSecondNetwork, _ = net.ParseMAC("cc:cc:cc:cc:cc:cc")
+			singleIPMacOnFirstNetwork, _ = net.ParseMAC("aa:bb:bb:bb:bb:bb")
+			singleIPMacOnSecondNetwork, _ = net.ParseMAC("ab:bb:bb:bb:bb:bb")
+
+			remoteLeaseOnNetwork1 = controller.Lease{
+				UnderlayIP:          "10.10.0.5",
+				OverlaySubnet:       "10.255.19.0/24", // on network 1 - 10.255.0.0/16
+				OverlayHardwareAddr: remoteMac.String(),
 			}
-		})
-
-		It("adds routing rule for each remote lease", func() {
-			err := converger.Converge(leases)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(fakeNetlink.RouteReplaceCallCount()).To(Equal(1))
-			addedRoute := fakeNetlink.RouteReplaceArgsForCall(0)
-			destGW, destNet, _ := net.ParseCIDR("10.255.19.0/24")
-			Expect(addedRoute).To(Equal(&netlink.Route{
-				LinkIndex: 42,
-				Scope:     netlink.SCOPE_UNIVERSE,
-				Dst:       destNet,
-				Gw:        destGW,
-				Src:       net.ParseIP("10.255.32.0").To4(),
-			}))
-		})
-
-		It("adds an ARP and FDB rule for each remote lease", func() {
-			err := converger.Converge(leases)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(fakeNetlink.NeighSetCallCount()).To(Equal(2))
-			neighs := []*netlink.Neigh{
-				fakeNetlink.NeighSetArgsForCall(0),
-				fakeNetlink.NeighSetArgsForCall(1),
+			remoteLeaseOnNetwork2 = controller.Lease{
+				UnderlayIP:          "10.10.0.7",
+				OverlaySubnet:       "10.250.50.0/24", // on network 2 - 10.250.0.0/16
+				OverlayHardwareAddr: remoteMacOnSecondNetwork.String(),
 			}
-			Expect(neighs).To(ConsistOf(
-				&netlink.Neigh{
-					LinkIndex:    42,
-					State:        netlink.NUD_PERMANENT,
-					Type:         syscall.RTN_UNICAST,
-					IP:           net.ParseIP("10.255.19.0"),
-					HardwareAddr: remoteMac,
-				},
-				&netlink.Neigh{
-					LinkIndex:    42,
-					State:        netlink.NUD_PERMANENT,
-					Family:       syscall.AF_BRIDGE,
-					Flags:        netlink.NTF_SELF,
-					IP:           net.ParseIP("10.10.0.5"),
-					HardwareAddr: remoteMac,
-				},
-			))
+			remoteSingleIPLeaseOnNetwork1 = controller.Lease{
+				UnderlayIP:          "10.10.0.9",
+				OverlaySubnet:       "10.255.1.11/32", // single IP lease on network 1 - 10.255.0.0/16
+				OverlayHardwareAddr: singleIPMacOnFirstNetwork.String(),
+			}
+			remoteSingleIPLeaseOnNetwork2 = controller.Lease{
+				UnderlayIP:          "10.10.0.11",
+				OverlaySubnet:       "10.255.50.11/32", // single IP lease on network 2 - 10.250.0.0/16
+				OverlayHardwareAddr: singleIPMacOnSecondNetwork.String(),
+			}
+
 		})
 
-		It("does not log anything about non-routable leases", func() {
-			err := converger.Converge(leases)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(logger.Logs()).To(HaveLen(0))
-		})
-
-		Context("when the a remote lease is removed", func() {
+		Context("when the local lease is SingleIP", func() {
 			var (
-				deletedNeighs []netlink.Neigh
-				oldDestMac    net.HardwareAddr
+				localOverlayIP    string
+				localOverlayLease *net.IPNet
 			)
 			BeforeEach(func() {
+				localOverlayIP = "10.255.0.66"
+				_, localOverlayLease, _ = net.ParseCIDR(fmt.Sprintf("%s/32", localOverlayIP))
+
+				converger = &vtep.Converger{
+					OverlayNetwork: overlayNetworks,
+					LocalSubnet:    localOverlayLease,
+					LocalVTEP:      localVTEP,
+					NetlinkAdapter: fakeNetlink,
+					Logger:         logger,
+					IsSingleIP:     true,
+				}
+
+				localLease := controller.Lease{
+					UnderlayIP:          "10.10.0.4",
+					OverlaySubnet:       fmt.Sprintf("%s/32", localOverlayIP),
+					OverlayHardwareAddr: localMac.String(),
+				}
+
+				leases = []controller.Lease{
+					localLease,
+					remoteLeaseOnNetwork1,
+					remoteLeaseOnNetwork2,
+					remoteSingleIPLeaseOnNetwork1,
+					remoteSingleIPLeaseOnNetwork2,
+				}
+			})
+
+			It("adds routing rule for each non-single IP remote lease with a src", func() {
+				err := converger.Converge(leases)
+				Expect(err).NotTo(HaveOccurred())
+
+				// RouteReplace Call count is called once for each non-SingleIP lease
+				Expect(fakeNetlink.RouteReplaceCallCount()).To(Equal(2))
+
+				addedRoute := fakeNetlink.RouteReplaceArgsForCall(0)
+				destGW, destNet, _ := net.ParseCIDR(remoteLeaseOnNetwork1.OverlaySubnet)
+				Expect(addedRoute).To(Equal(&netlink.Route{
+					LinkIndex: 42,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					Dst:       destNet, // 10.255.19.0/24
+					Gw:        destGW,  // 10.255.19.0
+					Flags:     unix.RTNH_F_ONLINK,
+					Src:       localOverlayLease.IP, // in the same overlay cidr, so it gets the local IP
+				}))
+
+				_, network2cidr, _ := net.ParseCIDR("10.250.0.0/16")
+				addedRoute = fakeNetlink.RouteReplaceArgsForCall(1)
+				destGW, destNet, _ = net.ParseCIDR(remoteLeaseOnNetwork2.OverlaySubnet)
+				Expect(addedRoute).To(Equal(&netlink.Route{
+					LinkIndex: 42,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					Dst:       destNet, // 10.250.50.0/24
+					Gw:        destGW,  // 10.250.50.0
+					Flags:     unix.RTNH_F_ONLINK,
+					Src:       network2cidr.IP, // on a different overlay idr, so it gets the first IP of the entire cidr
+				}))
+			})
+		})
+
+		Context("when the local lease is non-SingleIP", func() {
+			var (
+				localOverlayLease *net.IPNet
+			)
+			BeforeEach(func() {
+				_, localOverlayLease, _ = net.ParseCIDR("10.255.32.0/24")
+				converger = &vtep.Converger{
+					OverlayNetwork: overlayNetworks,
+					LocalSubnet:    localOverlayLease,
+					LocalVTEP:      localVTEP,
+					NetlinkAdapter: fakeNetlink,
+					Logger:         logger,
+					IsSingleIP:     false,
+				}
+
+				localLease := controller.Lease{
+					UnderlayIP:          "10.10.0.4",
+					OverlaySubnet:       "10.255.32.0/24", // local subnet on network 1
+					OverlayHardwareAddr: localMac.String(),
+				}
+
+				leases = []controller.Lease{
+					localLease,
+					remoteLeaseOnNetwork1,
+					remoteLeaseOnNetwork2,
+					remoteSingleIPLeaseOnNetwork1,
+					remoteSingleIPLeaseOnNetwork2,
+				}
+			})
+
+			It("adds routing rule for each non-single IP remote lease", func() {
+				err := converger.Converge(leases)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("testing that the remote leases are added")
+				Expect(fakeNetlink.RouteReplaceCallCount()).To(Equal(2))
+				addedRoute := fakeNetlink.RouteReplaceArgsForCall(0)
 				destGW, destNet, _ := net.ParseCIDR("10.255.19.0/24")
+				Expect(addedRoute).To(Equal(&netlink.Route{
+					LinkIndex: 42,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					Dst:       destNet,              // 10.255.19.0/24
+					Gw:        destGW,               // 10.255.19.0
+					Src:       localOverlayLease.IP, //10.255.32.0 - local IP because it is in the same overlay CIDR
+				}))
 
-				oldDestMac, _ = net.ParseMAC("ee:ee:0a:ff:14:00")
-				oldDestGW, oldDestNet, _ := net.ParseCIDR("10.255.20.0/24")
+				addedRoute = fakeNetlink.RouteReplaceArgsForCall(1)
+				destGW, destNet, _ = net.ParseCIDR("10.250.50.0/24")
+				Expect(addedRoute).To(Equal(&netlink.Route{
+					LinkIndex: 42,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					Dst:       destNet,                        // 10.250.50.0/24
+					Gw:        destGW,                         // 10.250.50.0
+					Src:       overlayNetworks.Networks[1].IP, // in a different CIDR - so use the IP of that CIDR
+				}))
+			})
 
-				fakeNetlink.FDBListReturns([]netlink.Neigh{
-					netlink.Neigh{
+			It("adds an ARP and FDB rule for each remote lease, including singleIP leases", func() {
+				err := converger.Converge(leases)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fakeNetlink.NeighSetCallCount()).To(Equal(8)) // called twice per remote lease
+				neighs := []*netlink.Neigh{
+					fakeNetlink.NeighSetArgsForCall(0),
+					fakeNetlink.NeighSetArgsForCall(1),
+					fakeNetlink.NeighSetArgsForCall(2),
+					fakeNetlink.NeighSetArgsForCall(3),
+					fakeNetlink.NeighSetArgsForCall(4),
+					fakeNetlink.NeighSetArgsForCall(5),
+					fakeNetlink.NeighSetArgsForCall(6),
+					fakeNetlink.NeighSetArgsForCall(7),
+				}
+				Expect(neighs).To(ConsistOf(
+					&netlink.Neigh{
+						LinkIndex:    42,
+						State:        netlink.NUD_PERMANENT,
+						Type:         syscall.RTN_UNICAST,
+						IP:           net.ParseIP("10.255.19.0"),
+						HardwareAddr: remoteMac,
+					},
+					&netlink.Neigh{
 						LinkIndex:    42,
 						State:        netlink.NUD_PERMANENT,
 						Family:       syscall.AF_BRIDGE,
@@ -130,309 +231,605 @@ var _ = Describe("Converger", func() {
 						IP:           net.ParseIP("10.10.0.5"),
 						HardwareAddr: remoteMac,
 					},
-					netlink.Neigh{
+					&netlink.Neigh{
+						LinkIndex:    42,
+						State:        netlink.NUD_PERMANENT,
+						Type:         syscall.RTN_UNICAST,
+						IP:           net.ParseIP("10.250.50.0"),
+						HardwareAddr: remoteMacOnSecondNetwork,
+					},
+					&netlink.Neigh{
 						LinkIndex:    42,
 						State:        netlink.NUD_PERMANENT,
 						Family:       syscall.AF_BRIDGE,
 						Flags:        netlink.NTF_SELF,
-						IP:           net.ParseIP("10.10.0.6"),
-						HardwareAddr: oldDestMac,
+						IP:           net.ParseIP("10.10.0.7"),
+						HardwareAddr: remoteMacOnSecondNetwork,
 					},
-				}, nil)
-
-				fakeNetlink.ARPListReturns([]netlink.Neigh{
-					netlink.Neigh{
+					&netlink.Neigh{ // singleIP on network 1 - ARP
 						LinkIndex:    42,
 						State:        netlink.NUD_PERMANENT,
 						Type:         syscall.RTN_UNICAST,
-						IP:           net.ParseIP("10.255.19.0"),
-						HardwareAddr: remoteMac,
+						IP:           net.ParseIP("10.255.1.11"),
+						HardwareAddr: singleIPMacOnFirstNetwork,
 					},
-					netlink.Neigh{
-						LinkIndex:    42,
-						State:        netlink.NUD_PERMANENT,
-						Type:         syscall.RTN_UNICAST,
-						IP:           net.ParseIP("10.255.20.0"),
-						HardwareAddr: oldDestMac,
-					},
-				}, nil)
-
-				fakeNetlink.RouteListReturns([]netlink.Route{
-					netlink.Route{
-						LinkIndex: 42,
-						Scope:     netlink.SCOPE_UNIVERSE,
-						Dst:       destNet,
-						Gw:        destGW,
-						Src:       net.ParseIP("10.255.32.0").To4(),
-					},
-					netlink.Route{
-						LinkIndex: 42,
-						Scope:     netlink.SCOPE_UNIVERSE,
-						Dst:       overlayNet,
-						Gw:        nil,
-						Src:       net.ParseIP("10.255.32.0").To4(),
-					},
-					netlink.Route{
-						LinkIndex: 42,
-						Scope:     netlink.SCOPE_UNIVERSE,
-						Dst:       oldDestNet,
-						Gw:        oldDestGW,
-						Src:       net.ParseIP("10.255.48.0").To4(),
-					},
-				}, nil)
-
-				deletedNeighs = []netlink.Neigh{}
-				fakeNetlink.NeighDelStub = func(neigh *netlink.Neigh) error {
-					deletedNeighs = append(deletedNeighs, *neigh)
-					return nil
-				}
-			})
-
-			It("deletes the routing, ARP, and FDB rules related to the removed lease", func() {
-				err := converger.Converge(leases)
-				Expect(err).NotTo(HaveOccurred())
-
-				By("checking that the route is deleted")
-				Expect(fakeNetlink.RouteDelCallCount()).To(Equal(1))
-				deletedRoute := fakeNetlink.RouteDelArgsForCall(0)
-				destGW, destNet, _ := net.ParseCIDR("10.255.20.0/24")
-				Expect(deletedRoute).To(Equal(&netlink.Route{
-					LinkIndex: 42,
-					Scope:     netlink.SCOPE_UNIVERSE,
-					Dst:       destNet,
-					Gw:        destGW,
-					Src:       net.ParseIP("10.255.48.0").To4(),
-				}))
-
-				By("checking that the ARP and FDB rules is deleted")
-				Expect(fakeNetlink.NeighDelCallCount()).To(Equal(2))
-
-				Expect(deletedNeighs).To(ConsistOf(
-					// ARP
-					netlink.Neigh{
-						LinkIndex:    42,
-						State:        netlink.NUD_PERMANENT,
-						Type:         syscall.RTN_UNICAST,
-						IP:           net.ParseIP("10.255.20.0"),
-						HardwareAddr: oldDestMac,
-					},
-					// FDB
-					netlink.Neigh{
+					&netlink.Neigh{ // singleIP on network 1 - Bridge
 						LinkIndex:    42,
 						State:        netlink.NUD_PERMANENT,
 						Family:       syscall.AF_BRIDGE,
 						Flags:        netlink.NTF_SELF,
-						IP:           net.ParseIP("10.10.0.6"),
-						HardwareAddr: oldDestMac,
+						IP:           net.ParseIP("10.10.0.9"),
+						HardwareAddr: singleIPMacOnFirstNetwork,
+					},
+					&netlink.Neigh{ // singleIP on network 2 - ARP
+						LinkIndex:    42,
+						State:        netlink.NUD_PERMANENT,
+						Type:         syscall.RTN_UNICAST,
+						IP:           net.ParseIP("10.255.50.11"),
+						HardwareAddr: singleIPMacOnSecondNetwork,
+					},
+					&netlink.Neigh{ // singleIP on network 2 - Bridge
+						LinkIndex:    42,
+						State:        netlink.NUD_PERMANENT,
+						Family:       syscall.AF_BRIDGE,
+						Flags:        netlink.NTF_SELF,
+						IP:           net.ParseIP("10.10.0.11"),
+						HardwareAddr: singleIPMacOnSecondNetwork,
 					},
 				))
 			})
 
-		})
-
-		Context("when there are other routing rules", func() {
-			BeforeEach(func() {
-				fakeNetlink.RouteListReturns([]netlink.Route{
-					netlink.Route{
-						LinkIndex: 42,
-						Scope:     netlink.SCOPE_UNIVERSE,
-						Dst:       overlayNet,
-						Gw:        nil,
-						Src:       net.ParseIP("10.255.32.0").To4(),
-					},
-				}, nil)
-			})
-
-			It("does not delete rules it did not create", func() {
+			It("does not log anything about non-routable leases", func() {
 				err := converger.Converge(leases)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(fakeNetlink.RouteDelCallCount()).To(Equal(0))
-			})
-		})
-
-		Context("when the link cannot be found", func() {
-			BeforeEach(func() {
-				fakeNetlink.LinkByIndexReturns(nil, errors.New("passionfruit"))
+				Expect(logger.Logs()).To(HaveLen(0))
 			})
 
-			It("breaks early and returns a meaningful error", func() {
-				err := converger.Converge(leases)
-				Expect(err).To(MatchError("link by index: passionfruit"))
-			})
-		})
+			Context("when a non-single IP remote lease is removed", func() {
+				var (
+					deletedNeighs []netlink.Neigh
+					oldDestMac    net.HardwareAddr
+				)
+				BeforeEach(func() {
+					destGW, destNet, _ := net.ParseCIDR("10.255.19.0/24")
+					destGWOnSecondNetwork, destNetOnSecondNetwork, _ := net.ParseCIDR("10.250.50.0/24")
 
-		Context("when previous routes cannot be found", func() {
-			BeforeEach(func() {
-				fakeNetlink.RouteListReturns(nil, errors.New("peach"))
-			})
+					oldDestMac, _ = net.ParseMAC("ee:ee:0a:ff:14:00")
+					oldDestGW, oldDestNet, _ := net.ParseCIDR("10.250.20.0/24")
 
-			It("breaks early and returns a meaningful error", func() {
-				err := converger.Converge(leases)
-				Expect(err).To(MatchError("list routes: peach"))
-			})
-		})
+					fakeNetlink.FDBListReturns([]netlink.Neigh{
+						netlink.Neigh{
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Family:       syscall.AF_BRIDGE,
+							Flags:        netlink.NTF_SELF,
+							IP:           net.ParseIP("10.10.0.5"),
+							HardwareAddr: remoteMac,
+						},
+						netlink.Neigh{
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Family:       syscall.AF_BRIDGE,
+							Flags:        netlink.NTF_SELF,
+							IP:           net.ParseIP("10.10.0.7"),
+							HardwareAddr: remoteMacOnSecondNetwork,
+						},
+						netlink.Neigh{
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Family:       syscall.AF_BRIDGE,
+							Flags:        netlink.NTF_SELF,
+							IP:           net.ParseIP("10.10.0.6"),
+							HardwareAddr: oldDestMac,
+						},
+						netlink.Neigh{ // singleIP on network 1 - Bridge
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Family:       syscall.AF_BRIDGE,
+							Flags:        netlink.NTF_SELF,
+							IP:           net.ParseIP("10.10.0.9"),
+							HardwareAddr: singleIPMacOnFirstNetwork,
+						},
+						netlink.Neigh{ // singleIP on network 2 - Bridge
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Family:       syscall.AF_BRIDGE,
+							Flags:        netlink.NTF_SELF,
+							IP:           net.ParseIP("10.10.0.11"),
+							HardwareAddr: singleIPMacOnSecondNetwork,
+						},
+					}, nil)
 
-		Context("when previous fdb entries cannot be found", func() {
-			BeforeEach(func() {
-				fakeNetlink.FDBListReturns(nil, errors.New("kiwi"))
-			})
+					fakeNetlink.ARPListReturns([]netlink.Neigh{
+						netlink.Neigh{
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Type:         syscall.RTN_UNICAST,
+							IP:           net.ParseIP("10.255.19.0"),
+							HardwareAddr: remoteMac,
+						},
+						netlink.Neigh{
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Type:         syscall.RTN_UNICAST,
+							IP:           net.ParseIP("10.250.50.0"),
+							HardwareAddr: remoteMacOnSecondNetwork,
+						},
+						netlink.Neigh{
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Type:         syscall.RTN_UNICAST,
+							IP:           net.ParseIP("10.250.20.0"),
+							HardwareAddr: oldDestMac,
+						},
+						netlink.Neigh{ // singleIP on network 1 - ARP
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Type:         syscall.RTN_UNICAST,
+							IP:           net.ParseIP("10.255.1.11"),
+							HardwareAddr: singleIPMacOnFirstNetwork,
+						},
+						netlink.Neigh{ // singleIP on network 2 - ARP
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Type:         syscall.RTN_UNICAST,
+							IP:           net.ParseIP("10.255.50.11"),
+							HardwareAddr: singleIPMacOnSecondNetwork,
+						},
+					}, nil)
 
-			It("breaks early and returns a meaningful error", func() {
-				err := converger.Converge(leases)
-				Expect(err).To(MatchError("list fdb: kiwi"))
-			})
-		})
+					fakeNetlink.RouteListReturns([]netlink.Route{
+						netlink.Route{
+							LinkIndex: 42,
+							Scope:     netlink.SCOPE_UNIVERSE,
+							Dst:       destNet,
+							Gw:        destGW,
+							Src:       localOverlayLease.IP,
+						},
+						netlink.Route{
+							LinkIndex: 42,
+							Scope:     netlink.SCOPE_UNIVERSE,
+							Dst:       overlayNetworks.Networks[0],
+							Gw:        nil,
+							Src:       localOverlayLease.IP,
+						},
+						netlink.Route{
+							LinkIndex: 42,
+							Scope:     netlink.SCOPE_UNIVERSE,
+							Dst:       destNetOnSecondNetwork,
+							Gw:        destGWOnSecondNetwork,
+							Src:       overlayNetworks.Networks[1].IP,
+						},
+						netlink.Route{
+							LinkIndex: 42,
+							Scope:     netlink.SCOPE_UNIVERSE,
+							Dst:       oldDestNet,
+							Gw:        oldDestGW,
+							Src:       overlayNetworks.Networks[1].IP,
+						},
+					}, nil)
 
-		Context("when previous arp entries cannot be found", func() {
-			BeforeEach(func() {
-				fakeNetlink.ARPListReturns(nil, errors.New("lychee"))
-			})
+					deletedNeighs = []netlink.Neigh{}
+					fakeNetlink.NeighDelStub = func(neigh *netlink.Neigh) error {
+						deletedNeighs = append(deletedNeighs, *neigh)
+						return nil
+					}
+				})
 
-			It("breaks early and returns a meaningful error", func() {
-				err := converger.Converge(leases)
-				Expect(err).To(MatchError("list arp: lychee"))
-			})
-		})
+				It("deletes the routing, ARP, and FDB rules related to the removed lease", func() {
+					err := converger.Converge(leases)
+					Expect(err).NotTo(HaveOccurred())
 
-		Context("when the lease subnet is malformed", func() {
-			BeforeEach(func() {
-				leases[1].OverlaySubnet = "banana"
-			})
-			It("breaks early and returns a meaningful error", func() {
-				err := converger.Converge(leases)
-				Expect(err).To(MatchError("parse lease: invalid CIDR address: banana"))
-			})
-		})
-
-		Context("when the underlay IP is malformed", func() {
-			BeforeEach(func() {
-				leases[1].UnderlayIP = "kumquat"
-			})
-			It("breaks early and returns a meaningful error", func() {
-				err := converger.Converge(leases)
-				Expect(err).To(MatchError("invalid underlay ip: kumquat"))
-			})
-		})
-
-		Context("when adding the route fails", func() {
-			BeforeEach(func() {
-				fakeNetlink.RouteReplaceReturns(errors.New("apricot"))
-			})
-			It("returns a meaningful error", func() {
-				err := converger.Converge(leases)
-				Expect(err).To(MatchError("add route: apricot"))
-			})
-		})
-
-		Context("when adding a neigh fails", func() {
-			BeforeEach(func() {
-				fakeNetlink.NeighSetReturns(errors.New("pear"))
-			})
-			It("returns a meaningful error", func() {
-				err := converger.Converge(leases)
-				Expect(err).To(MatchError("set neigh: pear"))
-			})
-		})
-
-		Context("when deleting the route fails", func() {
-			BeforeEach(func() {
-				fakeNetlink.RouteDelReturns(errors.New("durian"))
-
-				destGW, destNet, _ := net.ParseCIDR("10.255.19.0/24")
-				fakeNetlink.RouteListReturns([]netlink.Route{
-					netlink.Route{
+					By("checking that the route is deleted")
+					Expect(fakeNetlink.RouteDelCallCount()).To(Equal(1))
+					deletedRoute := fakeNetlink.RouteDelArgsForCall(0)
+					destGW, destNet, _ := net.ParseCIDR("10.250.20.0/24")
+					Expect(deletedRoute).To(Equal(&netlink.Route{
 						LinkIndex: 42,
 						Scope:     netlink.SCOPE_UNIVERSE,
 						Dst:       destNet,
 						Gw:        destGW,
-						Src:       net.ParseIP("10.255.32.0").To4(),
-					},
-				}, nil)
-			})
-			It("returns a meaningful error", func() {
-				err := converger.Converge([]controller.Lease{})
-				Expect(err).To(MatchError("del route: durian"))
-			})
-		})
+						Src:       overlayNetworks.Networks[1].IP,
+					}))
 
-		Context("when deleting a neigh fails", func() {
-			BeforeEach(func() {
-				fakeNetlink.NeighDelReturns(errors.New("mango"))
+					By("checking that the ARP and FDB rules is deleted")
+					Expect(fakeNetlink.NeighDelCallCount()).To(Equal(2))
 
-				fakeNetlink.ARPListReturns([]netlink.Neigh{
-					netlink.Neigh{
-						LinkIndex:    42,
-						State:        netlink.NUD_PERMANENT,
-						Type:         syscall.RTN_UNICAST,
-						IP:           net.ParseIP("10.255.19.0"),
-						HardwareAddr: remoteMac,
-					},
-				}, nil)
+					Expect(deletedNeighs).To(ConsistOf(
+						// ARP
+						netlink.Neigh{
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Type:         syscall.RTN_UNICAST,
+							IP:           net.ParseIP("10.250.20.0"),
+							HardwareAddr: oldDestMac,
+						},
+						// FDB
+						netlink.Neigh{
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Family:       syscall.AF_BRIDGE,
+							Flags:        netlink.NTF_SELF,
+							IP:           net.ParseIP("10.10.0.6"),
+							HardwareAddr: oldDestMac,
+						},
+					))
+				})
 			})
-			It("returns a meaningful error", func() {
-				err := converger.Converge([]controller.Lease{})
-				Expect(err).To(MatchError("del neigh with ip/hwaddr 10.255.19.0 ee:ee:aa:aa:aa:ff: mango"))
-			})
-		})
 
-		Context("when there are remote leases that are not in the overlay network", func() {
-			BeforeEach(func() {
-				leases = []controller.Lease{
-					{ // local, skipped
-						UnderlayIP:          "10.10.0.2",
-						OverlaySubnet:       "10.255.32.0/24",
-						OverlayHardwareAddr: "aa:aa:00:00:00:00",
-					},
-					{ // not in overlay, skipped
-						UnderlayIP:          "10.10.0.3",
-						OverlaySubnet:       "10.254.11.0/24",
-						OverlayHardwareAddr: "aa:aa:00:00:00:01",
-					},
-					{ // not in overlay, skipped
-						UnderlayIP:          "10.10.0.4",
-						OverlaySubnet:       "10.254.12.0/24",
-						OverlayHardwareAddr: "aa:aa:00:00:00:02",
-					},
-					{ // in overlay
-						UnderlayIP:          "10.10.0.5",
-						OverlaySubnet:       "10.255.19.0/24",
-						OverlayHardwareAddr: "aa:aa:00:00:00:03",
-					},
-				}
-			})
-			It("does not touch them and adds only the leases in the overlay network", func() {
-				err := converger.Converge(leases)
-				Expect(err).NotTo(HaveOccurred())
+			Context("when a single IP remote lease is removed", func() {
+				var (
+					deletedNeighs []netlink.Neigh
+					oldDestMac    net.HardwareAddr
+					oldDestGW     net.IP
+				)
 
-				Expect(fakeNetlink.RouteReplaceCallCount()).To(Equal(1))
-				addedRoute := fakeNetlink.RouteReplaceArgsForCall(0)
-				Expect(addedRoute.Dst.IP).To(Equal(net.ParseIP("10.255.19.0").To4()))
-				Expect(fakeNetlink.NeighSetCallCount()).To(Equal(2))
-				addedARP := fakeNetlink.NeighSetArgsForCall(0)
-				Expect(addedARP.IP).To(Equal(net.ParseIP("10.255.19.0")))
-				addedFDB := fakeNetlink.NeighSetArgsForCall(1)
-				Expect(addedFDB.IP).To(Equal(net.ParseIP("10.10.0.5")))
+				BeforeEach(func() {
+					// Info for lease to be deleted
+					// var oldDestNet *net.IPNet
+					oldDestMac, _ = net.ParseMAC("cc:bb:bb:bb:bb:bb")
+					oldDestGW, _, _ = net.ParseCIDR("10.250.0.55/32")
 
-				Expect(logger.Logs()).To(HaveLen(1))
-				Expect(logger.Logs()[0].LogLevel).To(Equal(lager.INFO))
-				Expect(logger.Logs()[0].ToJSON()).To(MatchRegexp("converger.*non-routable-lease-count.*2"))
-			})
-		})
+					fakeNetlink.FDBListReturns([]netlink.Neigh{
+						netlink.Neigh{
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Family:       syscall.AF_BRIDGE,
+							Flags:        netlink.NTF_SELF,
+							IP:           net.ParseIP("10.10.0.5"),
+							HardwareAddr: remoteMac,
+						},
+						netlink.Neigh{
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Family:       syscall.AF_BRIDGE,
+							Flags:        netlink.NTF_SELF,
+							IP:           net.ParseIP("10.10.0.7"),
+							HardwareAddr: remoteMacOnSecondNetwork,
+						},
+						netlink.Neigh{ // singleIP to be deleted
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Family:       syscall.AF_BRIDGE,
+							Flags:        netlink.NTF_SELF,
+							IP:           net.ParseIP("10.10.0.55"),
+							HardwareAddr: oldDestMac,
+						},
+						netlink.Neigh{ // singleIP on network 1 - Bridge
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Family:       syscall.AF_BRIDGE,
+							Flags:        netlink.NTF_SELF,
+							IP:           net.ParseIP("10.10.0.9"),
+							HardwareAddr: singleIPMacOnFirstNetwork,
+						},
+						netlink.Neigh{ // singleIP on network 2 - Bridge
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Family:       syscall.AF_BRIDGE,
+							Flags:        netlink.NTF_SELF,
+							IP:           net.ParseIP("10.10.0.11"),
+							HardwareAddr: singleIPMacOnSecondNetwork,
+						},
+					}, nil)
 
-		Context("when a lease has an invalid MAC", func() {
-			BeforeEach(func() {
-				leases = []controller.Lease{
-					{
-						UnderlayIP:          "10.10.0.5",
-						OverlaySubnet:       "10.255.19.0/24",
-						OverlayHardwareAddr: "banana",
-					},
-				}
+					fakeNetlink.ARPListReturns([]netlink.Neigh{
+						netlink.Neigh{
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Type:         syscall.RTN_UNICAST,
+							IP:           net.ParseIP("10.255.19.0"),
+							HardwareAddr: remoteMac,
+						},
+						netlink.Neigh{
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Type:         syscall.RTN_UNICAST,
+							IP:           net.ParseIP("10.250.50.0"),
+							HardwareAddr: remoteMacOnSecondNetwork,
+						},
+						netlink.Neigh{ // Single IP to be deleted
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Type:         syscall.RTN_UNICAST,
+							IP:           net.ParseIP("10.250.0.55"),
+							HardwareAddr: oldDestMac,
+						},
+						netlink.Neigh{ // singleIP on network 1 - ARP
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Type:         syscall.RTN_UNICAST,
+							IP:           net.ParseIP("10.255.1.11"),
+							HardwareAddr: singleIPMacOnFirstNetwork,
+						},
+						netlink.Neigh{ // singleIP on network 2 - ARP
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Type:         syscall.RTN_UNICAST,
+							IP:           net.ParseIP("10.255.50.11"),
+							HardwareAddr: singleIPMacOnSecondNetwork,
+						},
+					}, nil)
+
+					lease1IP, lease1CIDR, err := net.ParseCIDR("10.255.19.0/24")
+					Expect(err).NotTo(HaveOccurred())
+					lease2IP, lease2CIDR, err := net.ParseCIDR("10.250.50.0/24")
+					Expect(err).NotTo(HaveOccurred())
+
+					fakeNetlink.RouteListReturns([]netlink.Route{
+						netlink.Route{
+							LinkIndex: 42,
+							Scope:     netlink.SCOPE_UNIVERSE,
+							Dst:       lease1CIDR,
+							Gw:        lease1IP,
+							Src:       localOverlayLease.IP,
+						},
+						netlink.Route{
+							LinkIndex: 42,
+							Scope:     netlink.SCOPE_UNIVERSE,
+							Dst:       lease2CIDR,
+							Gw:        lease2IP,
+							Src:       overlayNetworks.Networks[1].IP,
+						},
+					}, nil)
+
+					deletedNeighs = []netlink.Neigh{}
+					fakeNetlink.NeighDelStub = func(neigh *netlink.Neigh) error {
+						deletedNeighs = append(deletedNeighs, *neigh)
+						return nil
+					}
+				})
+
+				It("deletes the ARP and FDB rules related to the removed lease", func() {
+					err := converger.Converge(leases)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("checking that no routes are deleted")
+					Expect(fakeNetlink.RouteDelCallCount()).To(Equal(0))
+
+					By("checking that the ARP and FDB rules is deleted")
+					Expect(fakeNetlink.NeighDelCallCount()).To(Equal(2))
+
+					Expect(deletedNeighs).To(ConsistOf(
+						// ARP
+						netlink.Neigh{
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Type:         syscall.RTN_UNICAST,
+							IP:           oldDestGW,
+							HardwareAddr: oldDestMac,
+						},
+						// FDB
+						netlink.Neigh{
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Family:       syscall.AF_BRIDGE,
+							Flags:        netlink.NTF_SELF,
+							IP:           net.ParseIP("10.10.0.55"),
+							HardwareAddr: oldDestMac,
+						},
+					))
+				})
 			})
-			It("returns an error", func() {
-				err := converger.Converge(leases)
-				Expect(err).To(MatchError("invalid hardware addr: banana"))
+
+			Context("when there are other routing rules", func() {
+				BeforeEach(func() {
+					fakeNetlink.RouteListReturns([]netlink.Route{
+						netlink.Route{
+							LinkIndex: 42,
+							Scope:     netlink.SCOPE_UNIVERSE,
+							Dst:       overlayNetworks.Networks[0],
+							Gw:        nil,
+						},
+					}, nil)
+				})
+
+				It("does not delete rules it did not create", func() {
+					err := converger.Converge(leases)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(fakeNetlink.RouteDelCallCount()).To(Equal(0))
+				})
+			})
+
+			Context("when the link cannot be found", func() {
+				BeforeEach(func() {
+					fakeNetlink.LinkByIndexReturns(nil, errors.New("passionfruit"))
+				})
+
+				It("breaks early and returns a meaningful error", func() {
+					err := converger.Converge(leases)
+					Expect(err).To(MatchError("link by index: passionfruit"))
+				})
+			})
+
+			Context("when previous routes cannot be found", func() {
+				BeforeEach(func() {
+					fakeNetlink.RouteListReturns(nil, errors.New("peach"))
+				})
+
+				It("breaks early and returns a meaningful error", func() {
+					err := converger.Converge(leases)
+					Expect(err).To(MatchError("list routes: peach"))
+				})
+			})
+
+			Context("when previous fdb entries cannot be found", func() {
+				BeforeEach(func() {
+					fakeNetlink.FDBListReturns(nil, errors.New("kiwi"))
+				})
+
+				It("breaks early and returns a meaningful error", func() {
+					err := converger.Converge(leases)
+					Expect(err).To(MatchError("list fdb: kiwi"))
+				})
+			})
+
+			Context("when previous arp entries cannot be found", func() {
+				BeforeEach(func() {
+					fakeNetlink.ARPListReturns(nil, errors.New("lychee"))
+				})
+
+				It("breaks early and returns a meaningful error", func() {
+					err := converger.Converge(leases)
+					Expect(err).To(MatchError("list arp: lychee"))
+				})
+			})
+
+			Context("when the lease subnet is malformed", func() {
+				BeforeEach(func() {
+					leases[1].OverlaySubnet = "banana"
+				})
+				It("breaks early and returns a meaningful error", func() {
+					err := converger.Converge(leases)
+					Expect(err).To(MatchError("parse lease: invalid CIDR address: banana"))
+				})
+			})
+
+			Context("when the underlay IP is malformed", func() {
+				BeforeEach(func() {
+					leases[1].UnderlayIP = "kumquat"
+				})
+				It("breaks early and returns a meaningful error", func() {
+					err := converger.Converge(leases)
+					Expect(err).To(MatchError("invalid underlay ip: kumquat"))
+				})
+			})
+
+			Context("when adding the route fails", func() {
+				BeforeEach(func() {
+					fakeNetlink.RouteReplaceReturns(errors.New("apricot"))
+				})
+				It("returns a meaningful error", func() {
+					err := converger.Converge(leases)
+					Expect(err).To(MatchError("add route: apricot"))
+				})
+			})
+
+			Context("when adding a neigh fails", func() {
+				BeforeEach(func() {
+					fakeNetlink.NeighSetReturns(errors.New("pear"))
+				})
+				It("returns a meaningful error", func() {
+					err := converger.Converge(leases)
+					Expect(err).To(MatchError("set neigh: pear"))
+				})
+			})
+
+			Context("when deleting the route fails", func() {
+				BeforeEach(func() {
+					fakeNetlink.RouteDelReturns(errors.New("durian"))
+
+					destGW, destNet, _ := net.ParseCIDR("10.255.19.0/24")
+					fakeNetlink.RouteListReturns([]netlink.Route{
+						netlink.Route{
+							LinkIndex: 42,
+							Scope:     netlink.SCOPE_UNIVERSE,
+							Dst:       destNet,
+							Gw:        destGW,
+						},
+					}, nil)
+				})
+				It("returns a meaningful error", func() {
+					err := converger.Converge([]controller.Lease{})
+					Expect(err).To(MatchError("del route: durian"))
+				})
+			})
+
+			Context("when deleting a neigh fails", func() {
+				BeforeEach(func() {
+					fakeNetlink.NeighDelReturns(errors.New("mango"))
+
+					fakeNetlink.ARPListReturns([]netlink.Neigh{
+						netlink.Neigh{
+							LinkIndex:    42,
+							State:        netlink.NUD_PERMANENT,
+							Type:         syscall.RTN_UNICAST,
+							IP:           net.ParseIP("10.255.19.0"),
+							HardwareAddr: remoteMac,
+						},
+					}, nil)
+				})
+				It("returns a meaningful error", func() {
+					err := converger.Converge([]controller.Lease{})
+					Expect(err).To(MatchError("del neigh with ip/hwaddr 10.255.19.0 ee:ee:aa:aa:aa:ff: mango"))
+				})
+			})
+
+			Context("when there are remote leases that are not in any overlay network CIDR", func() {
+				BeforeEach(func() {
+					leases = []controller.Lease{
+						{ // local, skipped
+							UnderlayIP:          "10.10.0.2",
+							OverlaySubnet:       "10.255.32.0/24",
+							OverlayHardwareAddr: "aa:aa:00:00:00:00",
+						},
+						{ // not in overlay, skipped
+							UnderlayIP:          "10.10.0.3",
+							OverlaySubnet:       "10.254.11.0/24",
+							OverlayHardwareAddr: "aa:aa:00:00:00:01",
+						},
+						{ // not in overlay, skipped
+							UnderlayIP:          "10.10.0.4",
+							OverlaySubnet:       "10.254.12.0/24",
+							OverlayHardwareAddr: "aa:aa:00:00:00:02",
+						},
+						{ // in overlay network 1: 10.255.0.0/16"
+							UnderlayIP:          "10.10.0.5",
+							OverlaySubnet:       "10.255.19.0/24",
+							OverlayHardwareAddr: "aa:aa:00:00:00:03",
+						},
+						{ // in overlay network 2: 10.250.0.0/16"
+							UnderlayIP:          "10.10.0.6",
+							OverlaySubnet:       "10.250.19.0/24",
+							OverlayHardwareAddr: "aa:aa:00:00:00:04",
+						},
+					}
+				})
+
+				It("does not touch them and adds only the leases in the overlay network", func() {
+					err := converger.Converge(leases)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("testing that routes were updated")
+					Expect(fakeNetlink.RouteReplaceCallCount()).To(Equal(2))
+					addedRoute := fakeNetlink.RouteReplaceArgsForCall(0)
+					Expect(addedRoute.Dst.IP).To(Equal(net.ParseIP("10.255.19.0").To4()))
+					addedRoute = fakeNetlink.RouteReplaceArgsForCall(1)
+					Expect(addedRoute.Dst.IP).To(Equal(net.ParseIP("10.250.19.0").To4()))
+
+					By("testing that ARP and FDB were updated")
+					Expect(fakeNetlink.NeighSetCallCount()).To(Equal(4))
+					addedARP := fakeNetlink.NeighSetArgsForCall(0)
+					Expect(addedARP.IP).To(Equal(net.ParseIP("10.255.19.0")))
+					addedFDB := fakeNetlink.NeighSetArgsForCall(1)
+					Expect(addedFDB.IP).To(Equal(net.ParseIP("10.10.0.5")))
+					addedARP = fakeNetlink.NeighSetArgsForCall(2)
+					Expect(addedARP.IP).To(Equal(net.ParseIP("10.250.19.0")))
+					addedFDB = fakeNetlink.NeighSetArgsForCall(3)
+					Expect(addedFDB.IP).To(Equal(net.ParseIP("10.10.0.6")))
+
+					Expect(logger.Logs()).To(HaveLen(1))
+					Expect(logger.Logs()[0].LogLevel).To(Equal(lager.INFO))
+					Expect(logger.Logs()[0].ToJSON()).To(MatchRegexp("converger.*non-routable-lease-count.*2"))
+				})
+			})
+
+			Context("when a lease has an invalid MAC", func() {
+				BeforeEach(func() {
+					leases = []controller.Lease{
+						{
+							UnderlayIP:          "10.10.0.5",
+							OverlaySubnet:       "10.255.19.0/24",
+							OverlayHardwareAddr: "banana",
+						},
+					}
+				})
+				It("returns an error", func() {
+					err := converger.Converge(leases)
+					Expect(err).To(MatchError("invalid hardware addr: banana"))
+				})
 			})
 		})
 	})

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/config/config.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/config/config.go
@@ -33,7 +33,7 @@ type VxlanPolicyAgent struct {
 	ForcePolicyPollCyclePort      int                       `json:"force_policy_poll_cycle_port" validate:"nonzero"`
 	ForcePolicyPollCycleHost      string                    `json:"force_policy_poll_cycle_host" validate:"nonzero"`
 	DisableContainerNetworkPolicy bool                      `json:"disable_container_network_policy"`
-	OverlayNetwork                string                    `json:"overlay_network"`
+	OverlayNetwork                []string                  `json:"overlay_network" validate:"nonzero"`
 	UnderlayIPs                   []string                  `json:"underlay_ips"`
 	IPTablesASGLogging            bool                      `json:"iptables_asg_logging"`
 	IPTablesDeniedLogsPerSec      int                       `json:"iptables_denied_logs_per_sec"`


### PR DESCRIPTION
👉 There is a lot of info in each individual commit message

- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

High level summary
---------------
**As a** CF operator
**I want** to provide multiple smaller cidrs for my overlay network instead of one big cidr
**So that** I don't have to find a huge amount of contiguous IPs to give to CF

Overlay network context
---------------

By default the overlay network is `10.255.0.0/16`. This IP range is reserved for private networks and this range is never publicly routable on the global internet. 

Every time a container is created in CF it gets a unique overlay IP associated with it. This allows internal routes to resolve to individual IPs so that c2c traffic can work.

🥧 Overlay network bosh properties - a pie metaphor
---------------
There are 2 bosh properties concerning the overlay network. Before going into the details, I am going to talk about them metaphorically.

Imagine the entire overlay network is a pie. One bosh property describes the type and size of the pie.

The purpose of this pie is to serve the hungry hungry Diegos. Each Diego Cell is hungry (hungry) and needs a slice of pie. Without a slice of pie, the Diego Cell cannot start (it has no energy!). This is an egalitarian kitchen, so each Diego Cell must get an equal slice of pie. 

The second bosh property determines the pie slice size that each Diego Cell gets. The smaller the slice of pie that each Diego Cell gets, the less “energy” the Cell has, and the fewer apps can run on each Cell. The larger the slice of pie is that each Diego Cell gets, the more “energy” the cell has, and more apps can run on each Cell. 

If the size of the pie stays constant, smaller slices of pie means there can be more Diego Cells (who are fed less each) and larger slices means there is a smaller number of possible Diego Cells (who are fed more each).

| Metaphorical bosh property name              | Real bosh property name | Description |
| :---------------- | :------: | ----: |
| size_of_network_overlay_pie       |   network   | Defines the entire “pie” (network overlay). A range of all of the IPs in the entire overlay network. |
| size_of_network_overlay_pie_slice |   subnet_prefix_length   | The size of the “pie slice” (subnet) each Diego Cell gets to allocate to apps. |

Overlay network bosh properties  (for real, no metaphors)
---------------

An operator provides a cidr for the overlay network via [this `network` bosh property on the silk controller job](https://github.com/cloudfoundry/silk-release/blob/8979669fb69e63b8819408e84444b354b6eaa9df/jobs/silk-controller/spec#L31-L33). By default this value is`10.255.0.0/16`.

An operator provides a [subnet_prefix_length via this bosh property on the silk controller job](https://github.com/cloudfoundry/silk-release/blob/8979669fb69e63b8819408e84444b354b6eaa9df/jobs/silk-controller/spec#L35-L37). This determines the number of IPs each Diego Cell gets. This determines how many apps can run on a single Diego Cell. A Diego Cell can only run as many apps at one time as it has IPs. By default the subnet_prefix_length is `/24`.

Let’s go through some examples of different values for these properties

| Example 1 | Default Property Values  |
|-------------------|---------|
| when `network` is | "10.255.0.0/16"   |
| when `subnet_prefix_length` is | 24  |
| Total number of IPs in the network (A) | /16 cidr has 65,536 IPs |
| Number of IPs per Diego Cell (B)       |  /24 cidr has 256 IPs   |
| Max number of Diego Cells supported    | A/B - 1 = 255 Diego Cells   |

| Example 2                              | Fewer apps per cell      |
|----------------------------------------|--------------------------|
| when `network` is                      | "10.255.0.0/16"          |
| when `subnet_prefix_length` is         | 25                       |
| Total number of IPs in the network (A) | /16 cidr has 65,536 IPs  |
| Number of IPs per Diego Cell (B)       | /25 cidr has 128 IPs     |
| Max number of Diego Cells supported    | A/B -1 = 511 Diego Cells |

| Example 3                              | fewer apps per cell and smaller network |
|----------------------------------------|-----------------------------------------|
| when `network` is                      | "10.255.0.0/17"                         |
| when `subnet_prefix_length` is         | 25                                      |
| Total number of IPs in the network (A) | /17 cidr has 32,768 IPs                 |
| Number of IPs per Diego Cell (B)       | /25 cidr has 128 IPs                    |
| Max number of Diego Cells supported    | A/B - 1= 255 Diego Cells                |

Problem Summary - more 🥧 metaphors
---------------
You have 1000 hungry hungry Diegos. How do you feed them? Can you make one pie big enough to serve all 1000 of them? That sounds hard. Do they even make ovens big enough? This is the conundrum that CF operators currently face. Currently the only option is to bake one pie large enough to serve all their Diegos. 

Wouldn’t it be great if our operators could bake 3 smaller pies to feed those hungry hungry Diegos? That is what this feature is all about.

Solution Summary
---------------
Currently an operator needs to provide a continuous cidr for the overlay network. This PR will let operators provide multiple non-consecutive CIDRs for their overlay network. For example, this PR makes: `["10.255.0.0/23", "10.255.10.0/23", "10.255.20.0/22"]`a valid overlay network property value.

How big does my multi-CIDR network need to be?
---------------
The overlay network CIDRs will still be cut up into smaller subnet "leases" for the Diego Cells. One "lease" from each CIDR in the overlay network is reserved to setup the networking and will not be distributed to Diego Cells. Because of this the overlay network CIDRs must have a larger prefix length than the `subnet_prefix_length`.

Let's go through more examples...

| Example 4 | 2 CIDRs in the overlay network |
|-------------------|---------|
| when `network` is | ["10.255.0.0/20", "10.255.96.0/21"]   |
| when `subnet_prefix_length` is | 24  |
| Total number of IPs in the first network CIDR (A) | /20 cidr has 4,096 IPs |
| Total number of IPs in the first network CIDR (A') | /21 cidr has 2,048 IPs |
| Number of IPs per Diego Cell (B)       |  /24 cidr has 256 IPs   |
| Number of CIDRs in the overlay network (C)       |  2   |
| Max number of Diego Cells supported    | ((A+A')/B) - (C) = 22 Diego Cells   |

| Example 5                              | 3 CIDRs in the overlay network     |
|----------------------------------------|--------------------------|
| when `network` is                      | ["10.255.0.0/20", "10.255.96.0/21", "10.255.200.0/23"]         |
| when `subnet_prefix_length` is         | 24                       |
| Total number of IPs in the first network CIDR (A) | /20 cidr has 4,096 IPs |
| Total number of IPs in the first network CIDR (A') | /21 cidr has 2,048 IPs |
| Total number of IPs in the first network CIDR (A'') | /23 cidr has 512 IPs |
| Number of IPs per Diego Cell (B)       |  /24 cidr has 256 IPs   |
| Number of CIDRs in the overlay network (C)       |  3   |
| Max number of Diego Cells supported    | ((A+A'+A'')/B) - (C) = 23 Diego Cells   |

| Example 6                              | 4 CIDRs in the overlay network and smaller `subnet_prefix_length`  |
|----------------------------------------|-----------------------------------------|
| when `network` is                      | ["10.255.0.0/20", "10.255.96.0/21", "10.255.200.0/23", "10.255.220.0/24"]         |
| when `subnet_prefix_length` is         | 25                       |
| Total number of IPs in the first network CIDR (A) | /20 cidr has 4,096 IPs |
| Total number of IPs in the first network CIDR (A') | /21 cidr has 2,048 IPs |
| Total number of IPs in the first network CIDR (A'') | /23 cidr has 512 IPs |
| Total number of IPs in the first network CIDR (A''') | /24 cidr has 256 IPs |
| Number of IPs per Diego Cell (B)       | /25 cidr has 128 IPs     |
| Number of CIDRs in the overlay network (C)       |  4   |
| Max number of Diego Cells supported    | ((A+A'+A''+A''')/B) - (C) = 50 Diego Cells   |

Invalid examples
---------------

| 🚫 Example 7    |  Wrong sized CIDRs |
|----------------------------------------|-----------------------------------------|
| `network`   | ["10.255.0.0/20", "10.255.96.0/21", "10.255.200.0/23", "10.255.220.0/24"]         |
| `subnet_prefix_length`  | 24  |
| invalid reason | subnet_prefix_length must be smaller than all CIDRs in the overlay network. In this case it is the same size as `"10.255.220.0/24"`.   |

| 🚫 Example 8    |  Wrong sized CIDRs |
|----------------------------------------|-----------------------------------------|
| `network`   | ["10.255.0.0/20", "10.255.96.0/21", "10.255.200.0/23", "10.255.220.0/32"]         |
| `subnet_prefix_length`  | 24   |
| invalid reason | subnet_prefix_length must be smaller than all CIDRs in the overlay network. In this case it larger than `"10.255.220.0/32"`.  |

Acceptance Criteria
---------------
These are the scenarios that I am going to manually test:

1. Backwards compatibility: when network is set to `10.255.0.0/16`
   * Test c2c without network policies
   * Test c2c with network policies
   * Test masquerading
   * Test single IPs
   * Test disable_container_networking_policies == true
 1. New stuff: when network is set to `["10.255.0.0/23", "10.255.10.0/23", "10.255.20.0/22"]`
    * Test c2c without network policies
    * Test c2c with network policies (same cell, same cidr, and across cidrs)
    * Test masquerading
    * Test disable_container_networking_policies == true


Backward Compatibility
---------------
Breaking Change? No. I did a lot of work to make sure this wouldn't break any current deployments. 


What's left
---------------
[x] Complete manual QA testing of all of the above acceptance criteria 
[x] Acceptance tests
[x] Docs