### PR TITLE
fix curl options to log level health check

### DIFF
--- a/jobs/silk-controller/templates/post-start.erb
+++ b/jobs/silk-controller/templates/post-start.erb
@@ -5,7 +5,7 @@ source /var/vcap/packages/silk-ctl-utils/ctl_util.sh
 
 export URL="127.0.0.1:<%= p("debug_port") %>/log-level"
 export TIMEOUT=25
-export CURL_OPTS="--data 'error'"
+export CURL_OPTS=("--data" "\"error\"")
 
-exit $(wait_for_server_to_become_healthy "${URL}" "${TIMEOUT}" "${CURL_OPTS}")
+exit $(wait_for_server_to_become_healthy "${URL}" "${TIMEOUT}" "${CURL_OPTS[@]}")
 <% end %>

--- a/jobs/vxlan-policy-agent/templates/post-start.erb
+++ b/jobs/vxlan-policy-agent/templates/post-start.erb
@@ -5,7 +5,7 @@ source /var/vcap/packages/silk-ctl-utils/ctl_util.sh
 
 export URL="127.0.0.1:<%= p("debug_server_port")%>/log-level"
 export TIMEOUT=25
-export CURL_OPTS="--data 'error'"
+export CURL_OPTS=("--data" "\"error\"")
 
-exit $(wait_for_server_to_become_healthy "${URL}" "${TIMEOUT}" "${CURL_OPTS}")
+exit $(wait_for_server_to_become_healthy "${URL}" "${TIMEOUT}" "${CURL_OPTS[@]}")
 <% end %>

--- a/src/code.cloudfoundry.org/silk-ctl-utils/ctl_util.sh
+++ b/src/code.cloudfoundry.org/silk-ctl-utils/ctl_util.sh
@@ -8,10 +8,12 @@ function log() {
 function wait_for_server_to_become_healthy() {
   local url=$1
   local timeout=$2
-  local curl_opts="${3:-}"
+  shift 2
+  local curl_opts=("$@")
   for _ in $(seq "${timeout}"); do
     set +e
-    curl -f --connect-timeout 1 "${curl_opts}" "${url}" > /dev/null 2>&1
+    curl_cmd=("curl -f --connect-timeout 1 "${curl_opts[*]}" "${url}" > /dev/null 2>&1")
+    eval "${curl_cmd}"
     if [ $? -eq 0 ]; then
       echo 0
       return


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
fix curl options param to check the loglevel api

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
