### PR TITLE
fix log level health check in vxlan policy agent monit process

### DIFF
--- a/jobs/vxlan-policy-agent/monit
+++ b/jobs/vxlan-policy-agent/monit
@@ -5,10 +5,11 @@ check process vxlan-policy-agent
   stop program "/var/vcap/jobs/bpm/bin/bpm stop vxlan-policy-agent"
   group vcap
   if failed
-     host 127.0.0.1
-     port <%= p("debug_server_port") %>
-     protocol HTTP
-     request "/log-level"
-     with timeout 10 seconds for 6 cycles
-     then restart
+    host 127.0.0.1
+    port <%= p("debug_port") %>
+    send "POST /log-level HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type:
+    application/x-www-form-urlencoded\r\nContent-Length: 5\r\n\r\nerror"
+    expect "HTTP/[0-9\.]+ 200.*"
+    with timeout 10 seconds for 6 cycles
+    then restart
 <% end %>


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
vxlan-policy-agent monit health check for log-level

Recent updates to log-level resource expects log level data with curl command. Modified the monit to include the health check.


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
