### PR TITLE
Increase VPA's client timeout to 30s by default and make it configurable

### DIFF
--- a/jobs/vxlan-policy-agent/spec
+++ b/jobs/vxlan-policy-agent/spec
@@ -52,6 +52,10 @@ properties:
     description: "The VXLAN policy agent queries the policy server on this interval in seconds and updates local policy rules."
     default: 5
 
+  client_timeout_seconds:
+    description: "Timeout to use for HTTP connections to policy_server"
+    default: 30
+
   enable_asg_syncing:
     description: "Enable dynamic updates to ASG rules for running containers"
     default: true

--- a/jobs/vxlan-policy-agent/templates/vxlan-policy-agent.json.erb
+++ b/jobs/vxlan-policy-agent/templates/vxlan-policy-agent.json.erb
@@ -46,7 +46,7 @@
       'cni_datastore_path' => '/var/vcap/data/container-metadata/store.json',
       'iptables_lock_file' => '/var/vcap/data/garden-cni/iptables.lock',
       'debug_server_host' => '127.0.0.1',
-      'client_timeout_seconds' => 5,
+      'client_timeout_seconds' => p("client_timeout_seconds"),
       'vni' => 1,
 
       'force_policy_poll_cycle_host' => '127.0.0.1',

--- a/spec/vxlan-policy-agent/vxlan-policy-agent_spec.rb
+++ b/spec/vxlan-policy-agent/vxlan-policy-agent_spec.rb
@@ -71,7 +71,7 @@ module Bosh::Template::Test
               'ca_cert_file' => '/var/vcap/jobs/vxlan-policy-agent/config/certs/ca.crt',
               'client_cert_file' => '/var/vcap/jobs/vxlan-policy-agent/config/certs/client.crt',
               'client_key_file' => '/var/vcap/jobs/vxlan-policy-agent/config/certs/client.key',
-              'client_timeout_seconds' => 5,
+              'client_timeout_seconds' => 30,
               'cni_datastore_path' => '/var/vcap/data/container-metadata/store.json',
               'debug_server_host' => '127.0.0.1',
               'debug_server_port' => 8721,
@@ -169,6 +169,17 @@ module Bosh::Template::Test
               expect(rendered_config['overlay_network']).to eq(['10.234.0.0/16'])
             end
           end 
+
+          context 'when client_timeout_seconds is provided' do
+            before do
+              merged_manifest_properties['client_timeout_seconds'] = 45
+            end
+
+            it 'overrides the default' do
+              rendered_config = JSON.parse(template.render(merged_manifest_properties, consumes: links))
+              expect(rendered_config['client_timeout_seconds']).to eq(45)
+            end
+          end
         end
       end
     end

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger.go
@@ -151,7 +151,7 @@ func (m *SinglePollCycle) DoASGCycleWithLastUpdatedCheck() error {
 		return m.DoASGCycle()
 	}
 
-	m.logger.Debug("skipping-poll-cycle", lager.Data{"last-updated-remotely": asgLastUpdated, "last-updated-locally": m.asgLastUpdated})
+	m.logger.Debug("skipping-asg-poll-cycle", lager.Data{"last-updated-remotely": asgLastUpdated, "last-updated-locally": m.asgLastUpdated})
 
 	return nil
 }


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
When vxlan-policy-agent runs in very high scale environments, the 5s timeout previously used is not enough, and each sync operation times out, not getting (or rarely getting) any new data. Since the Poller used waits for the current iteration to complete before kicking off the next one, it's fine if this client timeout exceeds the c2c polling interval of 5s.

In the rare case where >30s is needed for this, it is now configurable in the boshrelease.

Also fixes a copy-paste error with a log message for ASG polling.


Backward Compatibility
---------------
Breaking Change? no