### PR TITLE
Remove executor directive as its old tags no longer exist

### DIFF
--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -8,12 +8,6 @@ replace code.cloudfoundry.org/runtimeschema => code.cloudfoundry.org/runtimesche
 
 replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 
-// Prevents `go get -u ./...` from trying to get a branch of executor that we
-// tried to make an independent module (adding it's own go mod)`
-//   Generated from story https://www.pivotaltracker.com/story/show/184869807
-// i.e. we need executor to float on main (v0.0.0-...)
-exclude code.cloudfoundry.org/executor v0.1442.0
-
 require (
 	code.cloudfoundry.org/cf-networking-helpers v0.28.0
 	code.cloudfoundry.org/debugserver v0.26.0


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This was causing CI to not auto-bump executor code, and was needed back from a time when the very old executor repo version tags existed from pre-diego 1.0. Go get -u, mod tidy, vendor, and our test suites appear to work with it removed now.


Backward Compatibility
---------------
Breaking Change? no