### PR TITLE
cleanup time format property

### DIFF
--- a/jobs/iptables-logger/spec
+++ b/jobs/iptables-logger/spec
@@ -26,10 +26,3 @@ properties:
   disable:
     description: "Disable this monit job.  It will not run. Required for backwards compatability"
     default: false
-
-  logging.format.timestamp:
-    description: |
-      Format for timestamp in component logs. Valid values are 'rfc3339', 'deprecated'.
-      'rfc3339' is the recommended format. It will result in all timestamps controlled by iptables-logger to be in RFC3339 format, which is human readable.
-      'deprecated' will result in all timestamps being in the format they were before the rfc3339 flag was introduced. This format is different for different logs. We do not recommend using this flag unless you have scripts that expect a particular timestamp format.
-    default: "rfc3339"

--- a/jobs/iptables-logger/templates/iptables-logger.json.erb
+++ b/jobs/iptables-logger/templates/iptables-logger.json.erb
@@ -1,10 +1,6 @@
 <%=
   require 'json'
 
-  if !['rfc3339', 'deprecated'].include?(p('logging.format.timestamp'))
-    raise "'#{p('logging.format.timestamp')}' is not a valid timestamp format for the property 'logging.format.timestamp'. Valid options are: 'rfc3339' and 'deprecated'."
-  end
-
   toRender = {
     "kernel_log_file" => p("kernel_log_file"),
     "container_metadata_file" => "/var/vcap/data/container-metadata/store.json",
@@ -12,7 +8,6 @@
     "metron_address" => "127.0.0.1:#{p("metron_port")}",
     "host_ip" => spec.ip,
     "host_guid" => spec.id,
-    "log_timestamp_format" => p("logging.format.timestamp"),
   }
 
   JSON.pretty_generate(toRender)

--- a/jobs/silk-daemon/spec
+++ b/jobs/silk-daemon/spec
@@ -105,14 +105,6 @@ properties:
     description: "Log Level for silk-daemon to start with"
     default: info
 
-  logging.format.timestamp:
-    description: |
-        Format for timestamp in the drain log. Valid values are 'rfc3339' and 'deprecated'.
-        This property only affects the drain log because other component and bosh lifecycle logs were already in the rfc3339 format.
-        'rfc3339' is the recommended format. It will result in all timestamps in the drain log controlled by silk-daemon to be in RFC3339 format, which is human readable. This does not include stderr logs from golang libraries.
-        'deprecated' will result in all timestamps being in the format they were before the rfc3339 flag was introduced for the drain log.  We do not recommend using this flag unless you have scripts that expect a particular timestamp format.
-    default: "rfc3339"
-
   healthchecker.failure_counter_file:
     description: "File used by the healthchecker to monitor consecutive failures."
     default: /var/vcap/data/silk-daemon/counters/consecutive_healthchecker_failures.count

--- a/jobs/silk-daemon/templates/client-config.json.erb
+++ b/jobs/silk-daemon/templates/client-config.json.erb
@@ -35,10 +35,6 @@
     underlay_ip = spec.ip
   end
 
-  if !['rfc3339', 'deprecated'].include?(p('logging.format.timestamp'))
-    raise "'#{p('logging.format.timestamp')}' is not a valid timestamp format for the property 'logging.format.timestamp'. Valid options are: 'rfc3339' and 'deprecated'."
-  end
-
   toRender = {
     'underlay_ip' => underlay_ip,
     'subnet_prefix_length' => subnet_prefix_length,

--- a/jobs/silk-daemon/templates/drain.erb
+++ b/jobs/silk-daemon/templates/drain.erb
@@ -8,7 +8,6 @@ export PATH="<%= link("iptables").p("garden.iptables_bin_dir") %>:$PATH"
 LOG_DIR=/var/vcap/sys/log/silk-daemon
 LOGFILE="${LOG_DIR}"/drain.log
 SILK_DAEMON_HEALTH_CHECK_ADDRESS=localhost:<%= p("listen_port") %>
-LOG_FORMAT=<%= p("logging.format.timestamp") %>
 DATASTORE=/var/vcap/data/container-metadata/store.json
 CHECK_TIMEOUT=<%= p("container_metadata_file_check_timeout") %>
 export PIDFILE=/var/vcap/sys/run/bpm/silk-daemon/silk-daemon.pid
@@ -38,17 +37,9 @@ output_for_bosh() {
   local exit_code=$?
 
   if [ "${exit_code}" -eq 0 ]; then
-    if [ "$LOG_FORMAT" == "deprecated" ]; then
-      echo "$(date): drain success"
-    else
-      echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): drain success"
-    fi
+    echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): drain success"
   else
-    if [ "$LOG_FORMAT" == "deprecated" ]; then
-      echo "$(date): drain failed"
-    else
-      echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): drain failed"
-    fi
+    echo "$(date +%Y-%m-%dT%H:%M:%S.%sZ): drain failed"
   fi
 
   echo "${exit_code}" >&3

--- a/spec/iptables-logger/iptables_logger_spec.rb
+++ b/spec/iptables-logger/iptables_logger_spec.rb
@@ -14,7 +14,6 @@ module Bosh::Template::Test
           'kernel_log_file' => 'mylog.file',
           'metron_port' => 12345,
           'disable' => false,
-          'logging' => { 'format' => { 'timestamp' => 'rfc3339' }},
         }
       end
       let(:spec) do
@@ -34,21 +33,7 @@ module Bosh::Template::Test
               'metron_address' => '127.0.0.1:12345',
               'host_ip' => '1.2.3.4',
               'host_guid' => 'some-guid',
-              'log_timestamp_format' => 'rfc3339',
             })
-          end
-
-          context 'when logging.format.timestamp is set to an invalid value' do
-            let(:merged_manifest_properties) do
-              {
-                'logging' => {'format' => {'timestamp' => 'meow' }}
-              }
-            end
-            it 'throws a helpful error' do
-              expect {
-                template.render(merged_manifest_properties, spec: spec)
-              }.to raise_error("'meow' is not a valid timestamp format for the property 'logging.format.timestamp'. Valid options are: 'rfc3339' and 'deprecated'.")
-            end
           end
         end
       end

--- a/spec/silk-daemon/client_config_spec.rb
+++ b/spec/silk-daemon/client_config_spec.rb
@@ -28,7 +28,7 @@ module Bosh::Template::Test
           'vtep_port' => 6666,
           'log_prefix' => 'cfnetworking',
           'single_ip_only' => true,
-          'logging' => {'format' => {'timestamp' => 'rfc3339'}, 'level' => 'error' }
+          'logging' => {'level' => 'error' }
         }
       end
 
@@ -116,19 +116,6 @@ module Bosh::Template::Test
             it 'sets the underlay_ip to the ip associated with vxlan_network' do
               clientConfig = JSON.parse(template.render(merged_manifest_properties, consumes: links, spec: spec))
               expect(clientConfig['underlay_ip']).to eq("192.74.65.4")
-            end
-          end
-
-          context 'when logging.format.timestamp is set to an invalid value' do
-            let(:merged_manifest_properties) do
-              {
-                'logging' => {'format' => {'timestamp' => 'meow' }}
-              }
-            end
-            it 'throws a helpful error' do
-              expect {
-                template.render(merged_manifest_properties, consumes: links)
-              }.to raise_error("'meow' is not a valid timestamp format for the property 'logging.format.timestamp'. Valid options are: 'rfc3339' and 'deprecated'.")
             end
           end
 

--- a/src/code.cloudfoundry.org/iptables-logger/cmd/iptables-logger/main.go
+++ b/src/code.cloudfoundry.org/iptables-logger/cmd/iptables-logger/main.go
@@ -65,9 +65,7 @@ func main() {
 		ReOpen:    true,
 	}
 
-	if conf.LogTimestampFormat == "rfc3339" {
-		tailConfig.Logger = taillogger.Shim{Logger: logger}
-	}
+	tailConfig.Logger = taillogger.Shim{Logger: logger}
 
 	t, err := tail.TailFile(conf.KernelLogFile, tailConfig)
 	if err != nil {
@@ -109,7 +107,6 @@ func main() {
 		rotatablesink.DefaultFileWriterFunc(rotatablesink.DefaultFileWriter),
 		rotatablesink.DefaultDestinationFileInfo{},
 		logger,
-		conf.LogTimestampFormat == "rfc3339",
 	)
 
 	if err != nil {

--- a/src/code.cloudfoundry.org/iptables-logger/config/config.go
+++ b/src/code.cloudfoundry.org/iptables-logger/config/config.go
@@ -15,8 +15,6 @@ type Config struct {
 	MetronAddress         string `json:"metron_address" validate:"nonzero"`
 	HostIp                string `json:"host_ip" validate:"nonzero"`
 	HostGuid              string `json:"host_guid" validate:"nonzero"`
-
-	LogTimestampFormat string `json:"log_timestamp_format"`
 }
 
 func New(path string) (*Config, error) {

--- a/src/code.cloudfoundry.org/iptables-logger/config/config_test.go
+++ b/src/code.cloudfoundry.org/iptables-logger/config/config_test.go
@@ -44,7 +44,6 @@ var _ = Describe("Config", func() {
 				Expect(c.MetronAddress).To(Equal("http://1.2.3.4:1234"))
 				Expect(c.HostIp).To(Equal("1.2.3.4"))
 				Expect(c.HostGuid).To(Equal("some-guid"))
-				Expect(c.LogTimestampFormat).To(Equal("rfc3339"))
 			})
 		})
 

--- a/src/code.cloudfoundry.org/iptables-logger/rotatablesink/rotatewatcher.go
+++ b/src/code.cloudfoundry.org/iptables-logger/rotatablesink/rotatewatcher.go
@@ -12,14 +12,13 @@ import (
 )
 
 type RotatableSink struct {
-	fileToWatch                 string
-	fileToWatchInode            uint64
-	minLogLevel                 lager.LogLevel
-	WriterFactory               FileWriterFactory
-	writerSink                  lager.Sink
-	writeL                      *sync.Mutex
-	DestinationFileInfo         DestinationFileInfo
-	EnableRFC339TimestampFormat bool
+	fileToWatch         string
+	fileToWatchInode    uint64
+	minLogLevel         lager.LogLevel
+	WriterFactory       FileWriterFactory
+	writerSink          lager.Sink
+	writeL              *sync.Mutex
+	DestinationFileInfo DestinationFileInfo
 }
 
 func (rs *RotatableSink) Log(logFmt lager.LogFormat) {
@@ -28,15 +27,14 @@ func (rs *RotatableSink) Log(logFmt lager.LogFormat) {
 	rs.writerSink.Log(logFmt)
 }
 
-func NewRotatableSink(fileToWatch string, logLevel lager.LogLevel, fileWriterFactory FileWriterFactory, destinationFileInfo DestinationFileInfo, componentLogger lager.Logger, enableRFC339TimestampFormat bool) (*RotatableSink, error) {
+func NewRotatableSink(fileToWatch string, logLevel lager.LogLevel, fileWriterFactory FileWriterFactory, destinationFileInfo DestinationFileInfo, componentLogger lager.Logger) (*RotatableSink, error) {
 	var err error
 	rotatableSink := &RotatableSink{
-		fileToWatch:                 fileToWatch,
-		minLogLevel:                 logLevel,
-		WriterFactory:               fileWriterFactory,
-		DestinationFileInfo:         destinationFileInfo,
-		writeL:                      new(sync.Mutex),
-		EnableRFC339TimestampFormat: enableRFC339TimestampFormat,
+		fileToWatch:         fileToWatch,
+		minLogLevel:         logLevel,
+		WriterFactory:       fileWriterFactory,
+		DestinationFileInfo: destinationFileInfo,
+		writeL:              new(sync.Mutex),
 	}
 
 	err = rotatableSink.registerFileSink(fileToWatch)
@@ -98,11 +96,8 @@ func (rs *RotatableSink) rotateFileSink() error {
 	if err != nil {
 		return fmt.Errorf("create file writer: %s", err)
 	}
-	if rs.EnableRFC339TimestampFormat {
-		rs.writerSink = lager.NewPrettySink(outputLogFile, rs.minLogLevel)
-	} else {
-		rs.writerSink = lager.NewWriterSink(outputLogFile, rs.minLogLevel)
-	}
+	rs.writerSink = lager.NewPrettySink(outputLogFile, rs.minLogLevel)
+
 	return nil
 }
 


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
cleanup time format property


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
