### PR TITLE
fix curl options to log level health check

### DIFF
--- a/jobs/silk-controller/templates/post-start.erb
+++ b/jobs/silk-controller/templates/post-start.erb
@@ -5,7 +5,7 @@ source /var/vcap/packages/silk-ctl-utils/ctl_util.sh
 
 export URL="127.0.0.1:<%= p("debug_port") %>/log-level"
 export TIMEOUT=25
-export CURL_OPTS=("--data" "\"error\"")
+export CURL_OPTS=('--data' 'error')
 
 exit $(wait_for_server_to_become_healthy "${URL}" "${TIMEOUT}" "${CURL_OPTS[@]}")
 <% end %>

--- a/jobs/vxlan-policy-agent/templates/post-start.erb
+++ b/jobs/vxlan-policy-agent/templates/post-start.erb
@@ -5,7 +5,7 @@ source /var/vcap/packages/silk-ctl-utils/ctl_util.sh
 
 export URL="127.0.0.1:<%= p("debug_server_port")%>/log-level"
 export TIMEOUT=25
-export CURL_OPTS=("--data" "\"error\"")
+export CURL_OPTS=('--data' 'error')
 
 exit $(wait_for_server_to_become_healthy "${URL}" "${TIMEOUT}" "${CURL_OPTS[@]}")
 <% end %>

--- a/src/code.cloudfoundry.org/silk-ctl-utils/ctl_util.sh
+++ b/src/code.cloudfoundry.org/silk-ctl-utils/ctl_util.sh
@@ -12,8 +12,7 @@ function wait_for_server_to_become_healthy() {
   local curl_opts=("$@")
   for _ in $(seq "${timeout}"); do
     set +e
-    curl_cmd=("curl -f --connect-timeout 1 ${curl_opts[*]} ${url} > /dev/null 2>&1")
-    eval "${curl_cmd}"
+    curl -f --connect-timeout 1 "${curl_opts[@]}" "${url}" > /dev/null 2>&1
     if [ $? -eq 0 ]; then
       echo 0
       return


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
```
diego-api/d927f191-afc7-45c3-8079-12894f02c009:/var/vcap/data/sys/log/silk-controller# cat post-start.stderr.log
+ source /var/vcap/packages/silk-ctl-utils/ctl_util.sh
+ export URL=127.0.0.1:46455/log-level
+ URL=127.0.0.1:46455/log-level
+ export TIMEOUT=25
+ TIMEOUT=25
++ wait_for_server_to_become_healthy 127.0.0.1:46455/log-level 25
++ local url=127.0.0.1:46455/log-level
++ local timeout=25
+++ seq 25
++ for _ in $(seq "${timeout}")
++ set +e
++ curl -f --connect-timeout 1 127.0.0.1:46455/log-level
++ '[' 0 -eq 0 ']'
++ echo 0
++ return
+ exit 0
+ source /var/vcap/packages/silk-ctl-utils/ctl_util.sh
+ export URL=127.0.0.1:46455/log-level
+ URL=127.0.0.1:46455/log-level
+ export TIMEOUT=25
+ TIMEOUT=25
++ wait_for_server_to_become_healthy 127.0.0.1:46455/log-level 25
++ local url=127.0.0.1:46455/log-level
++ local timeout=25
+++ seq 25
++ for _ in $(seq "${timeout}")
++ set +e
++ curl -f --connect-timeout 1 127.0.0.1:46455/log-level
++ '[' 0 -eq 0 ']'
++ echo 0
++ return
+ exit 0
+ source /var/vcap/packages/silk-ctl-utils/ctl_util.sh
+ export URL=127.0.0.1:46455/log-level
+ URL=127.0.0.1:46455/log-level
+ export TIMEOUT=25
+ TIMEOUT=25
+ CURL_OPTS=('--data' '"error"')
+ export CURL_OPTS
++ wait_for_server_to_become_healthy 127.0.0.1:46455/log-level 25 --data '"error"'
++ local url=127.0.0.1:46455/log-level
++ local timeout=25
++ shift 2
++ curl_opts=('--data' '"error"')
++ local curl_opts
+++ seq 25
++ for _ in $(seq "${timeout}")
++ set +e
++ curl_cmd=("curl -f --connect-timeout 1 ${curl_opts[*]} ${url} > /dev/null 2>&1")
++ eval 'curl -f --connect-timeout 1 --data "error" 127.0.0.1:46455/log-level > /dev/null 2>&1'
+++ curl -f --connect-timeout 1 --data error 127.0.0.1:46455/log-level
++ '[' 0 -eq 0 ']'
++ echo 0
++ return
+ exit 0
+ source /var/vcap/packages/silk-ctl-utils/ctl_util.sh
+ export URL=127.0.0.1:46455/log-level
+ URL=127.0.0.1:46455/log-level
+ export TIMEOUT=25
+ TIMEOUT=25
++ wait_for_server_to_become_healthy 127.0.0.1:46455/log-level 25
++ local url=127.0.0.1:46455/log-level
++ local timeout=25
+++ seq 25
++ for _ in $(seq "${timeout}")
++ set +e
++ curl -f --connect-timeout 1 127.0.0.1:46455/log-level
++ '[' 0 -eq 0 ']'
++ echo 0
++ return
+ exit 0
+ source /var/vcap/packages/silk-ctl-utils/ctl_util.sh
+ export URL=127.0.0.1:46455/log-level
+ URL=127.0.0.1:46455/log-level
+ export TIMEOUT=25
+ TIMEOUT=25
+ CURL_OPTS=('--data' 'error')
+ export CURL_OPTS
++ wait_for_server_to_become_healthy 127.0.0.1:46455/log-level 25 --data error
++ local url=127.0.0.1:46455/log-level
++ local timeout=25
++ shift 2
++ curl_opts=('--data' 'error')
++ local curl_opts
+++ seq 25
++ for _ in $(seq "${timeout}")
++ set +e
++ curl -f --connect-timeout 1 --data error 127.0.0.1:46455/log-level
++ '[' 0 -eq 0 ']'
++ echo 0
++ return

```

Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
