### PR TITLE
Add tombstone mechanism to eliminate spurious VPA errors during container teardown     

### DIFF
--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
@@ -1893,7 +1893,7 @@ var _ = Describe("CniWrapperPlugin", func() {
 			})
 		})
 
-		Context("when the datastore delete fails", func() {
+		Context("when the datastore is corrupt (MarkForDelete and Delete both fail)", func() {
 			BeforeEach(func() {
 				file, err := os.OpenFile(datastorePath, os.O_RDWR, 0600)
 				Expect(err).ToNot(HaveOccurred())
@@ -1901,11 +1901,12 @@ var _ = Describe("CniWrapperPlugin", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("wraps and logs the error, and returns the success status code (for idempotency)", func() {
+			It("logs both store errors and returns success (DEL is idempotent)", func() {
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(session).Should(gexec.Exit(0))
 
+				Expect(string(session.Err.Contents())).To(ContainSubstring("store mark for delete: decoding file: invalid character"))
 				Expect(string(session.Err.Contents())).To(ContainSubstring("store delete: decoding file: invalid character"))
 			})
 

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
@@ -1943,6 +1943,31 @@ var _ = Describe("CniWrapperPlugin", func() {
 			})
 
 		})
+
+		Context("when the policy agent force-cleanup fails", func() {
+			BeforeEach(func() {
+				policyAgentServer.CleanupOrphanedASGsReturnCode = 500
+				policyAgentServer.CleanupOrphanedASGsReturnErrorMessage = "internal error"
+			})
+
+			// Stale Deleting entries block silk-daemon shutdown and IP allocation for new containers.
+			// Verify that store.Delete is always called, even when cleanup fails, by using defer.
+			It("still removes the container from the datastore even when cleanup fails", func() {
+				By("ensuring the container is in the datastore before DEL")
+				stateFileBytes, err := os.ReadFile(datastorePath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(stateFileBytes)).To(ContainSubstring(containerID))
+
+				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(session).Should(gexec.Exit(1))
+
+				By("verifying the container was removed from the datastore")
+				stateFileBytes, err = os.ReadFile(datastorePath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(stateFileBytes)).NotTo(ContainSubstring(containerID))
+			})
+		})
 	})
 
 })

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
@@ -433,9 +433,9 @@ func cmdDel(args *skel.CmdArgs) error {
 		CacheMutex:      new(sync.RWMutex),
 	}
 
-	container, err := store.Delete(args.ContainerID)
+	container, err := store.MarkForDelete(args.ContainerID)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "store delete: %s", err)
+		fmt.Fprintf(os.Stderr, "store mark for delete: %s", err)
 	}
 
 	enableIPv6 = enableIPv6 && container.IPv6 != ""
@@ -541,6 +541,12 @@ func cmdDel(args *skel.CmdArgs) error {
 	err = masquerader.DelIPMasq()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "removing IP masq: %s", err)
+	}
+
+	// Error is intentionally not returned: DEL must be idempotent, and iptables cleanup above
+	// already succeeded. A stale datastore entry is harmless at this point.
+	if _, err := store.Delete(args.ContainerID); err != nil {
+		fmt.Fprintf(os.Stderr, "store delete: %s", err)
 	}
 
 	resp, err := http.DefaultClient.Get(fmt.Sprintf("http://%s/force-orphaned-asgs-cleanup?container=%s", cfg.PolicyAgentForcePollAddress, args.ContainerID))

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/main.go
@@ -438,6 +438,14 @@ func cmdDel(args *skel.CmdArgs) error {
 		fmt.Fprintf(os.Stderr, "store mark for delete: %s", err)
 	}
 
+	// Ensure the container is always deleted from the store, even if cleanup fails.
+	// This prevents stale Deleting entries from blocking silk-daemon shutdown or IP allocation.
+	defer func() {
+		if _, delErr := store.Delete(args.ContainerID); delErr != nil {
+			fmt.Fprintf(os.Stderr, "store delete: %s", delErr)
+		}
+	}()
+
 	enableIPv6 = enableIPv6 && container.IPv6 != ""
 
 	pluginController, err := newPluginController(cfg, enableIPv6)

--- a/src/code.cloudfoundry.org/lib/datastore/datastore.go
+++ b/src/code.cloudfoundry.org/lib/datastore/datastore.go
@@ -25,6 +25,7 @@ type Datastore interface {
 	Add(handle, ip string, metadata map[string]interface{}, options ...Option) error
 	Delete(handle string) (Container, error)
 	ReadAll() (map[string]Container, error)
+	MarkForDelete(handle string) (Container, error)
 }
 
 type Container struct {
@@ -32,6 +33,7 @@ type Container struct {
 	IP       string                 `json:"ip"`
 	IPv6     string                 `json:"ipv6"`
 	Metadata map[string]interface{} `json:"metadata"`
+	Deleting bool                   `json:"deleting,omitempty"`
 }
 
 type Store struct {
@@ -188,6 +190,49 @@ func (c *Store) lookupFileOwnerUIDandGID() (int, int, error) {
 	}
 
 	return uid, gid, nil
+}
+
+func (c *Store) MarkForDelete(handle string) (Container, error) {
+	if handle == "" {
+		return Container{}, fmt.Errorf("invalid handle")
+	}
+
+	err := c.Locker.Lock()
+	if err != nil {
+		return Container{}, fmt.Errorf("lock: %s", err)
+	}
+	defer c.Locker.Unlock()
+
+	dataFile, err := os.OpenFile(c.DataFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		return Container{}, fmt.Errorf("open data file: %s", err)
+	}
+	defer dataFile.Close()
+
+	pool := make(map[string]*Container)
+	err = c.Serializer.DecodeAll(dataFile, &pool)
+	if err != nil {
+		return Container{}, fmt.Errorf("decoding file: %s", err)
+	}
+
+	existing, ok := pool[handle]
+	if !ok {
+		return Container{}, fmt.Errorf("entry does not exist")
+	}
+
+	existing.Deleting = true
+
+	err = c.Serializer.EncodeAndOverwrite(dataFile, pool)
+	if err != nil {
+		return *existing, fmt.Errorf("encode and overwrite: %s", err)
+	}
+
+	err = c.updateVersion()
+	if err != nil {
+		return *existing, err
+	}
+
+	return *existing, c.ensureFileOwnership()
 }
 
 func (c *Store) Delete(handle string) (Container, error) {

--- a/src/code.cloudfoundry.org/lib/datastore/datastore_test.go
+++ b/src/code.cloudfoundry.org/lib/datastore/datastore_test.go
@@ -410,6 +410,134 @@ var _ = Describe("Datastore", func() {
 
 	})
 
+	Context("when marking an entry for delete", func() {
+		BeforeEach(func() {
+			serializer.DecodeAllStub = func(_ io.ReadSeeker, a interface{}) error {
+				b := a.(*map[string]*datastore.Container)
+				*b = map[string]*datastore.Container{
+					handle: {
+						Handle:   handle,
+						IP:       ip,
+						Metadata: metadata,
+					},
+				}
+				return nil
+			}
+		})
+
+		It("marks the container as deleting and returns it", func() {
+			container, err := store.MarkForDelete(handle)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(container.Handle).To(Equal(handle))
+			Expect(container.IP).To(Equal(ip))
+			Expect(container.Metadata).To(Equal(metadata))
+			Expect(container.Deleting).To(BeTrue())
+
+			Expect(locker.LockCallCount()).To(Equal(1))
+			Expect(locker.UnlockCallCount()).To(Equal(1))
+			Expect(serializer.DecodeAllCallCount()).To(Equal(1))
+			Expect(serializer.EncodeAndOverwriteCallCount()).To(Equal(1))
+
+			_, actual := serializer.EncodeAndOverwriteArgsForCall(0)
+			pool := actual.(map[string]*datastore.Container)
+			Expect(pool[handle].Deleting).To(BeTrue())
+		})
+
+		It("updates the version", func() {
+			_, err := store.MarkForDelete(handle)
+			Expect(err).NotTo(HaveOccurred())
+
+			versionContents, err := os.ReadFile(versionFile.Name())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(versionContents)).To(Equal("2"))
+		})
+
+		Context("when handle is empty", func() {
+			It("returns an error", func() {
+				_, err := store.MarkForDelete("")
+				Expect(err).To(MatchError("invalid handle"))
+			})
+		})
+
+		Context("when handle does not exist", func() {
+			BeforeEach(func() {
+				serializer.DecodeAllStub = func(_ io.ReadSeeker, a interface{}) error {
+					b := a.(*map[string]*datastore.Container)
+					*b = map[string]*datastore.Container{}
+					return nil
+				}
+			})
+
+			It("returns an error", func() {
+				_, err := store.MarkForDelete("potato")
+				Expect(err).To(MatchError("entry does not exist"))
+			})
+		})
+
+		Context("when the locker fails to lock", func() {
+			BeforeEach(func() {
+				locker.LockReturns(errors.New("potato"))
+			})
+			It("wraps and returns the error", func() {
+				_, err := store.MarkForDelete(handle)
+				Expect(err).To(MatchError("lock: potato"))
+			})
+		})
+
+		Context("when the container is already marked for deletion", func() {
+			BeforeEach(func() {
+				serializer.DecodeAllStub = func(_ io.ReadSeeker, a interface{}) error {
+					b := a.(*map[string]*datastore.Container)
+					*b = map[string]*datastore.Container{
+						handle: {
+							Handle:   handle,
+							IP:       ip,
+							Metadata: metadata,
+							Deleting: true,
+						},
+					}
+					return nil
+				}
+			})
+
+			It("succeeds idempotently", func() {
+				container, err := store.MarkForDelete(handle)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(container.Deleting).To(BeTrue())
+			})
+		})
+
+		Context("when the data file fails to open", func() {
+			BeforeEach(func() {
+				store.DataFilePath = "/some/bad/path"
+			})
+			It("wraps and returns the error", func() {
+				_, err := store.MarkForDelete(handle)
+				Expect(err).To(MatchError("open data file: open /some/bad/path: no such file or directory"))
+			})
+		})
+
+		Context("when serializer fails to decode", func() {
+			BeforeEach(func() {
+				serializer.DecodeAllReturns(errors.New("potato"))
+			})
+			It("wraps and returns the error", func() {
+				_, err := store.MarkForDelete(handle)
+				Expect(err).To(MatchError("decoding file: potato"))
+			})
+		})
+
+		Context("when serializer fails to encode", func() {
+			BeforeEach(func() {
+				serializer.EncodeAndOverwriteReturns(errors.New("potato"))
+			})
+			It("wraps and returns the error", func() {
+				_, err := store.MarkForDelete(handle)
+				Expect(err).To(MatchError("encode and overwrite: potato"))
+			})
+		})
+	})
+
 	Context("when reading from datastore", func() {
 		It("deserializes the data from the file", func() {
 			data, err := store.ReadAll()

--- a/src/code.cloudfoundry.org/lib/fakes/datastore.go
+++ b/src/code.cloudfoundry.org/lib/fakes/datastore.go
@@ -35,6 +35,19 @@ type Datastore struct {
 		result1 datastore.Container
 		result2 error
 	}
+	MarkForDeleteStub        func(string) (datastore.Container, error)
+	markForDeleteMutex       sync.RWMutex
+	markForDeleteArgsForCall []struct {
+		arg1 string
+	}
+	markForDeleteReturns struct {
+		result1 datastore.Container
+		result2 error
+	}
+	markForDeleteReturnsOnCall map[int]struct {
+		result1 datastore.Container
+		result2 error
+	}
 	ReadAllStub        func() (map[string]datastore.Container, error)
 	readAllMutex       sync.RWMutex
 	readAllArgsForCall []struct {
@@ -179,6 +192,70 @@ func (fake *Datastore) DeleteReturnsOnCall(i int, result1 datastore.Container, r
 	}{result1, result2}
 }
 
+func (fake *Datastore) MarkForDelete(arg1 string) (datastore.Container, error) {
+	fake.markForDeleteMutex.Lock()
+	ret, specificReturn := fake.markForDeleteReturnsOnCall[len(fake.markForDeleteArgsForCall)]
+	fake.markForDeleteArgsForCall = append(fake.markForDeleteArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.MarkForDeleteStub
+	fakeReturns := fake.markForDeleteReturns
+	fake.recordInvocation("MarkForDelete", []interface{}{arg1})
+	fake.markForDeleteMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *Datastore) MarkForDeleteCallCount() int {
+	fake.markForDeleteMutex.RLock()
+	defer fake.markForDeleteMutex.RUnlock()
+	return len(fake.markForDeleteArgsForCall)
+}
+
+func (fake *Datastore) MarkForDeleteCalls(stub func(string) (datastore.Container, error)) {
+	fake.markForDeleteMutex.Lock()
+	defer fake.markForDeleteMutex.Unlock()
+	fake.MarkForDeleteStub = stub
+}
+
+func (fake *Datastore) MarkForDeleteArgsForCall(i int) string {
+	fake.markForDeleteMutex.RLock()
+	defer fake.markForDeleteMutex.RUnlock()
+	argsForCall := fake.markForDeleteArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *Datastore) MarkForDeleteReturns(result1 datastore.Container, result2 error) {
+	fake.markForDeleteMutex.Lock()
+	defer fake.markForDeleteMutex.Unlock()
+	fake.MarkForDeleteStub = nil
+	fake.markForDeleteReturns = struct {
+		result1 datastore.Container
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *Datastore) MarkForDeleteReturnsOnCall(i int, result1 datastore.Container, result2 error) {
+	fake.markForDeleteMutex.Lock()
+	defer fake.markForDeleteMutex.Unlock()
+	fake.MarkForDeleteStub = nil
+	if fake.markForDeleteReturnsOnCall == nil {
+		fake.markForDeleteReturnsOnCall = make(map[int]struct {
+			result1 datastore.Container
+			result2 error
+		})
+	}
+	fake.markForDeleteReturnsOnCall[i] = struct {
+		result1 datastore.Container
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *Datastore) ReadAll() (map[string]datastore.Container, error) {
 	fake.readAllMutex.Lock()
 	ret, specificReturn := fake.readAllReturnsOnCall[len(fake.readAllArgsForCall)]
@@ -238,12 +315,6 @@ func (fake *Datastore) ReadAllReturnsOnCall(i int, result1 map[string]datastore.
 func (fake *Datastore) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.addMutex.RLock()
-	defer fake.addMutex.RUnlock()
-	fake.deleteMutex.RLock()
-	defer fake.deleteMutex.RUnlock()
-	fake.readAllMutex.RLock()
-	defer fake.readAllMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/src/code.cloudfoundry.org/lib/fakes/locker.go
+++ b/src/code.cloudfoundry.org/lib/fakes/locker.go
@@ -139,10 +139,6 @@ func (fake *Locker) UnlockReturnsOnCall(i int, result1 error) {
 func (fake *Locker) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.lockMutex.RLock()
-	defer fake.lockMutex.RUnlock()
-	fake.unlockMutex.RLock()
-	defer fake.unlockMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner.go
@@ -90,6 +90,10 @@ func (p *VxlanPolicyPlanner) readFile(specifiedContainers ...string) ([]containe
 
 	var allContainers []container
 	for handle, containerMeta := range specifiedContainerMetadata {
+		if containerMeta.Deleting {
+			continue
+		}
+
 		ports, ok := containerMeta.Metadata["ports"].(string)
 		if !ok || ports == "" {
 			message := "Container metadata is missing key ports. CloudController version may be out of date or apps may need to be restaged."

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner_linux_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner_linux_test.go
@@ -1171,5 +1171,42 @@ var _ = Describe("Planner", func() {
 				})
 			})
 		})
+
+		Context("when a container is marked for deletion", func() {
+			BeforeEach(func() {
+				data["container-id-deleting"] = datastore.Container{
+					Handle: "container-id-deleting",
+					IP:     "10.255.1.99",
+					Metadata: map[string]interface{}{
+						"policy_group_id":    "some-app-guid",
+						"space_id":           "some-space-guid",
+						"ports":              "8080",
+						"container_workload": "app",
+					},
+					Deleting: true,
+				}
+				store.ReadAllReturns(data, nil)
+			})
+
+			It("skips the deleting container", func() {
+				rulesWithChains, err := policyPlanner.GetASGRulesAndChains()
+				Expect(err).NotTo(HaveOccurred())
+
+				for _, rwc := range rulesWithChains {
+					Expect(rwc.Chain.ParentChain).NotTo(ContainSubstring("container-id-deleting"))
+				}
+			})
+
+			It("still processes non-deleting containers", func() {
+				rulesWithChains, err := policyPlanner.GetASGRulesAndChains()
+				Expect(err).NotTo(HaveOccurred())
+
+				parentChains := []string{}
+				for _, rwc := range rulesWithChains {
+					parentChains = append(parentChains, rwc.Chain.ParentChain)
+				}
+				Expect(parentChains).To(ConsistOf("netout-container-id-1", "netout-container-id-2"))
+			})
+		})
 	})
 })


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
    During cmdDel, Garden destroys the container but VPA can race against the
    iptables cleanup window. Add a Deleting flag to the container datastore so
    the planner skips containers currently being torn down.
    
    - Add Deleting bool field to Container (omitempty for backward compat)
    - Add MarkForDelete to Datastore interface and Store implementation
    - Reorder cmdDel: MarkForDelete first, all iptables cleanup, then Delete
    - Planner skips containers with Deleting: true in GetASGRulesAndChains
    - Regenerate counterfeiter fakes for Datastore interface


Backward Compatibility
---------------
Breaking Change? no