### PR TITLE
modify health check for debug server log-level

### DIFF
--- a/jobs/silk-controller/templates/post-start.erb
+++ b/jobs/silk-controller/templates/post-start.erb
@@ -5,6 +5,7 @@ source /var/vcap/packages/silk-ctl-utils/ctl_util.sh
 
 export URL="127.0.0.1:<%= p("debug_port") %>/log-level"
 export TIMEOUT=25
+export CURL_OPTS="--data 'error'"
 
-exit $(wait_for_server_to_become_healthy "${URL}" "${TIMEOUT}")
+exit $(wait_for_server_to_become_healthy "${URL}" "${TIMEOUT}" "${CURL_OPTS}")
 <% end %>

--- a/jobs/vxlan-policy-agent/templates/post-start.erb
+++ b/jobs/vxlan-policy-agent/templates/post-start.erb
@@ -5,6 +5,7 @@ source /var/vcap/packages/silk-ctl-utils/ctl_util.sh
 
 export URL="127.0.0.1:<%= p("debug_server_port")%>/log-level"
 export TIMEOUT=25
+export CURL_OPTS="--data 'error'"
 
-exit $(wait_for_server_to_become_healthy "${URL}" "${TIMEOUT}")
+exit $(wait_for_server_to_become_healthy "${URL}" "${TIMEOUT}" "${CURL_OPTS}")
 <% end %>

--- a/src/code.cloudfoundry.org/silk-ctl-utils/ctl_util.sh
+++ b/src/code.cloudfoundry.org/silk-ctl-utils/ctl_util.sh
@@ -8,9 +8,10 @@ function log() {
 function wait_for_server_to_become_healthy() {
   local url=$1
   local timeout=$2
+  local curl_opts="${3:-}"
   for _ in $(seq "${timeout}"); do
     set +e
-    curl -f --connect-timeout 1 "${url}" > /dev/null 2>&1
+    curl -f --connect-timeout 1 "${curl_opts}" "${url}" > /dev/null 2>&1
     if [ $? -eq 0 ]; then
       echo 0
       return


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Fix the health check endpoint the log-level
https://github.com/cloudfoundry/debugserver/blob/2c6de87445987498c36fa57842b124e079101279/adapter.go#L49

Test result:
```
/5d785c86-c37d-4d8e-9b32-1d3d843e0bce:/var/vcap/sys/log/silk-controller$ curl -v 127.0.0.1:46455/log-level --data 'error'
*   Trying 127.0.0.1:46455...
* Connected to 127.0.0.1 (127.0.0.1) port 46455 (#0)
> POST /log-level HTTP/1.1
> Host: 127.0.0.1:46455
> User-Agent: curl/7.81.0
> Accept: */*
> Content-Length: 5
> Content-Type: application/x-www-form-urlencoded
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Date: Wed, 30 Jul 2025 02:01:27 GMT
< Content-Length: 41
< Content-Type: text/plain; charset=utf-8
< 
/log-level was invoked with Level: error
* Connection #0 to host 127.0.0.1 left intact```
*


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
