### PR TITLE
update the debug server port property name - vxlan monit job

### DIFF
--- a/jobs/vxlan-policy-agent/monit
+++ b/jobs/vxlan-policy-agent/monit
@@ -6,7 +6,7 @@ check process vxlan-policy-agent
   group vcap
   if failed
     host 127.0.0.1
-    port <%= p("debug_port") %>
+    port <%= p("debug_server_port") %>
     send "POST /log-level HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type:
     application/x-www-form-urlencoded\r\nContent-Length: 5\r\n\r\nerror"
     expect "HTTP/[0-9\.]+ 200.*"


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
update the debug server port property name for vxlan monit job

Test results:
```
compute/dc0a7976-65ae-4d8e-bc04-02ab3fac7650:/var/vcap/jobs/vxlan-policy-agent$ cat monit 

check process vxlan-policy-agent
  with pidfile /var/vcap/sys/run/bpm/vxlan-policy-agent/vxlan-policy-agent.pid
  start program "/var/vcap/jobs/bpm/bin/bpm start vxlan-policy-agent"
  stop program "/var/vcap/jobs/bpm/bin/bpm stop vxlan-policy-agent"
  group vcap
  if failed
    host 127.0.0.1
    port 8721
    send "POST /log-level HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type:
    application/x-www-form-urlencoded\r\nContent-Length: 5\r\n\r\nerror"
    expect "HTTP/[0-9\.]+ 200.*"
    with timeout 10 seconds for 6 cycles
    then restart

compute/dc0a7976-65ae-4d8e-bc04-02ab3fac7650:/var/vcap/jobs/vxlan-policy-agent$
```


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
