### PR TITLE
ai-assisted=yes Fix ASG chain race condition between silk-cni and vxlan-policy-agent periodic poller

### DIFF
--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
@@ -536,16 +536,38 @@ var _ = Describe("CniWrapperPlugin", func() {
 		})
 
 		Context("when the policy agent poller returns an error", func() {
-			It("returns an error", func() {
+			BeforeEach(func() {
 				policyAgentServer.ReturnCode = 500
 				policyAgentServer.ReturnErrorMessage = "an error occurred in the vpa"
+			})
 
+			It("returns an error", func() {
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(session).Should(gexec.Exit(1))
 				Expect(session.Out).Should(gbytes.Say(".*vpa response code: 500 with message: an error occurred in the vpa.*"))
 
 				Expect(policyAgentServer.PolicyPollEndpointCallCount).To(Equal(1))
+			})
+
+			It("cleans up iptables chains after store.Add succeeds", func() {
+				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(session).Should(gexec.Exit(1))
+
+				Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(inputChainName)))
+				Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(netoutChainName)))
+				Expect(AllIPTablesRules("nat")).ToNot(ContainElement(ContainSubstring(netinChainName)))
+			})
+
+			It("removes the container from the datastore after store.Add succeeds", func() {
+				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(session).Should(gexec.Exit(1))
+
+				stateFileBytes, err := os.ReadFile(datastorePath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(stateFileBytes)).NotTo(ContainSubstring(containerID))
 			})
 		})
 
@@ -1202,6 +1224,29 @@ var _ = Describe("CniWrapperPlugin", func() {
 				Eventually(session).Should(gexec.Exit(1))
 
 				Expect(AllIPTablesRules("nat")).NotTo(ContainElement("-A POSTROUTING -s 1.2.3.4/32 ! -d 10.255.30.0/24 ! -o some-device -j MASQUERADE"))
+				Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(inputChainName)))
+				Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(netoutChainName)))
+				Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(netoutLoggingChainName)))
+				Expect(AllIPTablesRules("nat")).ToNot(ContainElement(ContainSubstring(netinChainName)))
+			})
+		})
+
+		Context("when netOutProvider.Initialize fails", func() {
+			BeforeEach(func() {
+				inputStruct.HostTCPServices = []string{"invalid-host-port"}
+				input = GetInput(inputStruct)
+				cmd = cniCommand("ADD", input)
+			})
+
+			It("returns an error and does not leave iptables rules behind", func() {
+				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(session).Should(gexec.Exit(1))
+
+				Expect(session.Out.Contents()).To(ContainSubstring("initialize net out: input rules: host tcp services: address invalid-host-port: missing port in address"))
+
+				Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(inputChainName)))
+				Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(netoutChainName)))
 			})
 		})
 
@@ -1848,7 +1893,7 @@ var _ = Describe("CniWrapperPlugin", func() {
 			})
 		})
 
-		Context("when the datastore delete fails", func() {
+		Context("when the datastore is corrupt (MarkForDelete and Delete both fail)", func() {
 			BeforeEach(func() {
 				file, err := os.OpenFile(datastorePath, os.O_RDWR, 0600)
 				Expect(err).ToNot(HaveOccurred())
@@ -1856,11 +1901,12 @@ var _ = Describe("CniWrapperPlugin", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("wraps and logs the error, and returns the success status code (for idempotency)", func() {
+			It("logs both store errors and returns success (DEL is idempotent)", func() {
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(session).Should(gexec.Exit(0))
 
+				Expect(string(session.Err.Contents())).To(ContainSubstring("store mark for delete: decoding file: invalid character"))
 				Expect(string(session.Err.Contents())).To(ContainSubstring("store delete: decoding file: invalid character"))
 			})
 

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
@@ -62,31 +62,14 @@ func cmdAdd(args *skel.CmdArgs) error {
 	containerIPv4, containerIPv6 := common.ParseIPConfig(ips)
 	enableIPv6 = enableIPv6 && containerIPv6 != nil
 
-	var containerWorkload string
-
-	// Add container metadata info
-	store := &datastore.Store{
-		Serializer: &serial.Serial{},
-		Locker: &filelock.Locker{
-			FileLocker: filelock.NewLocker(cfg.Datastore + "_lock"),
-			Mutex:      new(sync.Mutex),
-		},
-		DataFilePath:    cfg.Datastore,
-		VersionFilePath: cfg.Datastore + "_version",
-		LockedFilePath:  cfg.Datastore + "_lock",
-		FileOwner:       cfg.DatastoreFileOwner,
-		FileGroup:       cfg.DatastoreFileGroup,
-		CacheMutex:      new(sync.RWMutex),
-	}
-
 	var cniAddData struct {
 		Metadata map[string]interface{}
 	}
-
 	if err := json.Unmarshal(args.StdinData, &cniAddData); err != nil {
 		return err // not tested, this should be impossible
 	}
 
+	var containerWorkload string
 	if workload, present := cniAddData.Metadata["container_workload"]; present {
 		containerWorkload, _ = workload.(string)
 	}
@@ -97,44 +80,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 		DaemonPort:                  fmt.Sprintf("%v", cfg.Delegate["daemonPort"]),
 		ContainerIP:                 containerIPv4.String(),
 		CustomNoMasqueradeCIDRRange: cfg.NoMasqueradeCIDRRange,
-	}
-
-	var storeOpts []datastore.Option
-	if enableIPv6 {
-		storeOpts = append(storeOpts, datastore.WithIPv6(containerIPv6.String()))
-	}
-
-	err = store.Add(
-		args.ContainerID,
-		containerIPv4.String(),
-		cniAddData.Metadata,
-		storeOpts...,
-	)
-
-	if err != nil {
-		storeErr := fmt.Errorf("store add: %s", err)
-		fmt.Fprintf(os.Stderr, "%s", storeErr)
-		fmt.Fprint(os.Stderr, "cleaning up from error")
-
-		err := masquerader.DelIPMasq()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "during cleanup: removing IP masq: %s", err)
-		}
-
-		return storeErr
-	}
-
-	resp, err := http.DefaultClient.Get(fmt.Sprintf("http://%s/force-policy-poll-cycle", cfg.PolicyAgentForcePollAddress))
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		// #nosec G104 - don't capture this error, as the one we generate below is more important to return
-		resp.Body.Close()
-
-		return fmt.Errorf("vpa response code: %v with message: %s", resp.StatusCode, body)
 	}
 
 	localDNSServers, err := getLocalDNSServers(cfg.DNSServers)
@@ -210,6 +155,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("initialize net out: %s", err)
 	}
 
+	var netOutProviderIPv6 *netrules.NetOut
+	var netinInitialized bool
+
 	netinProvider := netrules.NetIn{
 		ChainNamer: &netrules.ChainNamer{
 			MaxLength: 28,
@@ -219,24 +167,45 @@ func cmdAdd(args *skel.CmdArgs) error {
 		HostInterfaceNames: interfaceNames,
 	}
 
+	// netinInitialized and netOutProviderIPv6 are captured by reference intentionally:
+	// cleanupChains is defined before they are set, so it reads their final values at call time.
+	cleanupChains := func() {
+		if cleanupErr := netOutProvider.Cleanup(); cleanupErr != nil {
+			fmt.Fprintf(os.Stderr, "during cleanup: net out: %s", cleanupErr)
+		}
+		if netinInitialized {
+			if cleanupErr := netinProvider.Cleanup(args.ContainerID); cleanupErr != nil {
+				fmt.Fprintf(os.Stderr, "during cleanup: net in: %s", cleanupErr)
+			}
+		}
+		if enableIPv6 && netOutProviderIPv6 != nil {
+			if cleanupErr := netOutProviderIPv6.Cleanup(); cleanupErr != nil {
+				fmt.Fprintf(os.Stderr, "during cleanup: net out ipv6: %s", cleanupErr)
+			}
+		}
+	}
+
 	err = netinProvider.Initialize(args.ContainerID)
 	if err != nil {
+		cleanupChains()
 		return fmt.Errorf("initializing net in: %s", err)
 	}
+	netinInitialized = true
 
 	portMappings := cfg.RuntimeConfig.PortMappings
 	for _, netIn := range portMappings {
 		if netIn.HostPort <= 0 {
+			cleanupChains()
 			return fmt.Errorf("cannot allocate port %d", netIn.HostPort)
 		}
 
 		if err := netinProvider.AddRule(args.ContainerID, int(netIn.HostPort), int(netIn.ContainerPort), cfg.InstanceAddress, containerIPv4.String()); err != nil {
+			cleanupChains()
 			return fmt.Errorf("adding netin rule: %s", err)
 		}
 	}
 
 	var netOutChainIPv6 *netrules.NetOutChain
-	var netOutProviderIPv6 *netrules.NetOut
 
 	if enableIPv6 {
 		netOutChainIPv6 = &netrules.NetOutChain{
@@ -274,14 +243,81 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 		err = netOutProviderIPv6.Initialize()
 		if err != nil {
+			cleanupChains()
 			return fmt.Errorf("initialize net out ipv6: %s", err)
 		}
 	}
 
-	resp, err = http.DefaultClient.Get(fmt.Sprintf("http://%s/force-asgs-for-container?container=%s", cfg.PolicyAgentForcePollAddress, args.ContainerID))
+	// Add container metadata info - AFTER chains exist so VPA poller can't race
+	store := &datastore.Store{
+		Serializer: &serial.Serial{},
+		Locker: &filelock.Locker{
+			FileLocker: filelock.NewLocker(cfg.Datastore + "_lock"),
+			Mutex:      new(sync.Mutex),
+		},
+		DataFilePath:    cfg.Datastore,
+		VersionFilePath: cfg.Datastore + "_version",
+		LockedFilePath:  cfg.Datastore + "_lock",
+		FileOwner:       cfg.DatastoreFileOwner,
+		FileGroup:       cfg.DatastoreFileGroup,
+		CacheMutex:      new(sync.RWMutex),
+	}
+
+	var storeOpts []datastore.Option
+	if enableIPv6 {
+		storeOpts = append(storeOpts, datastore.WithIPv6(containerIPv6.String()))
+	}
+
+	err = store.Add(
+		args.ContainerID,
+		containerIPv4.String(),
+		cniAddData.Metadata,
+		storeOpts...,
+	)
+
 	if err != nil {
+		storeErr := fmt.Errorf("store add: %s", err)
+		fmt.Fprintf(os.Stderr, "%s", storeErr)
+		fmt.Fprint(os.Stderr, "cleaning up from error")
+
+		cleanupChains()
+		if cleanupErr := masquerader.DelIPMasq(); cleanupErr != nil {
+			fmt.Fprintf(os.Stderr, "during cleanup: removing IP masq: %s", cleanupErr)
+		}
+
+		return storeErr
+	}
+
+	cleanupStore := func() {
+		if _, cleanupErr := store.Delete(args.ContainerID); cleanupErr != nil {
+			fmt.Fprintf(os.Stderr, "during cleanup: store delete: %s", cleanupErr)
+		}
+	}
+
+	pollResp, err := http.DefaultClient.Get(fmt.Sprintf("http://%s/force-policy-poll-cycle", cfg.PolicyAgentForcePollAddress))
+	if err != nil {
+		cleanupChains()
+		cleanupStore()
 		return err
 	}
+	// #nosec G104 - don't capture this error, as the one we generate below is more important to return
+	defer pollResp.Body.Close()
+
+	if pollResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(pollResp.Body)
+		cleanupChains()
+		cleanupStore()
+		return fmt.Errorf("vpa response code: %v with message: %s", pollResp.StatusCode, body)
+	}
+
+	resp, err := http.DefaultClient.Get(fmt.Sprintf("http://%s/force-asgs-for-container?container=%s", cfg.PolicyAgentForcePollAddress, args.ContainerID))
+	if err != nil {
+		cleanupChains()
+		cleanupStore()
+		return err
+	}
+	// #nosec G104 - don't capture this error, as the one we generate below is more important to return
+	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusMethodNotAllowed {
 		netOutRules := cfg.RuntimeConfig.NetOutRules
@@ -302,9 +338,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusMethodNotAllowed {
 		body, _ := io.ReadAll(resp.Body)
-		// #nosec G104 - don't capture this error, as the one we generate below is more important to return
-		resp.Body.Close()
-
+		cleanupChains()
+		cleanupStore()
 		return fmt.Errorf("asg sync returned %v with message: %s", resp.StatusCode, body)
 	}
 
@@ -398,9 +433,9 @@ func cmdDel(args *skel.CmdArgs) error {
 		CacheMutex:      new(sync.RWMutex),
 	}
 
-	container, err := store.Delete(args.ContainerID)
+	container, err := store.MarkForDelete(args.ContainerID)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "store delete: %s", err)
+		fmt.Fprintf(os.Stderr, "store mark for delete: %s", err)
 	}
 
 	enableIPv6 = enableIPv6 && container.IPv6 != ""
@@ -508,15 +543,21 @@ func cmdDel(args *skel.CmdArgs) error {
 		fmt.Fprintf(os.Stderr, "removing IP masq: %s", err)
 	}
 
+	// Error is intentionally not returned: DEL must be idempotent, and iptables cleanup above
+	// already succeeded. A stale datastore entry is harmless at this point.
+	if _, err := store.Delete(args.ContainerID); err != nil {
+		fmt.Fprintf(os.Stderr, "store delete: %s", err)
+	}
+
 	resp, err := http.DefaultClient.Get(fmt.Sprintf("http://%s/force-orphaned-asgs-cleanup?container=%s", cfg.PolicyAgentForcePollAddress, args.ContainerID))
 	if err != nil {
 		return err
 	}
+	// #nosec G104 - don't capture this error, as the one we generate below is more important to return
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusMethodNotAllowed {
 		body, _ := io.ReadAll(resp.Body)
-		// #nosec G104 - don't capture this error, as the one we generate below is more important to return
-		resp.Body.Close()
 		return fmt.Errorf("asg cleanup returned %v with message: %s", resp.StatusCode, body)
 	}
 

--- a/src/code.cloudfoundry.org/lib/datastore/datastore.go
+++ b/src/code.cloudfoundry.org/lib/datastore/datastore.go
@@ -25,6 +25,7 @@ type Datastore interface {
 	Add(handle, ip string, metadata map[string]interface{}, options ...Option) error
 	Delete(handle string) (Container, error)
 	ReadAll() (map[string]Container, error)
+	MarkForDelete(handle string) (Container, error)
 }
 
 type Container struct {
@@ -32,6 +33,7 @@ type Container struct {
 	IP       string                 `json:"ip"`
 	IPv6     string                 `json:"ipv6"`
 	Metadata map[string]interface{} `json:"metadata"`
+	Deleting bool                   `json:"deleting,omitempty"`
 }
 
 type Store struct {
@@ -188,6 +190,49 @@ func (c *Store) lookupFileOwnerUIDandGID() (int, int, error) {
 	}
 
 	return uid, gid, nil
+}
+
+func (c *Store) MarkForDelete(handle string) (Container, error) {
+	if handle == "" {
+		return Container{}, fmt.Errorf("invalid handle")
+	}
+
+	err := c.Locker.Lock()
+	if err != nil {
+		return Container{}, fmt.Errorf("lock: %s", err)
+	}
+	defer c.Locker.Unlock()
+
+	dataFile, err := os.OpenFile(c.DataFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		return Container{}, fmt.Errorf("open data file: %s", err)
+	}
+	defer dataFile.Close()
+
+	pool := make(map[string]*Container)
+	err = c.Serializer.DecodeAll(dataFile, &pool)
+	if err != nil {
+		return Container{}, fmt.Errorf("decoding file: %s", err)
+	}
+
+	existing, ok := pool[handle]
+	if !ok {
+		return Container{}, fmt.Errorf("entry does not exist")
+	}
+
+	existing.Deleting = true
+
+	err = c.Serializer.EncodeAndOverwrite(dataFile, pool)
+	if err != nil {
+		return *existing, fmt.Errorf("encode and overwrite: %s", err)
+	}
+
+	err = c.updateVersion()
+	if err != nil {
+		return *existing, err
+	}
+
+	return *existing, c.ensureFileOwnership()
 }
 
 func (c *Store) Delete(handle string) (Container, error) {

--- a/src/code.cloudfoundry.org/lib/datastore/datastore_test.go
+++ b/src/code.cloudfoundry.org/lib/datastore/datastore_test.go
@@ -410,6 +410,134 @@ var _ = Describe("Datastore", func() {
 
 	})
 
+	Context("when marking an entry for delete", func() {
+		BeforeEach(func() {
+			serializer.DecodeAllStub = func(_ io.ReadSeeker, a interface{}) error {
+				b := a.(*map[string]*datastore.Container)
+				*b = map[string]*datastore.Container{
+					handle: {
+						Handle:   handle,
+						IP:       ip,
+						Metadata: metadata,
+					},
+				}
+				return nil
+			}
+		})
+
+		It("marks the container as deleting and returns it", func() {
+			container, err := store.MarkForDelete(handle)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(container.Handle).To(Equal(handle))
+			Expect(container.IP).To(Equal(ip))
+			Expect(container.Metadata).To(Equal(metadata))
+			Expect(container.Deleting).To(BeTrue())
+
+			Expect(locker.LockCallCount()).To(Equal(1))
+			Expect(locker.UnlockCallCount()).To(Equal(1))
+			Expect(serializer.DecodeAllCallCount()).To(Equal(1))
+			Expect(serializer.EncodeAndOverwriteCallCount()).To(Equal(1))
+
+			_, actual := serializer.EncodeAndOverwriteArgsForCall(0)
+			pool := actual.(map[string]*datastore.Container)
+			Expect(pool[handle].Deleting).To(BeTrue())
+		})
+
+		It("updates the version", func() {
+			_, err := store.MarkForDelete(handle)
+			Expect(err).NotTo(HaveOccurred())
+
+			versionContents, err := os.ReadFile(versionFile.Name())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(versionContents)).To(Equal("2"))
+		})
+
+		Context("when handle is empty", func() {
+			It("returns an error", func() {
+				_, err := store.MarkForDelete("")
+				Expect(err).To(MatchError("invalid handle"))
+			})
+		})
+
+		Context("when handle does not exist", func() {
+			BeforeEach(func() {
+				serializer.DecodeAllStub = func(_ io.ReadSeeker, a interface{}) error {
+					b := a.(*map[string]*datastore.Container)
+					*b = map[string]*datastore.Container{}
+					return nil
+				}
+			})
+
+			It("returns an error", func() {
+				_, err := store.MarkForDelete("potato")
+				Expect(err).To(MatchError("entry does not exist"))
+			})
+		})
+
+		Context("when the locker fails to lock", func() {
+			BeforeEach(func() {
+				locker.LockReturns(errors.New("potato"))
+			})
+			It("wraps and returns the error", func() {
+				_, err := store.MarkForDelete(handle)
+				Expect(err).To(MatchError("lock: potato"))
+			})
+		})
+
+		Context("when the container is already marked for deletion", func() {
+			BeforeEach(func() {
+				serializer.DecodeAllStub = func(_ io.ReadSeeker, a interface{}) error {
+					b := a.(*map[string]*datastore.Container)
+					*b = map[string]*datastore.Container{
+						handle: {
+							Handle:   handle,
+							IP:       ip,
+							Metadata: metadata,
+							Deleting: true,
+						},
+					}
+					return nil
+				}
+			})
+
+			It("succeeds idempotently", func() {
+				container, err := store.MarkForDelete(handle)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(container.Deleting).To(BeTrue())
+			})
+		})
+
+		Context("when the data file fails to open", func() {
+			BeforeEach(func() {
+				store.DataFilePath = "/some/bad/path"
+			})
+			It("wraps and returns the error", func() {
+				_, err := store.MarkForDelete(handle)
+				Expect(err).To(MatchError("open data file: open /some/bad/path: no such file or directory"))
+			})
+		})
+
+		Context("when serializer fails to decode", func() {
+			BeforeEach(func() {
+				serializer.DecodeAllReturns(errors.New("potato"))
+			})
+			It("wraps and returns the error", func() {
+				_, err := store.MarkForDelete(handle)
+				Expect(err).To(MatchError("decoding file: potato"))
+			})
+		})
+
+		Context("when serializer fails to encode", func() {
+			BeforeEach(func() {
+				serializer.EncodeAndOverwriteReturns(errors.New("potato"))
+			})
+			It("wraps and returns the error", func() {
+				_, err := store.MarkForDelete(handle)
+				Expect(err).To(MatchError("encode and overwrite: potato"))
+			})
+		})
+	})
+
 	Context("when reading from datastore", func() {
 		It("deserializes the data from the file", func() {
 			data, err := store.ReadAll()

--- a/src/code.cloudfoundry.org/lib/fakes/datastore.go
+++ b/src/code.cloudfoundry.org/lib/fakes/datastore.go
@@ -35,6 +35,19 @@ type Datastore struct {
 		result1 datastore.Container
 		result2 error
 	}
+	MarkForDeleteStub        func(string) (datastore.Container, error)
+	markForDeleteMutex       sync.RWMutex
+	markForDeleteArgsForCall []struct {
+		arg1 string
+	}
+	markForDeleteReturns struct {
+		result1 datastore.Container
+		result2 error
+	}
+	markForDeleteReturnsOnCall map[int]struct {
+		result1 datastore.Container
+		result2 error
+	}
 	ReadAllStub        func() (map[string]datastore.Container, error)
 	readAllMutex       sync.RWMutex
 	readAllArgsForCall []struct {
@@ -179,6 +192,70 @@ func (fake *Datastore) DeleteReturnsOnCall(i int, result1 datastore.Container, r
 	}{result1, result2}
 }
 
+func (fake *Datastore) MarkForDelete(arg1 string) (datastore.Container, error) {
+	fake.markForDeleteMutex.Lock()
+	ret, specificReturn := fake.markForDeleteReturnsOnCall[len(fake.markForDeleteArgsForCall)]
+	fake.markForDeleteArgsForCall = append(fake.markForDeleteArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.MarkForDeleteStub
+	fakeReturns := fake.markForDeleteReturns
+	fake.recordInvocation("MarkForDelete", []interface{}{arg1})
+	fake.markForDeleteMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *Datastore) MarkForDeleteCallCount() int {
+	fake.markForDeleteMutex.RLock()
+	defer fake.markForDeleteMutex.RUnlock()
+	return len(fake.markForDeleteArgsForCall)
+}
+
+func (fake *Datastore) MarkForDeleteCalls(stub func(string) (datastore.Container, error)) {
+	fake.markForDeleteMutex.Lock()
+	defer fake.markForDeleteMutex.Unlock()
+	fake.MarkForDeleteStub = stub
+}
+
+func (fake *Datastore) MarkForDeleteArgsForCall(i int) string {
+	fake.markForDeleteMutex.RLock()
+	defer fake.markForDeleteMutex.RUnlock()
+	argsForCall := fake.markForDeleteArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *Datastore) MarkForDeleteReturns(result1 datastore.Container, result2 error) {
+	fake.markForDeleteMutex.Lock()
+	defer fake.markForDeleteMutex.Unlock()
+	fake.MarkForDeleteStub = nil
+	fake.markForDeleteReturns = struct {
+		result1 datastore.Container
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *Datastore) MarkForDeleteReturnsOnCall(i int, result1 datastore.Container, result2 error) {
+	fake.markForDeleteMutex.Lock()
+	defer fake.markForDeleteMutex.Unlock()
+	fake.MarkForDeleteStub = nil
+	if fake.markForDeleteReturnsOnCall == nil {
+		fake.markForDeleteReturnsOnCall = make(map[int]struct {
+			result1 datastore.Container
+			result2 error
+		})
+	}
+	fake.markForDeleteReturnsOnCall[i] = struct {
+		result1 datastore.Container
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *Datastore) ReadAll() (map[string]datastore.Container, error) {
 	fake.readAllMutex.Lock()
 	ret, specificReturn := fake.readAllReturnsOnCall[len(fake.readAllArgsForCall)]
@@ -238,12 +315,6 @@ func (fake *Datastore) ReadAllReturnsOnCall(i int, result1 map[string]datastore.
 func (fake *Datastore) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.addMutex.RLock()
-	defer fake.addMutex.RUnlock()
-	fake.deleteMutex.RLock()
-	defer fake.deleteMutex.RUnlock()
-	fake.readAllMutex.RLock()
-	defer fake.readAllMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/src/code.cloudfoundry.org/lib/fakes/locker.go
+++ b/src/code.cloudfoundry.org/lib/fakes/locker.go
@@ -139,10 +139,6 @@ func (fake *Locker) UnlockReturnsOnCall(i int, result1 error) {
 func (fake *Locker) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.lockMutex.RLock()
-	defer fake.lockMutex.RUnlock()
-	fake.unlockMutex.RLock()
-	defer fake.unlockMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger.go
@@ -260,16 +260,23 @@ func (m *SinglePollCycle) SyncASGsForContainers(containers ...string) error {
 				})
 				chain, err := m.enforcer.EnforceRulesAndChain(ruleset)
 				if err != nil {
+					if _, ok := err.(*enforcer.ParentChainNotReadyErr); ok {
+						continue
+					}
 					if _, ok := err.(*enforcer.CleanupErr); ok {
 						m.updateRuleSet(chainKey, chain, ruleset)
 					}
-
 					errors = multierror.Append(errors, fmt.Errorf("enforce-asg: %s", err))
 				} else {
 					m.updateRuleSet(chainKey, chain, ruleset)
 				}
 			}
-			desiredChains = append(desiredChains, enforcer.LiveChain{Table: ruleset.Chain.Table, Name: m.asgChainToContainer[chainKey]})
+			// chainName is empty when EnforceRulesAndChain returned ParentChainNotReadyErr and
+			// we continued without calling updateRuleSet — skip those to avoid adding empty
+			// chain names to the desired set.
+			if chainName := m.asgChainToContainer[chainKey]; chainName != "" {
+				desiredChains = append(desiredChains, enforcer.LiveChain{Table: ruleset.Chain.Table, Name: chainName})
+			}
 		}
 		enforceDuration += time.Since(enforceStartTime)
 	}
@@ -308,8 +315,13 @@ func (m *SinglePollCycle) CleanupOrphanedASGsChains(containerHandle string) erro
 		return fmt.Errorf("clean-up-orphaned-asg-chains: %s", err)
 	}
 
-	delete(m.asgChainToContainer, chain)
-	delete(m.asgRuleSets, chain)
+	for key, chainName := range m.asgChainToContainer {
+		if chainName == chain.Name {
+			delete(m.asgChainToContainer, key)
+			delete(m.asgRuleSets, key)
+			break
+		}
+	}
 	return nil
 }
 

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger_test.go
@@ -685,12 +685,42 @@ var _ = Describe("Single Poll Cycle", func() {
 			})
 		})
 
+		Context("when the enforcer returns ParentChainNotReadyErr", func() {
+			BeforeEach(func() {
+				i := 0
+				fakeEnforcer.EnforceRulesAndChainStub = func(e enforcer.RulesWithChain) (string, error) {
+					i++
+					if i == 2 {
+						return "", &enforcer.ParentChainNotReadyErr{ParentChain: "netout-2"}
+					}
+					return e.Chain.Name, nil
+				}
+			})
+
+			It("skips that container without accumulating an error", func() {
+				err := p.DoASGCycle()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("still enforces other containers", func() {
+				err := p.DoASGCycle()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fakeEnforcer.EnforceRulesAndChainCallCount()).To(Equal(3))
+			})
+
+			It("does not include the skipped container in desired chains", func() {
+				err := p.DoASGCycle()
+				Expect(err).NotTo(HaveOccurred())
+				_, desiredChains := fakeEnforcer.CleanChainsMatchingArgsForCall(0)
+				Expect(desiredChains).To(Equal([]enforcer.LiveChain{
+					{Table: "filter", Name: "asg-1234"},
+					{Table: "filter", Name: "asg-3456"},
+				}))
+			})
+		})
+
 		Context("when the enforcer errors", func() {
 			BeforeEach(func() {
-				// set up an initial successful cycle to create the cache of container to asg mappings
-				// fakeEnforcer.EnforceRulesAndChainStub = func(chain enforcer.RulesWithChain) (string, error) {
-				// 	return fmt.Sprintf("%s-with-suffix", chain.Chain.Name), nil
-				// }
 				err := p.DoASGCycle()
 				Expect(err).ToNot(HaveOccurred())
 
@@ -965,6 +995,21 @@ var _ = Describe("Single Poll Cycle", func() {
 				chain := fakeEnforcer.CleanupChainArgsForCall(0)
 				Expect(chain.Name).To(Equal("asg-b6259c4829b649dd739c"))
 				Expect(chain.Table).To(Equal(enforcer.FilterTable))
+			})
+
+			Context("after a successful DoASGCycle", func() {
+				BeforeEach(func() {
+					err := p.DoASGCycle()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(p.CurrentlyAppliedChainNames()).To(ConsistOf("asg-1234", "asg-2345", "asg-3456"))
+				})
+
+				It("removes the chain from CurrentlyAppliedChainNames using the correct map key", func() {
+					err := p.CleanupOrphanedASGsChains("3456")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(p.CurrentlyAppliedChainNames()).To(ConsistOf("asg-1234", "asg-2345"))
+					Expect(p.CurrentlyAppliedChainNames()).NotTo(ContainElement("asg-3456"))
+				})
 			})
 
 			Context("the enforcer returns an error", func() {

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer.go
@@ -18,6 +18,7 @@ const (
 	ASGChainRegex          = `^c?asg-[A-Za-z0-9]+`
 	ContainerPrefixToStrip = `check-`
 	JumpRuleRegex          = `-A\s+%s\s+.*-[gj]\s+([^\s]+)`
+	chainAlreadyExistsMsg  = "chain already exists"
 )
 
 type Timestamper struct{}
@@ -107,6 +108,14 @@ type CleanupErr struct {
 
 func (e *CleanupErr) Error() string {
 	return fmt.Sprintf("cleaning up: %s", e.Err)
+}
+
+type ParentChainNotReadyErr struct {
+	ParentChain string
+}
+
+func (e *ParentChainNotReadyErr) Error() string {
+	return fmt.Sprintf("parent chain not ready: %s", e.ParentChain)
 }
 
 func (r *RulesWithChain) Equals(other RulesWithChain) bool {
@@ -230,6 +239,10 @@ func (e *Enforcer) EnforceOnChain(c Chain, rulesSpec []rules.IPTablesRule) (stri
 
 	err := e.replaceChainRules(logger, c, rulesSpec)
 	if err != nil {
+		if _, ok := err.(*ParentChainNotReadyErr); ok {
+			logger.Info("skipping-asg-enforcement", lager.Data{"chain": c.Name, "reason": err.Error()})
+			return "", err
+		}
 		logger.Error("replace-chain", err)
 		return "", err
 	}
@@ -249,10 +262,27 @@ func (e *Enforcer) EnforceOnChain(c Chain, rulesSpec []rules.IPTablesRule) (stri
 func (e *Enforcer) enforce(logger lager.Logger, table string, parentChain string, chainName string, rulespec ...rules.IPTablesRule) error {
 	logger.Debug("create-chain", lager.Data{"chain": chainName, "table": table})
 
+	chainPreExisted := false
 	err := e.iptables.NewChain(table, chainName)
 	if err != nil {
-		logger.Error("create-chain", err)
-		return fmt.Errorf("creating chain: %s", err)
+		// Prefer checking iptables directly over string-matching the error, since error
+		// message casing can vary across iptables versions. Fall back to the constant if
+		// ChainExists itself errors.
+		chainExists, chainExistsErr := e.iptables.ChainExists(table, chainName)
+		if chainExistsErr != nil {
+			chainExists = strings.Contains(strings.ToLower(err.Error()), chainAlreadyExistsMsg)
+		}
+		if chainExists {
+			logger.Info("chain-exists-flushing", lager.Data{"chain": chainName, "table": table})
+			if clearErr := e.iptables.ClearChain(table, chainName); clearErr != nil {
+				logger.Error("clear-existing-chain", clearErr)
+				return fmt.Errorf("clearing existing chain %s: %s", chainName, clearErr)
+			}
+			chainPreExisted = true
+		} else {
+			logger.Error("create-chain", err)
+			return fmt.Errorf("creating chain: %s", err)
+		}
 	}
 
 	if e.conf.DisableContainerNetworkPolicy {
@@ -270,15 +300,20 @@ func (e *Enforcer) enforce(logger lager.Logger, table string, parentChain string
 		}
 	}
 
-	logger.Debug("insert-chain", lager.Data{"parent-chain": parentChain, "table": table, "index": 1, "rule": rules.IPTablesRule{"-j", chainName}})
-	err = e.iptables.BulkInsert(table, parentChain, 1, rules.IPTablesRule{"-j", chainName})
-	if err != nil {
-		logger.Error("insert-chain", err)
-		delErr := e.deleteChain(logger, LiveChain{Table: table, Name: chainName}, "")
-		if delErr != nil {
-			logger.Error("cleanup-failed-insert", delErr)
+	// Skip inserting the jump rule when the chain pre-existed: BulkInsert uses
+	// iptables-restore --noflush with -I (insert), which is additive and would create
+	// a duplicate jump rule in the parent chain.
+	if !chainPreExisted {
+		logger.Debug("insert-chain", lager.Data{"parent-chain": parentChain, "table": table, "index": 1, "rule": rules.IPTablesRule{"-j", chainName}})
+		err = e.iptables.BulkInsert(table, parentChain, 1, rules.IPTablesRule{"-j", chainName})
+		if err != nil {
+			logger.Error("insert-chain", err)
+			delErr := e.deleteChain(logger, LiveChain{Table: table, Name: chainName}, "")
+			if delErr != nil {
+				logger.Error("cleanup-failed-insert", delErr)
+			}
+			return fmt.Errorf("inserting chain: %s", err)
 		}
-		return fmt.Errorf("inserting chain: %s", err)
 	}
 
 	logger.Debug("bulk-append", lager.Data{"chain": chainName, "table": table, "rules": rulespec})
@@ -304,8 +339,22 @@ func (e *Enforcer) replaceChainRules(logger lager.Logger, c Chain, rulesSpec []r
 	logger.Debug("replace-chain", lager.Data{"chain": c.Name, "table": c.Table, "rulesSpec": rulesSpec})
 
 	candidateName := e.candidateChainName(c.Name)
-	originalChainJumpExists, _ := e.iptables.Exists(c.Table, c.ParentChain, rules.IPTablesRule{"-j", c.Name})
-	candidateChainJumpExists, _ := e.iptables.Exists(c.Table, c.ParentChain, rules.IPTablesRule{"-j", candidateName})
+	originalChainJumpExists, err := e.iptables.Exists(c.Table, c.ParentChain, rules.IPTablesRule{"-j", c.Name})
+	if err != nil {
+		if parentReady, _ := e.iptables.ChainExists(c.Table, c.ParentChain); !parentReady {
+			logger.Info("parent-chain-not-ready", lager.Data{"parent": c.ParentChain, "error": err.Error()})
+			return &ParentChainNotReadyErr{ParentChain: c.ParentChain}
+		}
+		originalChainJumpExists = false
+	}
+	candidateChainJumpExists, err := e.iptables.Exists(c.Table, c.ParentChain, rules.IPTablesRule{"-j", candidateName})
+	if err != nil {
+		if parentReady, _ := e.iptables.ChainExists(c.Table, c.ParentChain); !parentReady {
+			logger.Info("parent-chain-not-ready", lager.Data{"parent": c.ParentChain, "error": err.Error()})
+			return &ParentChainNotReadyErr{ParentChain: c.ParentChain}
+		}
+		candidateChainJumpExists = false
+	}
 
 	logger.Debug("replace-chain-exists", lager.Data{"original": originalChainJumpExists, "candidate": candidateChainJumpExists})
 	if !originalChainJumpExists && !candidateChainJumpExists {
@@ -327,8 +376,7 @@ func (e *Enforcer) replaceChainRules(logger lager.Logger, c Chain, rulesSpec []r
 		}
 	}
 
-	err := e.enforce(logger, c.Table, c.ParentChain, candidateName, rulesSpec...)
-
+	err = e.enforce(logger, c.Table, c.ParentChain, candidateName, rulesSpec...)
 	if err != nil {
 		return err
 	}

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
@@ -245,6 +245,88 @@ var _ = Describe("Enforcer", func() {
 				})
 			})
 
+			Context("when Exists check for original chain returns an error", func() {
+				BeforeEach(func() {
+					iptables.ExistsStub = func(table string, parentChan string, ruleSpec rules.IPTablesRule) (bool, error) {
+						if ruleSpec[1] == "asg-handle" {
+							return false, errors.New("parent chain missing")
+						}
+						return false, nil
+					}
+				})
+
+				Context("when parent chain does not exist", func() {
+					BeforeEach(func() {
+						iptables.ChainExistsReturns(false, nil)
+					})
+
+					It("returns a ParentChainNotReadyErr", func() {
+						Expect(enforceErr).To(HaveOccurred())
+						_, ok := enforceErr.(*enforcer.ParentChainNotReadyErr)
+						Expect(ok).To(BeTrue())
+						Expect(enforceErr).To(MatchError("parent chain not ready: some-chain"))
+						Expect(iptables.NewChainCallCount()).To(Equal(0))
+					})
+				})
+
+				Context("when parent chain exists", func() {
+					BeforeEach(func() {
+						iptables.ChainExistsReturns(true, nil)
+					})
+
+					It("treats the jump as non-existent and proceeds to enforce", func() {
+						Expect(enforceErr).NotTo(HaveOccurred())
+						Expect(iptables.NewChainCallCount()).To(Equal(1))
+						table, chain := iptables.NewChainArgsForCall(0)
+						Expect(table).To(Equal("some-table"))
+						Expect(chain).To(Equal("asg-handle"))
+					})
+				})
+			})
+
+			Context("when Exists check for candidate chain returns an error", func() {
+				BeforeEach(func() {
+					iptables.ExistsStub = func(table string, parentChan string, ruleSpec rules.IPTablesRule) (bool, error) {
+						switch ruleSpec[1] {
+						case "asg-handle":
+							return true, nil
+						case "casg-handle":
+							return false, errors.New("parent chain missing")
+						default:
+							return false, errors.New("unexpected Exists call")
+						}
+					}
+				})
+
+				Context("when parent chain does not exist", func() {
+					BeforeEach(func() {
+						iptables.ChainExistsReturns(false, nil)
+					})
+
+					It("returns a ParentChainNotReadyErr", func() {
+						Expect(enforceErr).To(HaveOccurred())
+						_, ok := enforceErr.(*enforcer.ParentChainNotReadyErr)
+						Expect(ok).To(BeTrue())
+						Expect(enforceErr).To(MatchError("parent chain not ready: some-chain"))
+						Expect(iptables.NewChainCallCount()).To(Equal(0))
+					})
+				})
+
+				Context("when parent chain exists", func() {
+					BeforeEach(func() {
+						iptables.ChainExistsReturns(true, nil)
+					})
+
+					It("treats the candidate jump as non-existent and proceeds to enforce with candidate", func() {
+						Expect(enforceErr).NotTo(HaveOccurred())
+						Expect(iptables.NewChainCallCount()).To(Equal(1))
+						table, chain := iptables.NewChainArgsForCall(0)
+						Expect(table).To(Equal("some-table"))
+						Expect(chain).To(Equal("casg-handle"))
+					})
+				})
+			})
+
 			Context("when parent chain does not have candidate nor original chain", func() {
 				BeforeEach(func() {
 					iptables.ExistsStub = func(table string, parentChan string, ruleSpec rules.IPTablesRule) (bool, error) {
@@ -274,6 +356,47 @@ var _ = Describe("Enforcer", func() {
 				It("does not apply rename or clean up anything", func() {
 					Expect(iptables.RenameChainCallCount()).To(Equal(0))
 					Expect(iptables.ClearChainCallCount()).To(Equal(0))
+				})
+			})
+
+			Context("when NewChain returns 'chain already exists'", func() {
+				BeforeEach(func() {
+					iptables.ExistsStub = func(table string, parentChan string, ruleSpec rules.IPTablesRule) (bool, error) {
+						return false, nil
+					}
+					iptables.NewChainReturns(errors.New("chain already exists"))
+					iptables.ChainExistsReturns(true, nil)
+				})
+
+				It("flushes the existing chain and proceeds without inserting a duplicate jump rule", func() {
+					Expect(enforceErr).NotTo(HaveOccurred())
+					Expect(iptables.ClearChainCallCount()).To(BeNumerically(">=", 1))
+					table, chain := iptables.ClearChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("asg-handle"))
+					// BulkInsert must NOT be called when chain pre-existed to avoid duplicate jump rules
+					Expect(iptables.BulkInsertCallCount()).To(Equal(0))
+				})
+
+				Context("when ClearChain fails", func() {
+					BeforeEach(func() {
+						iptables.ClearChainReturns(errors.New("potato"))
+					})
+
+					It("returns an error", func() {
+						Expect(enforceErr).To(MatchError("clearing existing chain asg-handle: potato"))
+					})
+				})
+
+				Context("when ChainExists returns an error (fallback to error string matching)", func() {
+					BeforeEach(func() {
+						iptables.ChainExistsReturns(false, errors.New("iptables unavailable"))
+					})
+
+					It("flushes the existing chain via string-match fallback", func() {
+						Expect(enforceErr).NotTo(HaveOccurred())
+						Expect(iptables.ClearChainCallCount()).To(BeNumerically(">=", 1))
+					})
 				})
 			})
 

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner.go
@@ -90,6 +90,10 @@ func (p *VxlanPolicyPlanner) readFile(specifiedContainers ...string) ([]containe
 
 	var allContainers []container
 	for handle, containerMeta := range specifiedContainerMetadata {
+		if containerMeta.Deleting {
+			continue
+		}
+
 		ports, ok := containerMeta.Metadata["ports"].(string)
 		if !ok || ports == "" {
 			message := "Container metadata is missing key ports. CloudController version may be out of date or apps may need to be restaged."

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner_linux_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner_linux_test.go
@@ -1171,5 +1171,42 @@ var _ = Describe("Planner", func() {
 				})
 			})
 		})
+
+		Context("when a container is marked for deletion", func() {
+			BeforeEach(func() {
+				data["container-id-deleting"] = datastore.Container{
+					Handle: "container-id-deleting",
+					IP:     "10.255.1.99",
+					Metadata: map[string]interface{}{
+						"policy_group_id":    "some-app-guid",
+						"space_id":           "some-space-guid",
+						"ports":              "8080",
+						"container_workload": "app",
+					},
+					Deleting: true,
+				}
+				store.ReadAllReturns(data, nil)
+			})
+
+			It("skips the deleting container", func() {
+				rulesWithChains, err := policyPlanner.GetASGRulesAndChains()
+				Expect(err).NotTo(HaveOccurred())
+
+				for _, rwc := range rulesWithChains {
+					Expect(rwc.Chain.ParentChain).NotTo(ContainSubstring("container-id-deleting"))
+				}
+			})
+
+			It("still processes non-deleting containers", func() {
+				rulesWithChains, err := policyPlanner.GetASGRulesAndChains()
+				Expect(err).NotTo(HaveOccurred())
+
+				parentChains := []string{}
+				for _, rwc := range rulesWithChains {
+					parentChains = append(parentChains, rwc.Chain.ParentChain)
+				}
+				Expect(parentChains).To(ConsistOf("netout-container-id-1", "netout-container-id-2"))
+			})
+		})
 	})
 })


### PR DESCRIPTION


- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Errors encountered during CNI Add would result in failed container start, and containers being re-auctioned in diego. Errors encountered during CNI Del would result in error messages in the vxlan-policy-agent enforcer failing to create/modify chains for a container that the CNI is in the process of cleaning up. Any orphaned chains would get removed on the next poll cycle.

Individual fixes:

    - Reorder silk-cni cmdAdd to initialize iptables chains before writing to datastore
    - Add a new 'deleting' stage in CNI teardown to prevent races between polling and CNI teardowns.
    - Handle Exists errors in replaceChainRules to avoid partial failures
    - Add flush-and-reuse on 'Chain already exists' errors in enforcer
    - Fix CleanupOrphanedASGsChains map key bug
    - Prevent desiredChains from including empty chain names

    Made-with: claude-opus-4.6


Backward Compatibility
---------------
Breaking Change? no