### PR TITLE
deprecate loggregator v2 api

### DIFF
--- a/jobs/vxlan-policy-agent/spec
+++ b/jobs/vxlan-policy-agent/spec
@@ -109,9 +109,6 @@ properties:
     description: "Experimental feature. Enable IPv6 support, the host must also support and be configured for IPv6. The `ipv6.enable` property must be set to `true` on the silk-cni job as well."
     default: false
 
-  loggregator.use_v2_api:
-    description: "True to use local metron agent gRPC v2 API. False to use UDP v1 API."
-    default: false
   loggregator.v2_api_port:
     description: "Local metron agent gRPC port"
     default: 3458

--- a/jobs/vxlan-policy-agent/templates/vxlan-policy-agent.json.erb
+++ b/jobs/vxlan-policy-agent/templates/vxlan-policy-agent.json.erb
@@ -57,9 +57,7 @@
       'force_policy_poll_cycle_host' => '127.0.0.1',
     }
 
-  toRender[:loggregator]={}
-  toRender[:loggregator][:loggregator_use_v2_api] = p("loggregator.use_v2_api")
-  if p("loggregator.use_v2_api") == true
+    toRender[:loggregator]={}
     toRender[:loggregator][:loggregator_api_port] = p("loggregator.v2_api_port")
     toRender[:loggregator][:loggregator_ca_path] = "/var/vcap/jobs/vxlan-policy-agent/config/certs/loggregator/ca.crt"
     toRender[:loggregator][:loggregator_cert_path] = "/var/vcap/jobs/vxlan-policy-agent/config/certs/loggregator/client.crt"
@@ -71,7 +69,6 @@
     toRender[:loggregator][:loggregator_job_origin] = "vxlan-policy-agent"
     toRender[:loggregator][:loggregator_source_id] = "vxlan-policy-agent"
     toRender[:loggregator][:loggregator_instance_id] = spec.id
-  end
 
     JSON.pretty_generate(toRender)
 %>

--- a/spec/vxlan-policy-agent/vxlan-policy-agent_spec.rb
+++ b/spec/vxlan-policy-agent/vxlan-policy-agent_spec.rb
@@ -71,7 +71,7 @@ module Bosh::Template::Test
           let(:template) {job.template('config/vxlan-policy-agent.json')}
 
           it 'renders the template with the provided manifest properties' do
-            renderedConfig = JSON.parse(template.render(merged_manifest_properties, consumes: links))
+            renderedConfig = JSON.parse(template.render(merged_manifest_properties, consumes: links, spec: spec))
             expect(renderedConfig).to eq({
               'ca_cert_file' => '/var/vcap/jobs/vxlan-policy-agent/config/certs/ca.crt',
               'client_cert_file' => '/var/vcap/jobs/vxlan-policy-agent/config/certs/client.crt',
@@ -116,30 +116,6 @@ module Bosh::Template::Test
                 'rate_per_sec' => 100,
               },
               'loggregator' => {
-                'loggregator_use_v2_api' => false,
-              },
-              'enable_ipv6' => false
-            })
-          end
-
-          context 'when loggregator.use_v2_api is true' do
-            let(:ca_cert_template) {job.template('config/certs/loggregator/ca.crt')}
-            let(:client_cert_template) {job.template('config/certs/loggregator/client.crt')}
-            let(:client_key_template) {job.template('config/certs/loggregator/client.key')}
-
-            before do
-              merged_manifest_properties['loggregator'] = {
-                'use_v2_api' => true,
-                'ca_cert' => 'some-ca-cert',
-                'cert' => 'some-client-cert',
-                'key' => 'some-client-key'
-              }
-            end
-
-            it 'renders the loggregator config as well' do
-              renderedConfig = JSON.parse(template.render(merged_manifest_properties, consumes: links, spec: spec))
-              expect(renderedConfig['loggregator']).to eq({
-                'loggregator_use_v2_api' => true,
                 'loggregator_api_port' => 3458,
                 'loggregator_ca_path' => '/var/vcap/jobs/vxlan-policy-agent/config/certs/loggregator/ca.crt',
                 'loggregator_cert_path' => '/var/vcap/jobs/vxlan-policy-agent/config/certs/loggregator/client.crt',
@@ -151,25 +127,39 @@ module Bosh::Template::Test
                 'loggregator_job_origin' => "vxlan-policy-agent",
                 'loggregator_source_id' => "vxlan-policy-agent",
                 'loggregator_instance_id' => 'some-guid'
-              })
-            end
-
-            it 'renders the ca cert' do
-              rendered_ca_cert = ca_cert_template.render(merged_manifest_properties)
-              expect(rendered_ca_cert).to eq("\nsome-ca-cert\n\n")
-            end
-
-            it 'renders the client cert' do
-              rendered_client_cert = client_cert_template.render(merged_manifest_properties)
-              expect(rendered_client_cert).to eq("\nsome-client-cert\n\n")
-            end
-
-            it 'renders the ca cert' do
-              rendered_client_key = client_key_template.render(merged_manifest_properties)
-              expect(rendered_client_key).to eq("\nsome-client-key\n\n")
-            end
+              },
+              'enable_ipv6' => false
+            })
           end
-          
+      
+
+      let(:ca_cert_template) {job.template('config/certs/loggregator/ca.crt')}
+      let(:client_cert_template) {job.template('config/certs/loggregator/client.crt')}
+      let(:client_key_template) {job.template('config/certs/loggregator/client.key')}
+
+      before do
+        merged_manifest_properties['loggregator'] = {
+          'ca_cert' => 'some-ca-cert',
+          'cert' => 'some-client-cert',
+          'key' => 'some-client-key'
+        }
+      end
+
+      it 'renders the ca cert' do
+        rendered_ca_cert = ca_cert_template.render(merged_manifest_properties)
+        expect(rendered_ca_cert).to eq("\nsome-ca-cert\n\n")
+      end
+
+      it 'renders the client cert' do
+        rendered_client_cert = client_cert_template.render(merged_manifest_properties)
+        expect(rendered_client_cert).to eq("\nsome-client-cert\n\n")
+      end
+
+      it 'renders the ca cert' do
+        rendered_client_key = client_key_template.render(merged_manifest_properties)
+        expect(rendered_client_key).to eq("\nsome-client-key\n\n")
+      end
+
           context 'when the network is a single IP and not an array' do
             before do
               links.first.properties['network'] = '10.234.0.0/16'

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/vxlan-policy-agent/main.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/vxlan-policy-agent/main.go
@@ -230,10 +230,8 @@ func main() {
 		log.Fatalf("%s: initializing ingress client: %s", logPrefix, err)
 	}
 
-	if conf.LoggregatorConfig.UseV2API {
-		emitter := runtimeemitter.NewV1(metronClient)
-		go emitter.Run()
-	}
+	emitter := runtimeemitter.NewV1(metronClient)
+	go emitter.Run()
 
 	singlePollCycle := converger.NewSinglePollCycle(
 		[]converger.Planner{dynamicPlanner},


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
deprecate loggregator v2 api

```
~/workspace/silk-release |log-v2-deprecate ?:1| 
$ ./scripts/test-in-docker.bash vxlan-policy-agent
Using default tag: latest
latest: Pulling from cloudfoundry/tas-runtime-mysql-8.0
Digest: sha256:fc4a85bdc97f3dfc3de7f9eea3258944d69bab41f158ca6bb03f62c74bec19dc
Status: Image is up to date for cloudfoundry/tas-runtime-mysql-8.0:latest
docker.io/cloudfoundry/tas-runtime-mysql-8.0:latest
silk-release-mysql-docker-container
08aec4860f8c4f73dcfc21e6b03e82069e015e976f70285daac073a66798db1e
Don't run Bundler as root. Installing your bundle as root will break this
application for all non-root users on this machine.
Bundler 2.7.2 is running, but your lockfile was generated with 2.5.23. Installing Bundler 2.5.23 and restarting using that version.
Fetching gem metadata from https://rubygems.org/.
Fetching bundler 2.5.23
Installing bundler 2.5.23
Don't run Bundler as root. Installing your bundle as root will break this
application for all non-root users on this machine.
Fetching gem metadata from https://rubygems.org/.
Fetching semi_semantic 1.2.0
Fetching diff-lcs 1.5.1
Installing semi_semantic 1.2.0
Installing diff-lcs 1.5.1
Fetching rspec-support 3.13.2
Installing rspec-support 3.13.2
Fetching bosh-template 2.4.0
Fetching rspec-core 3.13.2
Installing bosh-template 2.4.0
Fetching rspec-expectations 3.13.3
Installing rspec-core 3.13.2
Installing rspec-expectations 3.13.3
Fetching rspec-mocks 3.13.2
Installing rspec-mocks 3.13.2
Fetching rspec 3.13.0
Installing rspec 3.13.0
Bundle complete! 2 Gemfile dependencies, 9 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
...............................................................

Finished in 0.19348 seconds (files took 0.13082 seconds to load)
63 examples, 0 failures

Verifying: verify_go repo/src/code.cloudfoundry.org/vxlan-policy-agent
go version go1.25.3 linux/amd64
Verifying: verify_go_version_match_bosh_release repo
Verifying: verify_gofmt repo/src/code.cloudfoundry.org/vxlan-policy-agent
Verifying: verify_govet repo/src/code.cloudfoundry.org/vxlan-policy-agent
Verifying: verify_staticcheck repo/src/code.cloudfoundry.org/vxlan-policy-agent
booting mysql.............connection established to mysql
Will skip:
  ./integration/linux
[1761753856] vxlan-policy-agent pre-start Integration Suite - 4/4 specs - 7 procs 
------------------------------
• [0.001 seconds]
Pre-Start when the PreStart() iptables flush and restore fails retries up to MAX_RETRIES times
/repo/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/pre-start/main_test.go:31

  Captured StdOut/StdErr Output >>
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  << Captured StdOut/StdErr Output
------------------------------
•
------------------------------
• [0.001 seconds]
Pre-Start when the PreStart() iptables flush and restore fails propagates errors up when encountered
/repo/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/pre-start/main_test.go:38

  Captured StdOut/StdErr Output >>
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  << Captured StdOut/StdErr Output
------------------------------
• [0.017 seconds]
Pre-Start when the PreStart() iptables flush and restore fails and eventually succeeds retries and then clears the iptables rules
/repo/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/pre-start/main_test.go:52

  Captured StdOut/StdErr Output >>
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  2025/10/29 16:05:22 pre-start error: iptables borked
  << Captured StdOut/StdErr Output
------------------------------
 SUCCESS! 152.568065ms 
[1761753856] Config Suite - 22/22 specs - 7 procs •••••••••••••••••••••• SUCCESS! 117.262129ms 
[1761753856] Converger Suite - 44/44 specs - 7 procs •••••••••••••••••••••••••••••••••••••••••••• SUCCESS! 164.186911ms 
[1761753856] Enforcer Suite - 41/41 specs - 7 procs ••••••••••••••••••••••••••••••••••••••••• SUCCESS! 146.649793ms 
[1761753856] Handlers Suite - 18/18 specs - 7 procs •••••••••••••••••• SUCCESS! 126.999587ms 
[1761753856] Planner Suite - 40/40 specs - 7 procs •••••••••••••••••••••••••••••••••••••••• SUCCESS! 1.123526497s 

Ginkgo ran 6 suites in 1m20.668881312s
Test Suite Passed
```

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
