### PR TITLE
fix curl options to log level health check

### DIFF
--- a/src/code.cloudfoundry.org/silk-ctl-utils/ctl_util.sh
+++ b/src/code.cloudfoundry.org/silk-ctl-utils/ctl_util.sh
@@ -12,7 +12,7 @@ function wait_for_server_to_become_healthy() {
   local curl_opts=("$@")
   for _ in $(seq "${timeout}"); do
     set +e
-    curl_cmd=("curl -f --connect-timeout 1 "${curl_opts[*]}" "${url}" > /dev/null 2>&1")
+    curl_cmd=("curl -f --connect-timeout 1 ${curl_opts[*]} ${url} > /dev/null 2>&1")
     eval "${curl_cmd}"
     if [ $? -eq 0 ]; then
       echo 0


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

fix curl options to log level health check
```
diego-api/d927f191-afc7-45c3-8079-12894f02c009:/var/vcap/data/sys/log/silk-controller# ls
bpm.log  post-start.stderr.log  post-start.stdout.log  silk-controller.stderr.log  silk-controller.stdout.log
diego-api/d927f191-afc7-45c3-8079-12894f02c009:/var/vcap/data/sys/log/silk-controller# cat post-start.stderr.log
+ source /var/vcap/packages/silk-ctl-utils/ctl_util.sh
+ export URL=127.0.0.1:46455/log-level
+ URL=127.0.0.1:46455/log-level
+ export TIMEOUT=25
+ TIMEOUT=25
++ wait_for_server_to_become_healthy 127.0.0.1:46455/log-level 25
++ local url=127.0.0.1:46455/log-level
++ local timeout=25
+++ seq 25
++ for _ in $(seq "${timeout}")
++ set +e
++ curl -f --connect-timeout 1 127.0.0.1:46455/log-level
++ '[' 0 -eq 0 ']'
++ echo 0

```
Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
