### PR TITLE
Add support for vxlan-policy-agent to not request full ASG info unless ASGs have been updated since the last check

### DIFF
--- a/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/vxlan-policy-agent/main.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/vxlan-policy-agent/main.go
@@ -245,7 +245,7 @@ func main() {
 	asgPoller := &poller.Poller{
 		Logger:          logger,
 		PollInterval:    asgPollInterval,
-		SingleCycleFunc: singlePollCycle.DoASGCycle,
+		SingleCycleFunc: singlePollCycle.DoASGCycleWithLastUpdatedCheck,
 	}
 
 	forcePolicyPollCycleServerAddress := fmt.Sprintf("%s:%d", conf.ForcePolicyPollCycleHost, conf.ForcePolicyPollCyclePort)

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger.go
@@ -17,6 +17,7 @@ import (
 //go:generate counterfeiter -o fakes/policy_client.go --fake-name PolicyClient . policyClient
 type policyClient interface {
 	GetPoliciesLastUpdated() (int, error)
+	GetSecurityGroupsLastUpdated() (int, error)
 }
 
 //go:generate counterfeiter -o fakes/planner.go --fake-name Planner . Planner
@@ -43,6 +44,7 @@ type SinglePollCycle struct {
 	metricsSender       metricsSender
 	policyClient        policyClient
 	lastUpdated         int
+	asgLastUpdated      int
 	logger              lager.Logger
 	policyRuleSets      map[enforcer.Chain]enforcer.RulesWithChain
 	asgRuleSets         map[enforcer.LiveChain]enforcer.RulesWithChain
@@ -54,15 +56,16 @@ type SinglePollCycle struct {
 
 func NewSinglePollCycle(planners []Planner, re ruleEnforcer, p policyClient, ms metricsSender, metronClient loggingclient.IngressClient, logger lager.Logger) *SinglePollCycle {
 	return &SinglePollCycle{
-		planners:      planners,
-		enforcer:      re,
-		policyClient:  p,
-		metricsSender: ms,
-		lastUpdated:   0,
-		logger:        logger,
-		metronClient:  metronClient,
-		policyMutex:   new(sync.Mutex),
-		asgMutex:      new(sync.Mutex),
+		planners:       planners,
+		enforcer:       re,
+		policyClient:   p,
+		metricsSender:  ms,
+		lastUpdated:    0,
+		asgLastUpdated: 0,
+		logger:         logger,
+		metronClient:   metronClient,
+		policyMutex:    new(sync.Mutex),
+		asgMutex:       new(sync.Mutex),
 	}
 }
 
@@ -132,6 +135,23 @@ func (m *SinglePollCycle) DoPolicyCycle() error {
 	pollDuration := time.Since(pollStartTime)
 	m.metricsSender.SendDuration(metricEnforceDuration, enforceDuration)
 	m.metricsSender.SendDuration(metricPollDuration, pollDuration)
+
+	return nil
+}
+
+func (m *SinglePollCycle) DoASGCycleWithLastUpdatedCheck() error {
+	asgLastUpdated, err := m.policyClient.GetSecurityGroupsLastUpdated()
+	if err != nil {
+		m.logger.Error("error-getting-security-groups-last-updated", err)
+		return m.DoASGCycle()
+	}
+	if m.asgLastUpdated == 0 || asgLastUpdated > m.asgLastUpdated {
+		m.logger.Debug("running-poll-cycle-for-updated-security-groups", lager.Data{"last-updated-remotely": asgLastUpdated, "last-updated-locally": m.asgLastUpdated})
+		m.asgLastUpdated = asgLastUpdated
+		return m.DoASGCycle()
+	}
+
+	m.logger.Debug("skipping-poll-cycle", lager.Data{"last-updated-remotely": asgLastUpdated, "last-updated-locally": m.asgLastUpdated})
 
 	return nil
 }

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger_test.go
@@ -313,6 +313,7 @@ var _ = Describe("Single Poll Cycle", func() {
 			fakeASGPlanner    *fakes.Planner
 			fakeEnforcer      *fakes.RuleEnforcer
 			fakeMetronClient  *diegologgingclientfakes.FakeIngressClient
+			fakePolicyClient  *fakes.PolicyClient
 			metricsSender     *fakes.MetricsSender
 			ASGRulesWithChain []enforcer.RulesWithChain
 			logger            *lagertest.TestLogger
@@ -323,7 +324,7 @@ var _ = Describe("Single Poll Cycle", func() {
 			fakeEnforcer = &fakes.RuleEnforcer{}
 			metricsSender = &fakes.MetricsSender{}
 			fakeMetronClient = &diegologgingclientfakes.FakeIngressClient{}
-			fakePolicyClient := &fakes.PolicyClient{}
+			fakePolicyClient = &fakes.PolicyClient{}
 			logger = lagertest.NewTestLogger("test")
 
 			fakeEnforcer.EnforceRulesAndChainStub = func(chain enforcer.RulesWithChain) (string, error) {
@@ -383,6 +384,64 @@ var _ = Describe("Single Poll Cycle", func() {
 			}
 
 			fakeASGPlanner.GetASGRulesAndChainsReturns(ASGRulesWithChain, nil)
+		})
+
+		Describe("DoPolicyCycleWithLastUpdatedCheck", func() {
+			Context("when policy server returns an error getting last updated date", func() {
+				BeforeEach(func() {
+					fakePolicyClient.GetSecurityGroupsLastUpdatedReturns(0, errors.New("endpoint-does-not-exist"))
+				})
+
+				It("runs security-groups cycle", func() {
+					Expect(fakeASGPlanner.GetASGRulesAndChainsCallCount()).To(Equal(0))
+					err := p.DoASGCycleWithLastUpdatedCheck()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeASGPlanner.GetASGRulesAndChainsCallCount()).To(Equal(1))
+				})
+			})
+
+			Context("when never called before", func() {
+				It("runs security-groups cycle", func() {
+					Expect(fakeASGPlanner.GetASGRulesAndChainsCallCount()).To(Equal(0))
+					err := p.DoASGCycleWithLastUpdatedCheck()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeASGPlanner.GetASGRulesAndChainsCallCount()).To(Equal(1))
+				})
+			})
+
+			Context("when called before", func() {
+				BeforeEach(func() {
+					fakePolicyClient.GetSecurityGroupsLastUpdatedReturns(10, nil)
+					err := p.DoASGCycleWithLastUpdatedCheck()
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				Context("when policy server last updated is newer", func() {
+					BeforeEach(func() {
+						fakePolicyClient.GetSecurityGroupsLastUpdatedReturns(20, nil)
+					})
+
+					It("runs security-groups cycle", func() {
+						Expect(fakeASGPlanner.GetASGRulesAndChainsCallCount()).To(Equal(1))
+						err := p.DoASGCycleWithLastUpdatedCheck()
+						Expect(err).NotTo(HaveOccurred())
+						Expect(fakeASGPlanner.GetASGRulesAndChainsCallCount()).To(Equal(2))
+					})
+				})
+
+				Context("when policy server last updated is the same", func() {
+					BeforeEach(func() {
+						fakePolicyClient.GetSecurityGroupsLastUpdatedReturns(10, nil)
+					})
+
+					It("doesn't run security-groups cycle", func() {
+						Expect(fakeASGPlanner.GetASGRulesAndChainsCallCount()).To(Equal(1))
+						err := p.DoASGCycleWithLastUpdatedCheck()
+						Expect(err).NotTo(HaveOccurred())
+						Expect(fakeASGPlanner.GetASGRulesAndChainsCallCount()).To(Equal(1))
+					})
+				})
+			})
 		})
 
 		It("enforces ASG rules on configured interval", func() {

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/converger/fakes/policy_client.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/converger/fakes/policy_client.go
@@ -18,6 +18,18 @@ type PolicyClient struct {
 		result1 int
 		result2 error
 	}
+	GetSecurityGroupsLastUpdatedStub        func() (int, error)
+	getSecurityGroupsLastUpdatedMutex       sync.RWMutex
+	getSecurityGroupsLastUpdatedArgsForCall []struct {
+	}
+	getSecurityGroupsLastUpdatedReturns struct {
+		result1 int
+		result2 error
+	}
+	getSecurityGroupsLastUpdatedReturnsOnCall map[int]struct {
+		result1 int
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -78,11 +90,69 @@ func (fake *PolicyClient) GetPoliciesLastUpdatedReturnsOnCall(i int, result1 int
 	}{result1, result2}
 }
 
+func (fake *PolicyClient) GetSecurityGroupsLastUpdated() (int, error) {
+	fake.getSecurityGroupsLastUpdatedMutex.Lock()
+	ret, specificReturn := fake.getSecurityGroupsLastUpdatedReturnsOnCall[len(fake.getSecurityGroupsLastUpdatedArgsForCall)]
+	fake.getSecurityGroupsLastUpdatedArgsForCall = append(fake.getSecurityGroupsLastUpdatedArgsForCall, struct {
+	}{})
+	stub := fake.GetSecurityGroupsLastUpdatedStub
+	fakeReturns := fake.getSecurityGroupsLastUpdatedReturns
+	fake.recordInvocation("GetSecurityGroupsLastUpdated", []interface{}{})
+	fake.getSecurityGroupsLastUpdatedMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *PolicyClient) GetSecurityGroupsLastUpdatedCallCount() int {
+	fake.getSecurityGroupsLastUpdatedMutex.RLock()
+	defer fake.getSecurityGroupsLastUpdatedMutex.RUnlock()
+	return len(fake.getSecurityGroupsLastUpdatedArgsForCall)
+}
+
+func (fake *PolicyClient) GetSecurityGroupsLastUpdatedCalls(stub func() (int, error)) {
+	fake.getSecurityGroupsLastUpdatedMutex.Lock()
+	defer fake.getSecurityGroupsLastUpdatedMutex.Unlock()
+	fake.GetSecurityGroupsLastUpdatedStub = stub
+}
+
+func (fake *PolicyClient) GetSecurityGroupsLastUpdatedReturns(result1 int, result2 error) {
+	fake.getSecurityGroupsLastUpdatedMutex.Lock()
+	defer fake.getSecurityGroupsLastUpdatedMutex.Unlock()
+	fake.GetSecurityGroupsLastUpdatedStub = nil
+	fake.getSecurityGroupsLastUpdatedReturns = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *PolicyClient) GetSecurityGroupsLastUpdatedReturnsOnCall(i int, result1 int, result2 error) {
+	fake.getSecurityGroupsLastUpdatedMutex.Lock()
+	defer fake.getSecurityGroupsLastUpdatedMutex.Unlock()
+	fake.GetSecurityGroupsLastUpdatedStub = nil
+	if fake.getSecurityGroupsLastUpdatedReturnsOnCall == nil {
+		fake.getSecurityGroupsLastUpdatedReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 error
+		})
+	}
+	fake.getSecurityGroupsLastUpdatedReturnsOnCall[i] = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *PolicyClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.getPoliciesLastUpdatedMutex.RLock()
 	defer fake.getPoliciesLastUpdatedMutex.RUnlock()
+	fake.getSecurityGroupsLastUpdatedMutex.RLock()
+	defer fake.getSecurityGroupsLastUpdatedMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner_linux.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner_linux.go
@@ -230,7 +230,7 @@ func (p *VxlanPolicyPlanner) getContainerSecurityGroups(allContainers []containe
 	spaceGuids := extractSpaceGUIDs(allContainers)
 	securityGroups, err := p.PolicyClient.GetSecurityGroupsForSpace(spaceGuids...)
 	if err != nil {
-		err = fmt.Errorf("failed to get ingress tags: %s", err)
+		err = fmt.Errorf("failed to get security groups: %s", err)
 		return []policy_client.SecurityGroup{}, err
 	}
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Makes vxlan-policy-agent cause less load on policy-server's DB

Backward Compatibility
---------------
Breaking Change? No