### PR TITLE
Bump rspec -> 3.13.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,20 +3,20 @@ GEM
   specs:
     bosh-template (2.4.0)
       semi_semantic (~> 1.2.0)
-    diff-lcs (1.5.0)
-    rspec (3.12.0)
-      rspec-core (~> 3.12.0)
-      rspec-expectations (~> 3.12.0)
-      rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.2)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.3)
+    diff-lcs (1.5.1)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.2)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.6)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-support (3.12.1)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.2)
     semi_semantic (1.2.0)
 
 PLATFORMS
@@ -27,4 +27,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.4.19
+   2.5.23


### PR DESCRIPTION
- [V] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
The current versions for rspec is older than a year.
Bumping rspec -> 3.13.0 to fit the SAP requirements for OSS compliance.

The tests have been executed locally by executing 'scripts/test-in-docker.bash'. The tests' output did not change after bumping the versions.

Executed commands:
bundle update rspec
