### PR TITLE
Fix VPA ASG chain race conditions and map key bugs     

### DIFF
--- a/src/code.cloudfoundry.org/cni-teardown/integration/integration_test.go
+++ b/src/code.cloudfoundry.org/cni-teardown/integration/integration_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Teardown", func() {
 		BeforeEach(func() {
 			cmd := exec.Command("lsmod")
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			session.Wait(5 * time.Second)
 			if !strings.Contains(string(session.Out.Contents()), "ifb") {
 				Skip("Docker for Mac does not contain IFB kernel module")

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/integration/cni_wrapper_plugin_test.go
@@ -308,35 +308,35 @@ var _ = Describe("CniWrapperPlugin", func() {
 
 	AfterEach(func() {
 		By("checking that ip masquerade rule is removed")
-		Expect(AllIPTablesRules("nat")).ToNot(ContainElement("-A POSTROUTING -s 1.2.3.4/32 ! -d 10.255.30.0/24 ! -o some-device -j MASQUERADE"))
+		Expect(AllIPTablesRules("nat")).NotTo(ContainElement("-A POSTROUTING -s 1.2.3.4/32 ! -d 10.255.30.0/24 ! -o some-device -j MASQUERADE"))
 
 		By("checking that iptables netin rules are removed")
-		Expect(AllIPTablesRules("nat")).ToNot(ContainElement(`-N ` + netinChainName))
-		Expect(AllIPTablesRules("nat")).ToNot(ContainElement(`-A PREROUTING -j ` + netinChainName))
-		Expect(AllIPTablesRules("mangle")).ToNot(ContainElement(`-N ` + netinChainName))
-		Expect(AllIPTablesRules("mangle")).ToNot(ContainElement(`-A PREROUTING -j ` + netinChainName))
+		Expect(AllIPTablesRules("nat")).NotTo(ContainElement(`-N ` + netinChainName))
+		Expect(AllIPTablesRules("nat")).NotTo(ContainElement(`-A PREROUTING -j ` + netinChainName))
+		Expect(AllIPTablesRules("mangle")).NotTo(ContainElement(`-N ` + netinChainName))
+		Expect(AllIPTablesRules("mangle")).NotTo(ContainElement(`-A PREROUTING -j ` + netinChainName))
 
 		By("checking that all port forwarding rules were removed from the netin chain")
-		Expect(AllIPTablesRules("nat")).ToNot(ContainElement(ContainSubstring(netinChainName)))
-		Expect(AllIPTablesRules("nat")).ToNot(ContainElement(ContainSubstring(netinChainName)))
+		Expect(AllIPTablesRules("nat")).NotTo(ContainElement(ContainSubstring(netinChainName)))
+		Expect(AllIPTablesRules("nat")).NotTo(ContainElement(ContainSubstring(netinChainName)))
 
 		By("checking that all mark rules were removed from the netin chain")
-		Expect(AllIPTablesRules("mangle")).ToNot(ContainElement(ContainSubstring(netinChainName)))
+		Expect(AllIPTablesRules("mangle")).NotTo(ContainElement(ContainSubstring(netinChainName)))
 
 		By("checking that there are no more netout rules for this container")
-		Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(inputChainName)))
-		Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(netoutChainName)))
-		Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(netoutLoggingChainName)))
+		Expect(AllIPTablesRules("filter")).NotTo(ContainElement(ContainSubstring(inputChainName)))
+		Expect(AllIPTablesRules("filter")).NotTo(ContainElement(ContainSubstring(netoutChainName)))
+		Expect(AllIPTablesRules("filter")).NotTo(ContainElement(ContainSubstring(netoutLoggingChainName)))
 
 		By("checking that there are no more overlay rules for this container")
-		Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(overlayChainName)))
+		Expect(AllIPTablesRules("filter")).NotTo(ContainElement(ContainSubstring(overlayChainName)))
 
 		// IPv6
 		if testIPv6 {
 			By("checking that there are no more ipv6 netout rules for this container")
-			Expect(AllIP6TablesRules("filter")).ToNot(ContainElement(ContainSubstring(inputChainName)))
-			Expect(AllIP6TablesRules("filter")).ToNot(ContainElement(ContainSubstring(netoutChainName)))
-			Expect(AllIP6TablesRules("filter")).ToNot(ContainElement(ContainSubstring(netoutLoggingChainName)))
+			Expect(AllIP6TablesRules("filter")).NotTo(ContainElement(ContainSubstring(inputChainName)))
+			Expect(AllIP6TablesRules("filter")).NotTo(ContainElement(ContainSubstring(netoutChainName)))
+			Expect(AllIP6TablesRules("filter")).NotTo(ContainElement(ContainSubstring(netoutLoggingChainName)))
 		}
 
 		os.Remove(debugFileName)
@@ -514,7 +514,7 @@ var _ = Describe("CniWrapperPlugin", func() {
 
 		It("calls the policy agent asg updater", func() {
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Eventually(session).Should(gexec.Exit(0))
 			Expect(policyAgentServer.SyncASGEndpointCallCount).To(Equal(1))
 			Expect(policyAgentServer.SyncASGEndpointContainerRequested).To(Equal("some-container-id-that-is-long"))
@@ -555,9 +555,9 @@ var _ = Describe("CniWrapperPlugin", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(session).Should(gexec.Exit(1))
 
-				Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(inputChainName)))
-				Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(netoutChainName)))
-				Expect(AllIPTablesRules("nat")).ToNot(ContainElement(ContainSubstring(netinChainName)))
+				Expect(AllIPTablesRules("filter")).NotTo(ContainElement(ContainSubstring(inputChainName)))
+				Expect(AllIPTablesRules("filter")).NotTo(ContainElement(ContainSubstring(netoutChainName)))
+				Expect(AllIPTablesRules("nat")).NotTo(ContainElement(ContainSubstring(netinChainName)))
 			})
 
 			It("removes the container from the datastore after store.Add succeeds", func() {
@@ -575,7 +575,7 @@ var _ = Describe("CniWrapperPlugin", func() {
 			It("ignores and moves on, since dynamic asgs have been disabled", func() {
 				policyAgentServer.ASGReturnCode = 405
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Eventually(session).Should(gexec.Exit(0))
 				Expect(policyAgentServer.SyncASGEndpointCallCount).To(Equal(1))
 				Expect(policyAgentServer.SyncASGEndpointContainerRequested).To(Equal("some-container-id-that-is-long"))
@@ -586,11 +586,11 @@ var _ = Describe("CniWrapperPlugin", func() {
 			It("does not add additional iptables rules to the netout-chain", func() {
 				policyAgentServer.ASGReturnCode = 200
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Eventually(session).Should(gexec.Exit(0))
 				Expect(policyAgentServer.SyncASGEndpointCallCount).To(Equal(1))
 				Expect(policyAgentServer.SyncASGEndpointContainerRequested).To(Equal("some-container-id-that-is-long"))
-				Expect(strings.Join(AllIPTablesRules("filter"), "\n")).ToNot(ContainSubstring("11.11.11.11-22.22.22.22"))
+				Expect(strings.Join(AllIPTablesRules("filter"), "\n")).NotTo(ContainSubstring("11.11.11.11-22.22.22.22"))
 			})
 		})
 
@@ -598,7 +598,7 @@ var _ = Describe("CniWrapperPlugin", func() {
 			It("adds additional iptables rules to the netout-chain", func() {
 				policyAgentServer.ASGReturnCode = 405
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Eventually(session).Should(gexec.Exit(0))
 				Expect(policyAgentServer.SyncASGEndpointCallCount).To(Equal(1))
 				Expect(policyAgentServer.SyncASGEndpointContainerRequested).To(Equal("some-container-id-that-is-long"))
@@ -1224,10 +1224,10 @@ var _ = Describe("CniWrapperPlugin", func() {
 				Eventually(session).Should(gexec.Exit(1))
 
 				Expect(AllIPTablesRules("nat")).NotTo(ContainElement("-A POSTROUTING -s 1.2.3.4/32 ! -d 10.255.30.0/24 ! -o some-device -j MASQUERADE"))
-				Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(inputChainName)))
-				Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(netoutChainName)))
-				Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(netoutLoggingChainName)))
-				Expect(AllIPTablesRules("nat")).ToNot(ContainElement(ContainSubstring(netinChainName)))
+				Expect(AllIPTablesRules("filter")).NotTo(ContainElement(ContainSubstring(inputChainName)))
+				Expect(AllIPTablesRules("filter")).NotTo(ContainElement(ContainSubstring(netoutChainName)))
+				Expect(AllIPTablesRules("filter")).NotTo(ContainElement(ContainSubstring(netoutLoggingChainName)))
+				Expect(AllIPTablesRules("nat")).NotTo(ContainElement(ContainSubstring(netinChainName)))
 			})
 		})
 
@@ -1245,8 +1245,8 @@ var _ = Describe("CniWrapperPlugin", func() {
 
 				Expect(session.Out.Contents()).To(ContainSubstring("initialize net out: input rules: host tcp services: address invalid-host-port: missing port in address"))
 
-				Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(inputChainName)))
-				Expect(AllIPTablesRules("filter")).ToNot(ContainElement(ContainSubstring(netoutChainName)))
+				Expect(AllIPTablesRules("filter")).NotTo(ContainElement(ContainSubstring(inputChainName)))
+				Expect(AllIPTablesRules("filter")).NotTo(ContainElement(ContainSubstring(netoutChainName)))
 			})
 		})
 
@@ -1394,11 +1394,11 @@ var _ = Describe("CniWrapperPlugin", func() {
 				It("does not add additional iptables rules to the netout-chain", func() {
 					policyAgentServer.ASGReturnCode = 200
 					session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 					Eventually(session).Should(gexec.Exit(0))
 					Expect(policyAgentServer.SyncASGEndpointCallCount).To(Equal(1))
 					Expect(policyAgentServer.SyncASGEndpointContainerRequested).To(Equal("some-container-id-that-is-long"))
-					Expect(strings.Join(AllIP6TablesRules("filter"), "\n")).ToNot(ContainSubstring("2333:3::3-2444:4::4"))
+					Expect(strings.Join(AllIP6TablesRules("filter"), "\n")).NotTo(ContainSubstring("2333:3::3-2444:4::4"))
 				})
 			})
 
@@ -1406,7 +1406,7 @@ var _ = Describe("CniWrapperPlugin", func() {
 				It("adds additional iptables rules to the netout-chain", func() {
 					policyAgentServer.ASGReturnCode = 405
 					session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 					Eventually(session).Should(gexec.Exit(0))
 					Expect(policyAgentServer.SyncASGEndpointCallCount).To(Equal(1))
 					Expect(policyAgentServer.SyncASGEndpointContainerRequested).To(Equal("some-container-id-that-is-long"))
@@ -1525,9 +1525,9 @@ var _ = Describe("CniWrapperPlugin", func() {
 					Eventually(session).Should(gexec.Exit(0))
 
 					By("checking that there are no rules for this container")
-					Expect(AllIP6TablesRules("filter")).ToNot(ContainElement(ContainSubstring(inputChainName)))
-					Expect(AllIP6TablesRules("filter")).ToNot(ContainElement(ContainSubstring(netoutChainName)))
-					Expect(AllIP6TablesRules("filter")).ToNot(ContainElement(ContainSubstring(netoutLoggingChainName)))
+					Expect(AllIP6TablesRules("filter")).NotTo(ContainElement(ContainSubstring(inputChainName)))
+					Expect(AllIP6TablesRules("filter")).NotTo(ContainElement(ContainSubstring(netoutChainName)))
+					Expect(AllIP6TablesRules("filter")).NotTo(ContainElement(ContainSubstring(netoutLoggingChainName)))
 				})
 			})
 
@@ -1843,7 +1843,7 @@ var _ = Describe("CniWrapperPlugin", func() {
 
 		It("calls the policy agent orphaned asg cleanup", func() {
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Eventually(session).Should(gexec.Exit(0))
 			Expect(policyAgentServer.CleanupOrphanedASGsEndpointCallCount).To(Equal(1))
 			Expect(policyAgentServer.CleanupOrphanedASGsEndpointContainerRequested).To(Equal(containerID))
@@ -1853,7 +1853,7 @@ var _ = Describe("CniWrapperPlugin", func() {
 			It("ignores and moves on, since dynamic asgs have been disabled", func() {
 				policyAgentServer.CleanupOrphanedASGsReturnCode = 405
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Eventually(session).Should(gexec.Exit(0))
 				Expect(policyAgentServer.CleanupOrphanedASGsEndpointCallCount).To(Equal(1))
 			})
@@ -1896,9 +1896,9 @@ var _ = Describe("CniWrapperPlugin", func() {
 		Context("when the datastore is corrupt (MarkForDelete and Delete both fail)", func() {
 			BeforeEach(func() {
 				file, err := os.OpenFile(datastorePath, os.O_RDWR, 0600)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				_, err = io.WriteString(file, "}{blarg")
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("logs both store errors and returns success (DEL is idempotent)", func() {
@@ -2031,30 +2031,30 @@ func (a *mockPolicyAgentServer) stop() error {
 
 func createDummyInterface(interfaceName, ipAddress string) {
 	err := netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: interfaceName}})
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	link, err := netlink.LinkByName(interfaceName)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	addr, err := netlink.ParseAddr(ipAddress + "/32")
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = netlink.AddrAdd(link, addr)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 }
 
 func removeDummyInterface(interfaceName, ipAddress string) {
 	link, err := netlink.LinkByName(interfaceName)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	addr, err := netlink.ParseAddr(ipAddress + "/32")
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = netlink.AddrDel(link, addr)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = netlink.LinkDel(link)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 }
 
 func intPtr(val int) *int {

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/masquerader_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/masquerader_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Masquerader", func() {
 						thisShouldPanic := func() {
 							fakeSilkDaemonServer.GetHandler(1)
 						}
-						Expect(thisShouldNotPanic).ToNot(Panic())
+						Expect(thisShouldNotPanic).NotTo(Panic())
 						Expect(thisShouldPanic).To(Panic())
 					})
 				})
@@ -182,7 +182,7 @@ var _ = Describe("Masquerader", func() {
 			It("makes a masq rule with the customNoMasqueradeCIDRRange", func() {
 				expectedRule := rules.IPTablesRule{"--source", containerIP, "!", "-o", vtepName, "!", "--destination", customNoMasqueradeCIDRRange, "--jump", "MASQUERADE"}
 				err := masquerader.AddIPMasq()
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(fakeIPTables.BulkAppendCallCount()).To(Equal(1))
 				table, chain, rules := fakeIPTables.BulkAppendArgsForCall(0)
 				Expect(table).To(Equal("nat"))
@@ -306,7 +306,7 @@ var _ = Describe("Masquerader", func() {
 			It("makes a masq rule with the customNoMasqueradeCIDRRange", func() {
 				expectedRule := rules.IPTablesRule{"--source", containerIP, "!", "-o", vtepName, "!", "--destination", customNoMasqueradeCIDRRange, "--jump", "MASQUERADE"}
 				err := masquerader.DelIPMasq()
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(fakeIPTables.DeleteCallCount()).To(Equal(1))
 				table, chain, rule := fakeIPTables.DeleteArgsForCall(0)
 				Expect(table).To(Equal("nat"))

--- a/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/security_group_rule_test.go
+++ b/src/code.cloudfoundry.org/cni-wrapper-plugin/netrules/security_group_rule_test.go
@@ -111,7 +111,7 @@ var _ = Describe("SecurityGroupRule", func() {
 				Code:        3,
 			}
 			rule, err := netrules.NewRuleFromSecurityGroupRule(securityGroupRule)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(fmt.Sprintf("%d/%d", rule.ICMPInfo().Type, rule.ICMPInfo().Code)).To(Equal("0/3"))
 		})
 		It("parses -1 as all types", func() {
@@ -121,7 +121,7 @@ var _ = Describe("SecurityGroupRule", func() {
 				Code:        3,
 			}
 			rule, err := netrules.NewRuleFromSecurityGroupRule(securityGroupRule)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(fmt.Sprintf("%d/%d", rule.ICMPInfo().Type, rule.ICMPInfo().Code)).To(Equal("255/3"))
 		})
 		It("parses -1 as all codes", func() {
@@ -131,7 +131,7 @@ var _ = Describe("SecurityGroupRule", func() {
 				Code:        -1,
 			}
 			rule, err := netrules.NewRuleFromSecurityGroupRule(securityGroupRule)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(fmt.Sprintf("%d/%d", rule.ICMPInfo().Type, rule.ICMPInfo().Code)).To(Equal("0/255"))
 		})
 	})

--- a/src/code.cloudfoundry.org/iptables-logger/integration/integration_test.go
+++ b/src/code.cloudfoundry.org/iptables-logger/integration/integration_test.go
@@ -140,13 +140,13 @@ var _ = Describe("Integration", func() {
 		fakeMetron = metrics.NewFakeMetron(suiteConfig.ParallelProcess)
 
 		kernelLogFile, err = os.CreateTemp("", "")
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		containerMetadataFile, err = os.CreateTemp("", "")
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		outputDir, err := os.MkdirTemp("", "")
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		outputFile = filepath.Join(outputDir, "iptables.log")
 		conf = config.Config{
@@ -258,7 +258,7 @@ var _ = Describe("Integration", func() {
 			var err error
 			Expect(os.Rename(kernelLogFile.Name(), filepath.Join(os.TempDir(), "kernel.log.backup"))).To(Succeed())
 			kernelLogFile, err = os.Create(kernelLogFilename)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			By("logging denied egress packets")
 			go AddToKernelLog(EGRESS_DENIED_KERNEL_LOG, kernelLogFile)
@@ -279,7 +279,7 @@ var _ = Describe("Integration", func() {
 			var err error
 			Expect(os.Remove(kernelLogFile.Name())).To(Succeed())
 			kernelLogFile, err = os.Create(kernelLogFilename)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			By("logging denied egress packets")
 			go AddToKernelLog(EGRESS_DENIED_KERNEL_LOG, kernelLogFile)
@@ -298,7 +298,7 @@ var _ = Describe("Integration", func() {
 			By("rotate destination file")
 			Expect(os.Rename(outputFile, filepath.Join(os.TempDir(), "destination.log.backup"))).To(Succeed())
 			_, err := os.Create(outputFile)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			By("waiting for the rotatable sink to pickup the new file")
 			time.Sleep(2 * time.Second)

--- a/src/code.cloudfoundry.org/iptables-logger/rotatablesink/rotatewatcher_test.go
+++ b/src/code.cloudfoundry.org/iptables-logger/rotatablesink/rotatewatcher_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Rotatewatcher", func() {
 					fakeTestWriterFactory = NewTestWriterFactory(fileToWatch, nil)
 					var err error
 					rotatableSink, err = rotatablesink.NewRotatableSink(fileToWatchName, lager.DEBUG, fakeTestWriterFactory, fakeDestinationFileInfo, fakeLogger)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 				})
 
 				It("returns a sensible error and does not update the file sink", func() {
@@ -249,15 +249,15 @@ var _ = Describe("Rotatewatcher", func() {
 
 			It("should return true when file exists", func() {
 				fileExists, err := defaultDestinationFileInfo.FileExists(fileToWatchName)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(fileExists).To(BeTrue())
 			})
 
 			Context("when the file does not exist", func() {
 				It("returns false", func() {
 					fileExists, err := defaultDestinationFileInfo.FileExists(fmt.Sprintf("%s_does_not_exist", fileToWatchName))
-					Expect(err).ToNot(HaveOccurred())
-					Expect(fileExists).ToNot(BeTrue())
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fileExists).NotTo(BeTrue())
 				})
 			})
 
@@ -272,7 +272,7 @@ var _ = Describe("Rotatewatcher", func() {
 		Describe("FileInode", func() {
 			It("should return the file to watch inode", func() {
 				inode, err := defaultDestinationFileInfo.FileInode(fileToWatchName)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(inode).To(BeNumerically(">", 0))
 			})
 

--- a/src/code.cloudfoundry.org/lib/datastore/datastore_test.go
+++ b/src/code.cloudfoundry.org/lib/datastore/datastore_test.go
@@ -332,7 +332,7 @@ var _ = Describe("Datastore", func() {
 			Expect(file.(*os.File).Name()).To(Equal(dataFile.Name()))
 
 			_, actual := serializer.EncodeAndOverwriteArgsForCall(0)
-			Expect(actual).ToNot(HaveKey(handle))
+			Expect(actual).NotTo(HaveKey(handle))
 		})
 
 		It("updates the version", func() {

--- a/src/code.cloudfoundry.org/lib/multiple-cidr-network/multiple_cidr_network_test.go
+++ b/src/code.cloudfoundry.org/lib/multiple-cidr-network/multiple_cidr_network_test.go
@@ -39,7 +39,7 @@ var _ = Describe("MultipleCIDRNetwork", func() {
 				cidr2 := "10.50.50.0/24" // 10.50.50.0 - 10.50.50.255
 				cidr3 := "10.255.0.0/16" // 10.255.0.0 - 10.255.255.255
 				network, err = NewMultipleCIDRNetwork([]string{cidr1, cidr2, cidr3})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("creates an array of net.IPNet's", func() {
@@ -58,7 +58,7 @@ var _ = Describe("MultipleCIDRNetwork", func() {
 		DescribeTable("it returns the size of the smallest mask",
 			func(cidrs []string, expectedSize int) {
 				n, err := NewMultipleCIDRNetwork(cidrs)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(n.SmallestMask).To(Equal(expectedSize))
 			},
 			Entry("When the cidrs have different masks", []string{"10.255.0.0/16", "10.255.0.0/24", "10.255.0.0/32"}, 32),
@@ -70,14 +70,14 @@ var _ = Describe("MultipleCIDRNetwork", func() {
 		BeforeEach(func() {
 			var err error
 			network, err = NewMultipleCIDRNetwork([]string{validCIDR1, validCIDR2, validCIDR3})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		Context("when the IP is contained in a network", func() {
 			DescribeTable("it returns true",
 				func(check string) {
 					ip := net.ParseIP(check)
-					Expect(ip).ToNot(BeNil())
+					Expect(ip).NotTo(BeNil())
 
 					found := network.Contains(ip)
 					Expect(found).To(BeTrue())
@@ -92,7 +92,7 @@ var _ = Describe("MultipleCIDRNetwork", func() {
 			DescribeTable("it returns false",
 				func(check string) {
 					ip := net.ParseIP(check)
-					Expect(ip).ToNot(BeNil())
+					Expect(ip).NotTo(BeNil())
 
 					found := network.Contains(ip)
 					Expect(found).To(BeFalse())
@@ -108,17 +108,17 @@ var _ = Describe("MultipleCIDRNetwork", func() {
 		BeforeEach(func() {
 			var err error
 			network, err = NewMultipleCIDRNetwork([]string{validCIDR1, validCIDR2, validCIDR3})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		Context("when the IP is contained in a network", func() {
 			DescribeTable("it returns the single network it is in",
 				func(check string, firstIPOfExpectedNetwork net.IP) {
 					ip := net.ParseIP(check)
-					Expect(ip).ToNot(BeNil())
+					Expect(ip).NotTo(BeNil())
 
 					n := network.WhichNetworkContains(ip)
-					Expect(n).ToNot(BeNil())
+					Expect(n).NotTo(BeNil())
 					Expect(n.IP).To(Equal(firstIPOfExpectedNetwork))
 
 				},
@@ -132,7 +132,7 @@ var _ = Describe("MultipleCIDRNetwork", func() {
 			DescribeTable("it returns nil",
 				func(check string) {
 					ip := net.ParseIP(check)
-					Expect(ip).ToNot(BeNil())
+					Expect(ip).NotTo(BeNil())
 
 					network := network.WhichNetworkContains(ip)
 					Expect(network).To(BeNil())

--- a/src/code.cloudfoundry.org/lib/rules/locked_iptables_test.go
+++ b/src/code.cloudfoundry.org/lib/rules/locked_iptables_test.go
@@ -217,7 +217,7 @@ var _ = Describe("LockedIptables", func() {
 		})
 		It("locks and passes the correct parameters to iptables", func() {
 			err := lockedIPT.DeleteAfterRuleNum("some-table", "some-chain", 2)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(lock.LockCallCount()).To(Equal(1))
 			Expect(lock.UnlockCallCount()).To(Equal(1))
@@ -302,7 +302,7 @@ var _ = Describe("LockedIptables", func() {
 
 		It("locks and passes the correct parameters to iptables", func() {
 			err := lockedIPT.DeleteAfterRuleNumKeepReject("some-table", "some-chain", 2)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(lock.LockCallCount()).To(Equal(1))
 			Expect(lock.UnlockCallCount()).To(Equal(1))
@@ -400,7 +400,7 @@ var _ = Describe("LockedIptables", func() {
 
 			It("locks and passes the correct parameters to iptables", func() {
 				err := lockedIPT.DeleteAfterRuleNumKeepReject("some-table", "some-chain", 2)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(lock.LockCallCount()).To(Equal(1))
 				Expect(lock.UnlockCallCount()).To(Equal(1))
@@ -493,7 +493,7 @@ var _ = Describe("LockedIptables", func() {
 			Expect(ipt.ListChainsCallCount()).To(Equal(1))
 			table := ipt.ListChainsArgsForCall(0)
 			Expect(table).To(Equal("some-table"))
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 		Context("when locking fails", func() {
 			BeforeEach(func() {

--- a/src/code.cloudfoundry.org/lib/rules/rules_test.go
+++ b/src/code.cloudfoundry.org/lib/rules/rules_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Rules", func() {
 	Describe("NewIPTablesRuleFromIPTablesLine", func() {
 		It("parses rules properly", func() {
 			rule, err := rules.NewIPTablesRuleFromIPTablesLine(`-D netout--ee8fd40b-55f6-4522-5 -m limit --limit 1/sec --limit-burst 1 -j LOG --log-prefix "DENY_ee8fd40b-55f6-4522-51d9 "`)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(rule).To(Equal(rules.IPTablesRule{
 				"-D", "netout--ee8fd40b-55f6-4522-5", "-m", "limit",
 				"--limit", "1/sec", "--limit-burst", "1", "-j", "LOG",

--- a/src/code.cloudfoundry.org/silk-daemon-shutdown/integration/integration_test.go
+++ b/src/code.cloudfoundry.org/silk-daemon-shutdown/integration/integration_test.go
@@ -130,10 +130,10 @@ var _ = Describe("Teardown", func() {
 			Eventually(session, DEFAULT_TIMEOUT).Should(gexec.Exit(0))
 
 			rules := AllIPTablesRules("filter")
-			Expect(rules).ToNot(ContainElement(ContainSubstring("-N istio-ingress")))
-			Expect(rules).ToNot(ContainElement(ContainSubstring("-A OUTPUT -j istio-ingress")))
-			Expect(rules).ToNot(ContainElement(ContainSubstring(fmt.Sprintf("-A istio-ingress -o silk-vtep -j MARK --set-xmark 0x%s/0xffffffff", tag))))
-			Expect(rules).ToNot(ContainElement(ContainSubstring("-A istio-ingress -o silk-vtep -j ACCEPT")))
+			Expect(rules).NotTo(ContainElement(ContainSubstring("-N istio-ingress")))
+			Expect(rules).NotTo(ContainElement(ContainSubstring("-A OUTPUT -j istio-ingress")))
+			Expect(rules).NotTo(ContainElement(ContainSubstring(fmt.Sprintf("-A istio-ingress -o silk-vtep -j MARK --set-xmark 0x%s/0xffffffff", tag))))
+			Expect(rules).NotTo(ContainElement(ContainSubstring("-A istio-ingress -o silk-vtep -j ACCEPT")))
 		})
 	})
 

--- a/src/code.cloudfoundry.org/silk-datastore-syncer/integration/integration_test.go
+++ b/src/code.cloudfoundry.org/silk-datastore-syncer/integration/integration_test.go
@@ -28,13 +28,13 @@ var _ = Describe("Datastore syncer", func() {
 	BeforeEach(func() {
 		var err error
 		silkFile, err = os.CreateTemp(GinkgoT().TempDir(), "silkfile")
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 		u, err := user.Current()
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 		groups, err := u.GroupIds()
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 		group, err := user.LookupGroupId(groups[0])
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 		store = &datastore.Store{
 			Serializer: &serial.Serial{},
 			Locker: &filelock.Locker{
@@ -56,7 +56,7 @@ var _ = Describe("Datastore syncer", func() {
 
 		cmd := exec.Command(binaryPath, "-n", "1", "--gardenNetwork", "tcp", "--gardenAddr", fakeGarden.Addr(), "--silkFile", silkFile.Name(), "--silkFileOwner", u.Name, "--silkFileGroup", group.Name)
 		session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -68,7 +68,7 @@ var _ = Describe("Datastore syncer", func() {
 
 	It("updates the log config", func() {
 		err := store.Add("test", "127.0.0.1", map[string]interface{}{"log_config": `{"guid":"test","index":0,"source_name":"test","tags":{"test":"value"}}`})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 		containers := struct {
 			Handles []string
 		}{
@@ -80,7 +80,7 @@ var _ = Describe("Datastore syncer", func() {
 
 		Eventually(func() datastore.Container {
 			readContainers, err := store.ReadAll()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			return readContainers["test"]
 		}, 10).Should(Equal(datastore.Container{
 			Handle:   "test",
@@ -91,7 +91,7 @@ var _ = Describe("Datastore syncer", func() {
 
 	It("updates the log config when the container has IPv6 address", func() {
 		err := store.Add("test", "127.0.0.1", map[string]interface{}{"log_config": `{"guid":"test","index":0,"source_name":"test","tags":{"test":"value"}}`}, datastore.WithIPv6("2600::1"))
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 		containers := struct {
 			Handles []string
 		}{
@@ -103,7 +103,7 @@ var _ = Describe("Datastore syncer", func() {
 
 		Eventually(func() datastore.Container {
 			readContainers, err := store.ReadAll()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			return readContainers["test"]
 		}, 10).Should(Equal(datastore.Container{
 			Handle:   "test",
@@ -115,7 +115,7 @@ var _ = Describe("Datastore syncer", func() {
 
 	It("doesn't add new entries, or remove old entries in the log config", func() {
 		err := store.Add("test", "127.0.0.1", map[string]interface{}{"log_config": `{"guid":"test","index":0,"source_name":"test","tags":{"test":"value"}}`})
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 		containers := struct {
 			Handles []string
 		}{
@@ -128,7 +128,7 @@ var _ = Describe("Datastore syncer", func() {
 		Consistently(session, 3).ShouldNot(gexec.Exit())
 		Eventually(func() datastore.Container {
 			readContainers, err := store.ReadAll()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			return readContainers["test"]
 		}, 10).Should(Equal(datastore.Container{
 			Handle:   "test",
@@ -153,7 +153,7 @@ var _ = Describe("Datastore syncer", func() {
 	})
 	It("doesn't crash when container has no metadata", func() {
 		err := store.Add("test", "127.0.0.1", nil)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 		containers := struct {
 			Handles []string
 		}{
@@ -165,7 +165,7 @@ var _ = Describe("Datastore syncer", func() {
 
 		Eventually(func() datastore.Container {
 			readContainers, err := store.ReadAll()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			return readContainers["test"]
 		}, 10).Should(Equal(datastore.Container{
 			Handle:   "test",

--- a/src/code.cloudfoundry.org/silk/cni/integration/error_cases_test.go
+++ b/src/code.cloudfoundry.org/silk/cni/integration/error_cases_test.go
@@ -94,7 +94,7 @@ var _ = Describe("errors", func() {
 
 				cniError := &cniDatabaseError{}
 				err := json.Unmarshal(session.Out.Contents(), cniError)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(cniError.Code).To(Equal(100))
 				Expect(cniError.Msg).To(Equal("discover network info"))

--- a/src/code.cloudfoundry.org/silk/controller/leaser/cidrpool_test.go
+++ b/src/code.cloudfoundry.org/silk/controller/leaser/cidrpool_test.go
@@ -153,7 +153,7 @@ var _ = Describe("CIDRPool", func() {
 			for i := 1; i <= expectedNumBlockLeases; i++ {
 				By("testing that there are still leases left")
 				lease := cidrPool.GetAvailableBlock(taken)
-				Expect(lease).ToNot(Equal(""))
+				Expect(lease).NotTo(Equal(""))
 
 				By("testing that the lease is a valid subnet")
 				leaseIP, leaseSubnet, err := net.ParseCIDR(lease)
@@ -187,7 +187,7 @@ var _ = Describe("CIDRPool", func() {
 					if index1 == index2 {
 						continue
 					}
-					Expect(i).ToNot(Equal(j))
+					Expect(i).NotTo(Equal(j))
 				}
 			}
 		},
@@ -213,7 +213,7 @@ var _ = Describe("CIDRPool", func() {
 			for i := 1; i <= expectedNumSingleIPLeases; i++ {
 				By("testing that there are still leases left")
 				lease := cidrPool.GetAvailableSingleIP(taken)
-				Expect(lease).ToNot(Equal(""))
+				Expect(lease).NotTo(Equal(""))
 
 				By("testing that the lease is a valid subnet")
 				leaseIP, leaseSubnet, err := net.ParseCIDR(lease)
@@ -247,7 +247,7 @@ var _ = Describe("CIDRPool", func() {
 					if index1 == index2 {
 						continue
 					}
-					Expect(i).ToNot(Equal(j))
+					Expect(i).NotTo(Equal(j))
 				}
 			}
 		},

--- a/src/code.cloudfoundry.org/silk/daemon/vtep/converger_test.go
+++ b/src/code.cloudfoundry.org/silk/daemon/vtep/converger_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Converger", func() {
 			fakeNetlink = &fakes.NetlinkAdapter{}
 
 			overlayNetworks, err = mcn.NewMultipleCIDRNetwork([]string{"10.255.0.0/16", "10.250.0.0/16"})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			logger = lagertest.NewTestLogger("test")
 			localVTEP = net.Interface{

--- a/src/code.cloudfoundry.org/silk/lib/datastore/datastore_test.go
+++ b/src/code.cloudfoundry.org/silk/lib/datastore/datastore_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Datastore", func() {
 			Expect(file).To(Equal(lockedFile))
 
 			_, actual := serializer.EncodeAndOverwriteArgsForCall(0)
-			Expect(actual).ToNot(HaveKey(handle))
+			Expect(actual).NotTo(HaveKey(handle))
 		})
 
 		It("is idempotent", func() {

--- a/src/code.cloudfoundry.org/silk/lib/hwaddr/hwaddr_test.go
+++ b/src/code.cloudfoundry.org/silk/lib/hwaddr/hwaddr_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Hwaddr", func() {
 		)
 		It("returns a MAC addr with the given prefix, based on the provided IP", func() {
 			addr, err := hwaddr.GenerateHardwareAddr4(ipV4Addr, validPrefix)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			// IP variables are []byte types, with len 16. IPv4 addrs only use the last 4 bytes for addr info
 			Expect(addr.String()).To(Equal(fmt.Sprintf("aa:bb:%02x:%02x:%02x:%02x", ipV4Addr[12], ipV4Addr[13], ipV4Addr[14], ipV4Addr[15])))
 		})

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/pre-start/main_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/cmd/pre-start/main_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Pre-Start", func() {
 
 	It("clears the iptables rules for filter/nat tables", func() {
 		err := main.PreStart(fakeIpTables)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 		Expect(fakeIpTables.FlushAndRestoreCallCount()).To(Equal(1))
 		Expect(fakeIpTables.FlushAndRestoreArgsForCall(0)).To(Equal("*filter\n:INPUT ACCEPT [0:0]\n:FORWARD ACCEPT [0:0]\n:OUTPUT ACCEPT [0:0]\nCOMMIT\n*nat\n:PREROUTING ACCEPT [0:0]\n:INPUT ACCEPT [0:0]\n:OUTPUT ACCEPT [0:0]\n:POSTROUTING ACCEPT [0:0]\nCOMMIT\n"))
 	})
@@ -52,7 +52,7 @@ var _ = Describe("Pre-Start", func() {
 			It("retries and then clears the iptables rules", func() {
 				err := main.PreStart(fakeIpTables)
 				Expect(fakeIpTables.FlushAndRestoreCallCount()).To(Equal(4))
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger.go
@@ -260,16 +260,23 @@ func (m *SinglePollCycle) SyncASGsForContainers(containers ...string) error {
 				})
 				chain, err := m.enforcer.EnforceRulesAndChain(ruleset)
 				if err != nil {
+					if _, ok := err.(*enforcer.ParentChainNotReadyErr); ok {
+						continue
+					}
 					if _, ok := err.(*enforcer.CleanupErr); ok {
 						m.updateRuleSet(chainKey, chain, ruleset)
 					}
-
 					errors = multierror.Append(errors, fmt.Errorf("enforce-asg: %s", err))
 				} else {
 					m.updateRuleSet(chainKey, chain, ruleset)
 				}
 			}
-			desiredChains = append(desiredChains, enforcer.LiveChain{Table: ruleset.Chain.Table, Name: m.asgChainToContainer[chainKey]})
+			// chainName is empty when EnforceRulesAndChain returned ParentChainNotReadyErr and
+			// we continued without calling updateRuleSet — skip those to avoid adding empty
+			// chain names to the desired set.
+			if chainName := m.asgChainToContainer[chainKey]; chainName != "" {
+				desiredChains = append(desiredChains, enforcer.LiveChain{Table: ruleset.Chain.Table, Name: chainName})
+			}
 		}
 		enforceDuration += time.Since(enforceStartTime)
 	}
@@ -308,8 +315,13 @@ func (m *SinglePollCycle) CleanupOrphanedASGsChains(containerHandle string) erro
 		return fmt.Errorf("clean-up-orphaned-asg-chains: %s", err)
 	}
 
-	delete(m.asgChainToContainer, chain)
-	delete(m.asgRuleSets, chain)
+	for key, chainName := range m.asgChainToContainer {
+		if chainName == chain.Name {
+			delete(m.asgChainToContainer, key)
+			delete(m.asgRuleSets, key)
+			break
+		}
+	}
 	return nil
 }
 

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger_test.go
@@ -685,12 +685,42 @@ var _ = Describe("Single Poll Cycle", func() {
 			})
 		})
 
+		Context("when the enforcer returns ParentChainNotReadyErr", func() {
+			BeforeEach(func() {
+				i := 0
+				fakeEnforcer.EnforceRulesAndChainStub = func(e enforcer.RulesWithChain) (string, error) {
+					i++
+					if i == 2 {
+						return "", &enforcer.ParentChainNotReadyErr{ParentChain: "netout-2"}
+					}
+					return e.Chain.Name, nil
+				}
+			})
+
+			It("skips that container without accumulating an error", func() {
+				err := p.DoASGCycle()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("still enforces other containers", func() {
+				err := p.DoASGCycle()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fakeEnforcer.EnforceRulesAndChainCallCount()).To(Equal(3))
+			})
+
+			It("does not include the skipped container in desired chains", func() {
+				err := p.DoASGCycle()
+				Expect(err).NotTo(HaveOccurred())
+				_, desiredChains := fakeEnforcer.CleanChainsMatchingArgsForCall(0)
+				Expect(desiredChains).To(Equal([]enforcer.LiveChain{
+					{Table: "filter", Name: "asg-1234"},
+					{Table: "filter", Name: "asg-3456"},
+				}))
+			})
+		})
+
 		Context("when the enforcer errors", func() {
 			BeforeEach(func() {
-				// set up an initial successful cycle to create the cache of container to asg mappings
-				// fakeEnforcer.EnforceRulesAndChainStub = func(chain enforcer.RulesWithChain) (string, error) {
-				// 	return fmt.Sprintf("%s-with-suffix", chain.Chain.Name), nil
-				// }
 				err := p.DoASGCycle()
 				Expect(err).ToNot(HaveOccurred())
 
@@ -965,6 +995,21 @@ var _ = Describe("Single Poll Cycle", func() {
 				chain := fakeEnforcer.CleanupChainArgsForCall(0)
 				Expect(chain.Name).To(Equal("asg-b6259c4829b649dd739c"))
 				Expect(chain.Table).To(Equal(enforcer.FilterTable))
+			})
+
+			Context("after a successful DoASGCycle", func() {
+				BeforeEach(func() {
+					err := p.DoASGCycle()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(p.CurrentlyAppliedChainNames()).To(ConsistOf("asg-1234", "asg-2345", "asg-3456"))
+				})
+
+				It("removes the chain from CurrentlyAppliedChainNames using the correct map key", func() {
+					err := p.CleanupOrphanedASGsChains("3456")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(p.CurrentlyAppliedChainNames()).To(ConsistOf("asg-1234", "asg-2345"))
+					Expect(p.CurrentlyAppliedChainNames()).NotTo(ContainElement("asg-3456"))
+				})
 			})
 
 			Context("the enforcer returns an error", func() {

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/converger/converger_test.go
@@ -722,7 +722,7 @@ var _ = Describe("Single Poll Cycle", func() {
 		Context("when the enforcer errors", func() {
 			BeforeEach(func() {
 				err := p.DoASGCycle()
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				//simulate changes to rules, so enforcer will get called again
 				newFakeASGs := []enforcer.RulesWithChain{
@@ -967,13 +967,13 @@ var _ = Describe("Single Poll Cycle", func() {
 		Describe("SyncASGsForContainer", func() {
 			It("passes specified containers to the planner", func() {
 				err := p.SyncASGsForContainers("container-1", "container-2")
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(fakeASGPlanner.GetASGRulesAndChainsArgsForCall(0)).To(Equal([]string{"container-1", "container-2"}))
 			})
 
 			It("does not clean up orphans when syncing specific containers", func() {
 				err := p.SyncASGsForContainers("container-1", "container-2")
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(fakeEnforcer.CleanChainsMatchingCallCount()).To(Equal(0))
 			})
 		})
@@ -981,7 +981,7 @@ var _ = Describe("Single Poll Cycle", func() {
 		Describe("CleanupOrphanedASGsChains", func() {
 			It("cleans up asg chains with no desired chains", func() {
 				err := p.CleanupOrphanedASGsChains("some-container-handle")
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(fakeEnforcer.CleanupChainCallCount()).To(Equal(1))
 				chain := fakeEnforcer.CleanupChainArgsForCall(0)
 				Expect(chain.Name).To(Equal("asg-somecontainerhandle"))
@@ -990,7 +990,7 @@ var _ = Describe("Single Poll Cycle", func() {
 
 			It("cleans up asg chains for check container", func() {
 				err := p.CleanupOrphanedASGsChains("check-b6259c48-29b6-49dd-739c-2a4418fd137c")
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(fakeEnforcer.CleanupChainCallCount()).To(Equal(1))
 				chain := fakeEnforcer.CleanupChainArgsForCall(0)
 				Expect(chain.Name).To(Equal("asg-b6259c4829b649dd739c"))
@@ -1000,13 +1000,13 @@ var _ = Describe("Single Poll Cycle", func() {
 			Context("after a successful DoASGCycle", func() {
 				BeforeEach(func() {
 					err := p.DoASGCycle()
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 					Expect(p.CurrentlyAppliedChainNames()).To(ConsistOf("asg-1234", "asg-2345", "asg-3456"))
 				})
 
 				It("removes the chain from CurrentlyAppliedChainNames using the correct map key", func() {
 					err := p.CleanupOrphanedASGsChains("3456")
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 					Expect(p.CurrentlyAppliedChainNames()).To(ConsistOf("asg-1234", "asg-2345"))
 					Expect(p.CurrentlyAppliedChainNames()).NotTo(ContainElement("asg-3456"))
 				})

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer.go
@@ -341,7 +341,11 @@ func (e *Enforcer) replaceChainRules(logger lager.Logger, c Chain, rulesSpec []r
 	candidateName := e.candidateChainName(c.Name)
 	originalChainJumpExists, err := e.iptables.Exists(c.Table, c.ParentChain, rules.IPTablesRule{"-j", c.Name})
 	if err != nil {
-		if parentReady, _ := e.iptables.ChainExists(c.Table, c.ParentChain); !parentReady {
+		parentReady, chainErr := e.iptables.ChainExists(c.Table, c.ParentChain)
+		if chainErr != nil {
+			return chainErr
+		}
+		if !parentReady {
 			logger.Info("parent-chain-not-ready", lager.Data{"parent": c.ParentChain, "error": err.Error()})
 			return &ParentChainNotReadyErr{ParentChain: c.ParentChain}
 		}
@@ -349,7 +353,11 @@ func (e *Enforcer) replaceChainRules(logger lager.Logger, c Chain, rulesSpec []r
 	}
 	candidateChainJumpExists, err := e.iptables.Exists(c.Table, c.ParentChain, rules.IPTablesRule{"-j", candidateName})
 	if err != nil {
-		if parentReady, _ := e.iptables.ChainExists(c.Table, c.ParentChain); !parentReady {
+		parentReady, chainErr := e.iptables.ChainExists(c.Table, c.ParentChain)
+		if chainErr != nil {
+			return chainErr
+		}
+		if !parentReady {
 			logger.Info("parent-chain-not-ready", lager.Data{"parent": c.ParentChain, "error": err.Error()})
 			return &ParentChainNotReadyErr{ParentChain: c.ParentChain}
 		}

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer.go
@@ -18,6 +18,7 @@ const (
 	ASGChainRegex          = `^c?asg-[A-Za-z0-9]+`
 	ContainerPrefixToStrip = `check-`
 	JumpRuleRegex          = `-A\s+%s\s+.*-[gj]\s+([^\s]+)`
+	chainAlreadyExistsMsg  = "chain already exists"
 )
 
 type Timestamper struct{}
@@ -107,6 +108,14 @@ type CleanupErr struct {
 
 func (e *CleanupErr) Error() string {
 	return fmt.Sprintf("cleaning up: %s", e.Err)
+}
+
+type ParentChainNotReadyErr struct {
+	ParentChain string
+}
+
+func (e *ParentChainNotReadyErr) Error() string {
+	return fmt.Sprintf("parent chain not ready: %s", e.ParentChain)
 }
 
 func (r *RulesWithChain) Equals(other RulesWithChain) bool {
@@ -230,6 +239,10 @@ func (e *Enforcer) EnforceOnChain(c Chain, rulesSpec []rules.IPTablesRule) (stri
 
 	err := e.replaceChainRules(logger, c, rulesSpec)
 	if err != nil {
+		if _, ok := err.(*ParentChainNotReadyErr); ok {
+			logger.Info("skipping-asg-enforcement", lager.Data{"chain": c.Name, "reason": err.Error()})
+			return "", err
+		}
 		logger.Error("replace-chain", err)
 		return "", err
 	}
@@ -249,10 +262,27 @@ func (e *Enforcer) EnforceOnChain(c Chain, rulesSpec []rules.IPTablesRule) (stri
 func (e *Enforcer) enforce(logger lager.Logger, table string, parentChain string, chainName string, rulespec ...rules.IPTablesRule) error {
 	logger.Debug("create-chain", lager.Data{"chain": chainName, "table": table})
 
+	chainPreExisted := false
 	err := e.iptables.NewChain(table, chainName)
 	if err != nil {
-		logger.Error("create-chain", err)
-		return fmt.Errorf("creating chain: %s", err)
+		// Prefer checking iptables directly over string-matching the error, since error
+		// message casing can vary across iptables versions. Fall back to the constant if
+		// ChainExists itself errors.
+		chainExists, chainExistsErr := e.iptables.ChainExists(table, chainName)
+		if chainExistsErr != nil {
+			chainExists = strings.Contains(strings.ToLower(err.Error()), chainAlreadyExistsMsg)
+		}
+		if chainExists {
+			logger.Info("chain-exists-flushing", lager.Data{"chain": chainName, "table": table})
+			if clearErr := e.iptables.ClearChain(table, chainName); clearErr != nil {
+				logger.Error("clear-existing-chain", clearErr)
+				return fmt.Errorf("clearing existing chain %s: %s", chainName, clearErr)
+			}
+			chainPreExisted = true
+		} else {
+			logger.Error("create-chain", err)
+			return fmt.Errorf("creating chain: %s", err)
+		}
 	}
 
 	if e.conf.DisableContainerNetworkPolicy {
@@ -270,15 +300,20 @@ func (e *Enforcer) enforce(logger lager.Logger, table string, parentChain string
 		}
 	}
 
-	logger.Debug("insert-chain", lager.Data{"parent-chain": parentChain, "table": table, "index": 1, "rule": rules.IPTablesRule{"-j", chainName}})
-	err = e.iptables.BulkInsert(table, parentChain, 1, rules.IPTablesRule{"-j", chainName})
-	if err != nil {
-		logger.Error("insert-chain", err)
-		delErr := e.deleteChain(logger, LiveChain{Table: table, Name: chainName}, "")
-		if delErr != nil {
-			logger.Error("cleanup-failed-insert", delErr)
+	// Skip inserting the jump rule when the chain pre-existed: BulkInsert uses
+	// iptables-restore --noflush with -I (insert), which is additive and would create
+	// a duplicate jump rule in the parent chain.
+	if !chainPreExisted {
+		logger.Debug("insert-chain", lager.Data{"parent-chain": parentChain, "table": table, "index": 1, "rule": rules.IPTablesRule{"-j", chainName}})
+		err = e.iptables.BulkInsert(table, parentChain, 1, rules.IPTablesRule{"-j", chainName})
+		if err != nil {
+			logger.Error("insert-chain", err)
+			delErr := e.deleteChain(logger, LiveChain{Table: table, Name: chainName}, "")
+			if delErr != nil {
+				logger.Error("cleanup-failed-insert", delErr)
+			}
+			return fmt.Errorf("inserting chain: %s", err)
 		}
-		return fmt.Errorf("inserting chain: %s", err)
 	}
 
 	logger.Debug("bulk-append", lager.Data{"chain": chainName, "table": table, "rules": rulespec})
@@ -304,8 +339,22 @@ func (e *Enforcer) replaceChainRules(logger lager.Logger, c Chain, rulesSpec []r
 	logger.Debug("replace-chain", lager.Data{"chain": c.Name, "table": c.Table, "rulesSpec": rulesSpec})
 
 	candidateName := e.candidateChainName(c.Name)
-	originalChainJumpExists, _ := e.iptables.Exists(c.Table, c.ParentChain, rules.IPTablesRule{"-j", c.Name})
-	candidateChainJumpExists, _ := e.iptables.Exists(c.Table, c.ParentChain, rules.IPTablesRule{"-j", candidateName})
+	originalChainJumpExists, err := e.iptables.Exists(c.Table, c.ParentChain, rules.IPTablesRule{"-j", c.Name})
+	if err != nil {
+		if parentReady, _ := e.iptables.ChainExists(c.Table, c.ParentChain); !parentReady {
+			logger.Info("parent-chain-not-ready", lager.Data{"parent": c.ParentChain, "error": err.Error()})
+			return &ParentChainNotReadyErr{ParentChain: c.ParentChain}
+		}
+		originalChainJumpExists = false
+	}
+	candidateChainJumpExists, err := e.iptables.Exists(c.Table, c.ParentChain, rules.IPTablesRule{"-j", candidateName})
+	if err != nil {
+		if parentReady, _ := e.iptables.ChainExists(c.Table, c.ParentChain); !parentReady {
+			logger.Info("parent-chain-not-ready", lager.Data{"parent": c.ParentChain, "error": err.Error()})
+			return &ParentChainNotReadyErr{ParentChain: c.ParentChain}
+		}
+		candidateChainJumpExists = false
+	}
 
 	logger.Debug("replace-chain-exists", lager.Data{"original": originalChainJumpExists, "candidate": candidateChainJumpExists})
 	if !originalChainJumpExists && !candidateChainJumpExists {
@@ -327,8 +376,7 @@ func (e *Enforcer) replaceChainRules(logger lager.Logger, c Chain, rulesSpec []r
 		}
 	}
 
-	err := e.enforce(logger, c.Table, c.ParentChain, candidateName, rulesSpec...)
-
+	err = e.enforce(logger, c.Table, c.ParentChain, candidateName, rulesSpec...)
 	if err != nil {
 		return err
 	}

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer.go
@@ -371,11 +371,23 @@ func (e *Enforcer) replaceChainRules(logger lager.Logger, c Chain, rulesSpec []r
 
 	if candidateChainJumpExists {
 		if originalChainJumpExists {
-			err := e.cleanupOldChain(e.Logger, LiveChain{Table: c.Table, Name: candidateName}, c.ParentChain, "")
+			logger.Debug("replace-chain-rename-candidate-recovery", lager.Data{"chain": c.Name, "table": c.Table})
+			err := e.cleanupOldChain(e.Logger, LiveChain{Table: c.Table, Name: c.Name}, c.ParentChain, "")
+			if err != nil {
+				return err
+			}
+			err = e.iptables.RenameChain(c.Table, candidateName, c.Name)
 			if err != nil {
 				return err
 			}
 		} else {
+			originalChainExists, _ := e.iptables.ChainExists(c.Table, c.Name)
+			if originalChainExists {
+				logger.Debug("cleanup-orphaned-original-chain", lager.Data{"chain": c.Name, "table": c.Table})
+				e.iptables.ClearChain(c.Table, c.Name)
+				e.iptables.DeleteChain(c.Table, c.Name)
+			}
+
 			logger.Debug("replace-chain-rename-original", lager.Data{"chain": c.Name, "table": c.Table})
 			err := e.iptables.RenameChain(c.Table, candidateName, c.Name)
 			if err != nil {

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
@@ -245,6 +245,88 @@ var _ = Describe("Enforcer", func() {
 				})
 			})
 
+			Context("when Exists check for original chain returns an error", func() {
+				BeforeEach(func() {
+					iptables.ExistsStub = func(table string, parentChan string, ruleSpec rules.IPTablesRule) (bool, error) {
+						if ruleSpec[1] == "asg-handle" {
+							return false, errors.New("parent chain missing")
+						}
+						return false, nil
+					}
+				})
+
+				Context("when parent chain does not exist", func() {
+					BeforeEach(func() {
+						iptables.ChainExistsReturns(false, nil)
+					})
+
+					It("returns a ParentChainNotReadyErr", func() {
+						Expect(enforceErr).To(HaveOccurred())
+						_, ok := enforceErr.(*enforcer.ParentChainNotReadyErr)
+						Expect(ok).To(BeTrue())
+						Expect(enforceErr).To(MatchError("parent chain not ready: some-chain"))
+						Expect(iptables.NewChainCallCount()).To(Equal(0))
+					})
+				})
+
+				Context("when parent chain exists", func() {
+					BeforeEach(func() {
+						iptables.ChainExistsReturns(true, nil)
+					})
+
+					It("treats the jump as non-existent and proceeds to enforce", func() {
+						Expect(enforceErr).NotTo(HaveOccurred())
+						Expect(iptables.NewChainCallCount()).To(Equal(1))
+						table, chain := iptables.NewChainArgsForCall(0)
+						Expect(table).To(Equal("some-table"))
+						Expect(chain).To(Equal("asg-handle"))
+					})
+				})
+			})
+
+			Context("when Exists check for candidate chain returns an error", func() {
+				BeforeEach(func() {
+					iptables.ExistsStub = func(table string, parentChan string, ruleSpec rules.IPTablesRule) (bool, error) {
+						switch ruleSpec[1] {
+						case "asg-handle":
+							return true, nil
+						case "casg-handle":
+							return false, errors.New("parent chain missing")
+						default:
+							return false, errors.New("unexpected Exists call")
+						}
+					}
+				})
+
+				Context("when parent chain does not exist", func() {
+					BeforeEach(func() {
+						iptables.ChainExistsReturns(false, nil)
+					})
+
+					It("returns a ParentChainNotReadyErr", func() {
+						Expect(enforceErr).To(HaveOccurred())
+						_, ok := enforceErr.(*enforcer.ParentChainNotReadyErr)
+						Expect(ok).To(BeTrue())
+						Expect(enforceErr).To(MatchError("parent chain not ready: some-chain"))
+						Expect(iptables.NewChainCallCount()).To(Equal(0))
+					})
+				})
+
+				Context("when parent chain exists", func() {
+					BeforeEach(func() {
+						iptables.ChainExistsReturns(true, nil)
+					})
+
+					It("treats the candidate jump as non-existent and proceeds to enforce with candidate", func() {
+						Expect(enforceErr).NotTo(HaveOccurred())
+						Expect(iptables.NewChainCallCount()).To(Equal(1))
+						table, chain := iptables.NewChainArgsForCall(0)
+						Expect(table).To(Equal("some-table"))
+						Expect(chain).To(Equal("casg-handle"))
+					})
+				})
+			})
+
 			Context("when parent chain does not have candidate nor original chain", func() {
 				BeforeEach(func() {
 					iptables.ExistsStub = func(table string, parentChan string, ruleSpec rules.IPTablesRule) (bool, error) {
@@ -274,6 +356,47 @@ var _ = Describe("Enforcer", func() {
 				It("does not apply rename or clean up anything", func() {
 					Expect(iptables.RenameChainCallCount()).To(Equal(0))
 					Expect(iptables.ClearChainCallCount()).To(Equal(0))
+				})
+			})
+
+			Context("when NewChain returns 'chain already exists'", func() {
+				BeforeEach(func() {
+					iptables.ExistsStub = func(table string, parentChan string, ruleSpec rules.IPTablesRule) (bool, error) {
+						return false, nil
+					}
+					iptables.NewChainReturns(errors.New("chain already exists"))
+					iptables.ChainExistsReturns(true, nil)
+				})
+
+				It("flushes the existing chain and proceeds without inserting a duplicate jump rule", func() {
+					Expect(enforceErr).NotTo(HaveOccurred())
+					Expect(iptables.ClearChainCallCount()).To(BeNumerically(">=", 1))
+					table, chain := iptables.ClearChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(chain).To(Equal("asg-handle"))
+					// BulkInsert must NOT be called when chain pre-existed to avoid duplicate jump rules
+					Expect(iptables.BulkInsertCallCount()).To(Equal(0))
+				})
+
+				Context("when ClearChain fails", func() {
+					BeforeEach(func() {
+						iptables.ClearChainReturns(errors.New("potato"))
+					})
+
+					It("returns an error", func() {
+						Expect(enforceErr).To(MatchError("clearing existing chain asg-handle: potato"))
+					})
+				})
+
+				Context("when ChainExists returns an error (fallback to error string matching)", func() {
+					BeforeEach(func() {
+						iptables.ChainExistsReturns(false, errors.New("iptables unavailable"))
+					})
+
+					It("flushes the existing chain via string-match fallback", func() {
+						Expect(enforceErr).NotTo(HaveOccurred())
+						Expect(iptables.ClearChainCallCount()).To(BeNumerically(">=", 1))
+					})
 				})
 			})
 

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
@@ -1056,7 +1056,7 @@ var _ = Describe("Enforcer", func() {
 		It("deletes orphaned chains on filter table", func() {
 			deletedChains, err := ruleEnforcer.CleanChainsMatching(regexp.MustCompile(enforcer.ASGChainRegex), desiredChains)
 
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(iptables.ListChainsCallCount()).To(Equal(1))
 
 			Expect(iptables.ListChainsArgsForCall(0)).To(Equal("filter"))
@@ -1072,16 +1072,16 @@ var _ = Describe("Enforcer", func() {
 			By("not deleting desired chains", func() {
 				for i := 0; i < iptables.DeleteCallCount(); i++ {
 					_, chain := iptables.DeleteChainArgsForCall(i)
-					Expect(chain).ToNot(BeElementOf([]string{"asg-aaaaa01645708469990518", "asg-bbbbb01645708469990518", "casg-ddddd01645708469990518"}))
+					Expect(chain).NotTo(BeElementOf([]string{"asg-aaaaa01645708469990518", "asg-bbbbb01645708469990518", "casg-ddddd01645708469990518"}))
 				}
-				Expect(deletedChains).ToNot(ContainElements([]string{"asg-aaaaa01645708469990518", "asg-bbbbb01645708469990518", "casg-ddddd01645708469990518"}))
+				Expect(deletedChains).NotTo(ContainElements([]string{"asg-aaaaa01645708469990518", "asg-bbbbb01645708469990518", "casg-ddddd01645708469990518"}))
 			})
 			By("not deleting chains outside the scope of our regex", func() {
 				for i := 0; i < iptables.DeleteCallCount(); i++ {
 					_, chain := iptables.DeleteChainArgsForCall(i)
-					Expect(chain).ToNot(BeElementOf([]string{"donttouchme", "reallydonttouchme"}))
+					Expect(chain).NotTo(BeElementOf([]string{"donttouchme", "reallydonttouchme"}))
 				}
-				Expect(deletedChains).ToNot(ContainElements([]string{"donttouchme", "reallydonttouchme"}))
+				Expect(deletedChains).NotTo(ContainElements([]string{"donttouchme", "reallydonttouchme"}))
 			})
 			By("deleting target chains that the orphan jumps to", func() {
 				table, chain1 := iptables.DeleteChainArgsForCall(1)
@@ -1096,7 +1096,7 @@ var _ = Describe("Enforcer", func() {
 		Context("when there are no desired chains", func() {
 			It("deletes alls chains on filter table matching pattern", func() {
 				deletedChains, err := ruleEnforcer.CleanChainsMatching(regexp.MustCompile(enforcer.ASGChainRegex), []enforcer.LiveChain{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(deletedChains).To(ConsistOf([]enforcer.LiveChain{
 					{Table: "filter", Name: "asg-bbbbb01645708469990518"},
 					{Table: "filter", Name: "asg-ccccc01645708469990518"},

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
@@ -327,6 +327,88 @@ var _ = Describe("Enforcer", func() {
 				})
 			})
 
+			Context("when Exists check for original chain returns an error", func() {
+				BeforeEach(func() {
+					iptables.ExistsStub = func(table string, parentChan string, ruleSpec rules.IPTablesRule) (bool, error) {
+						if ruleSpec[1] == "asg-handle" {
+							return false, errors.New("parent chain missing")
+						}
+						return false, nil
+					}
+				})
+
+				Context("when parent chain does not exist", func() {
+					BeforeEach(func() {
+						iptables.ChainExistsReturns(false, nil)
+					})
+
+					It("returns a ParentChainNotReadyErr", func() {
+						Expect(enforceErr).To(HaveOccurred())
+						_, ok := enforceErr.(*enforcer.ParentChainNotReadyErr)
+						Expect(ok).To(BeTrue())
+						Expect(enforceErr).To(MatchError("parent chain not ready: some-chain"))
+						Expect(iptables.NewChainCallCount()).To(Equal(0))
+					})
+				})
+
+				Context("when parent chain exists", func() {
+					BeforeEach(func() {
+						iptables.ChainExistsReturns(true, nil)
+					})
+
+					It("treats the jump as non-existent and proceeds to enforce", func() {
+						Expect(enforceErr).NotTo(HaveOccurred())
+						Expect(iptables.NewChainCallCount()).To(Equal(1))
+						table, chain := iptables.NewChainArgsForCall(0)
+						Expect(table).To(Equal("some-table"))
+						Expect(chain).To(Equal("asg-handle"))
+					})
+				})
+			})
+
+			Context("when Exists check for candidate chain returns an error", func() {
+				BeforeEach(func() {
+					iptables.ExistsStub = func(table string, parentChan string, ruleSpec rules.IPTablesRule) (bool, error) {
+						switch ruleSpec[1] {
+						case "asg-handle":
+							return true, nil
+						case "casg-handle":
+							return false, errors.New("parent chain missing")
+						default:
+							return false, errors.New("unexpected Exists call")
+						}
+					}
+				})
+
+				Context("when parent chain does not exist", func() {
+					BeforeEach(func() {
+						iptables.ChainExistsReturns(false, nil)
+					})
+
+					It("returns a ParentChainNotReadyErr", func() {
+						Expect(enforceErr).To(HaveOccurred())
+						_, ok := enforceErr.(*enforcer.ParentChainNotReadyErr)
+						Expect(ok).To(BeTrue())
+						Expect(enforceErr).To(MatchError("parent chain not ready: some-chain"))
+						Expect(iptables.NewChainCallCount()).To(Equal(0))
+					})
+				})
+
+				Context("when parent chain exists", func() {
+					BeforeEach(func() {
+						iptables.ChainExistsReturns(true, nil)
+					})
+
+					It("treats the candidate jump as non-existent and proceeds to enforce with candidate", func() {
+						Expect(enforceErr).NotTo(HaveOccurred())
+						Expect(iptables.NewChainCallCount()).To(Equal(1))
+						table, chain := iptables.NewChainArgsForCall(0)
+						Expect(table).To(Equal("some-table"))
+						Expect(chain).To(Equal("casg-handle"))
+					})
+				})
+			})
+
 			Context("when parent chain does not have candidate nor original chain", func() {
 				BeforeEach(func() {
 					iptables.ExistsStub = func(table string, parentChan string, ruleSpec rules.IPTablesRule) (bool, error) {

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/enforcer/enforcer_test.go
@@ -83,6 +83,36 @@ var _ = Describe("Enforcer", func() {
 					Expect(newChain).To(Equal("asg-handle"))
 				})
 
+				Context("when orphaned original chain exists", func() {
+					BeforeEach(func() {
+						iptables.ChainExistsStub = func(table, chain string) (bool, error) {
+							if chain == "asg-handle" {
+								return true, nil
+							}
+							return false, nil
+						}
+					})
+
+					It("clears and deletes the orphaned original chain before renaming", func() {
+						Expect(enforceErr).NotTo(HaveOccurred())
+						Expect(iptables.ClearChainCallCount()).To(Equal(2))
+						table, chain := iptables.ClearChainArgsForCall(0)
+						Expect(table).To(Equal("some-table"))
+						Expect(chain).To(Equal("asg-handle"))
+
+						Expect(iptables.DeleteChainCallCount()).To(Equal(2))
+						table, chain = iptables.DeleteChainArgsForCall(0)
+						Expect(table).To(Equal("some-table"))
+						Expect(chain).To(Equal("asg-handle"))
+
+						Expect(iptables.RenameChainCallCount()).To(Equal(2))
+						table, oldChain, newChain := iptables.RenameChainArgsForCall(0)
+						Expect(table).To(Equal("some-table"))
+						Expect(oldChain).To(Equal("casg-handle"))
+						Expect(newChain).To(Equal("asg-handle"))
+					})
+				})
+
 				Context("when renaming candidate chain fails", func() {
 					BeforeEach(func() {
 						iptables.RenameChainReturns(errors.New("failed-to-rename"))
@@ -113,18 +143,24 @@ var _ = Describe("Enforcer", func() {
 					}
 				})
 
-				It("deletes candidate chain", func() {
+				It("deletes original chain and renames candidate chain", func() {
 					Expect(iptables.ClearChainCallCount()).To(Equal(2))
 					table, chain := iptables.ClearChainArgsForCall(0)
 					Expect(table).To(Equal("some-table"))
-					Expect(chain).To(Equal("casg-handle"))
+					Expect(chain).To(Equal("asg-handle"))
 					Expect(iptables.DeleteChainCallCount()).To(Equal(2))
 					table, chain = iptables.DeleteChainArgsForCall(0)
 					Expect(table).To(Equal("some-table"))
-					Expect(chain).To(Equal("casg-handle"))
+					Expect(chain).To(Equal("asg-handle"))
+
+					Expect(iptables.RenameChainCallCount()).To(Equal(2))
+					table, oldChain, newChain := iptables.RenameChainArgsForCall(0)
+					Expect(table).To(Equal("some-table"))
+					Expect(oldChain).To(Equal("casg-handle"))
+					Expect(newChain).To(Equal("asg-handle"))
 				})
 
-				Context("when deleting candidate chain fails", func() {
+				Context("when deleting original chain fails", func() {
 					BeforeEach(func() {
 						iptables.DeleteReturns(errors.New("failed-to-delete"))
 					})

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/integration/linux/linux_suite_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/integration/linux/linux_suite_test.go
@@ -59,30 +59,30 @@ func TestIntegration(t *testing.T) {
 
 func createDummyInterface(interfaceName, ipAddress string) {
 	err := netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: interfaceName}})
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	link, err := netlink.LinkByName(interfaceName)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	addr, err := netlink.ParseAddr(ipAddress + "/32")
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = netlink.AddrAdd(link, addr)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 }
 
 func removeDummyInterface(interfaceName, ipAddress string) {
 	link, err := netlink.LinkByName(interfaceName)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	addr, err := netlink.ParseAddr(ipAddress + "/32")
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = netlink.AddrDel(link, addr)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	err = netlink.LinkDel(link)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/integration/linux/linux_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/integration/linux/linux_test.go
@@ -406,11 +406,11 @@ var _ = Describe("VXLAN Policy Agent", func() {
 
 					It("cleans up the parent asg keeping the reject rule", func() {
 						Eventually(iptablesFilterRules, "4s", "1s").ShouldNot(MatchRegexp(`-A netout--some-handle -m state --state RELATED,ESTABLISHED -j ACCEPT`))
-						Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -p tcp -m state --state INVALID -j DROP`))
+						Expect(iptablesFilterRules()).NotTo(MatchRegexp(`-A netout--some-handle -p tcp -m state --state INVALID -j DROP`))
 						Expect(iptablesFilterRules()).To(MatchRegexp(`-A netout--some-handle -j asg-.+`))
-						Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -p icmp -m iprange --dst-range 0.0.0.0-255.255.255.255 -m icmp --icmp-type 0/0 -j ACCEPT`))
-						Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -m iprange --dst-range 11.0.0.0-169.253.255.255 -j ACCEPT`))
-						Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -m iprange --dst-range 0.0.0.0-9.255.255.255 -j ACCEPT`))
+						Expect(iptablesFilterRules()).NotTo(MatchRegexp(`-A netout--some-handle -p icmp -m iprange --dst-range 0.0.0.0-255.255.255.255 -m icmp --icmp-type 0/0 -j ACCEPT`))
+						Expect(iptablesFilterRules()).NotTo(MatchRegexp(`-A netout--some-handle -m iprange --dst-range 11.0.0.0-169.253.255.255 -j ACCEPT`))
+						Expect(iptablesFilterRules()).NotTo(MatchRegexp(`-A netout--some-handle -m iprange --dst-range 0.0.0.0-9.255.255.255 -j ACCEPT`))
 						Expect(iptablesFilterRules()).To(MatchRegexp(`-A netout--some-handle -j REJECT --reject-with icmp-port-unreachable`))
 					})
 
@@ -475,12 +475,12 @@ var _ = Describe("VXLAN Policy Agent", func() {
 								}).Should(Equal(http.StatusOK))
 
 								Eventually(iptablesFilterRules, "1s", "100ms").ShouldNot(MatchRegexp(`-A asg-.+ -m state --state RELATED,ESTABLISHED -j ACCEPT`))
-								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A asg-.+ -p tcp -m state --state INVALID -j DROP`))
-								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -j asg-.+`))
-								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A asg-.+ -p icmp -m iprange --dst-range 0.0.0.0-255.255.255.255 -m icmp --icmp-type 0/0 -j ACCEPT`))
-								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A asg-.+ -m iprange --dst-range 11.0.0.0-169.253.255.255 -j ACCEPT`))
-								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A asg-.+ -m iprange --dst-range 0.0.0.0-9.255.255.255 -j ACCEPT`))
-								Expect(iptablesFilterRules()).ToNot(MatchRegexp(`-A asg-.+ -j REJECT --reject-with icmp-port-unreachable`))
+								Expect(iptablesFilterRules()).NotTo(MatchRegexp(`-A asg-.+ -p tcp -m state --state INVALID -j DROP`))
+								Expect(iptablesFilterRules()).NotTo(MatchRegexp(`-A netout--some-handle -j asg-.+`))
+								Expect(iptablesFilterRules()).NotTo(MatchRegexp(`-A asg-.+ -p icmp -m iprange --dst-range 0.0.0.0-255.255.255.255 -m icmp --icmp-type 0/0 -j ACCEPT`))
+								Expect(iptablesFilterRules()).NotTo(MatchRegexp(`-A asg-.+ -m iprange --dst-range 11.0.0.0-169.253.255.255 -j ACCEPT`))
+								Expect(iptablesFilterRules()).NotTo(MatchRegexp(`-A asg-.+ -m iprange --dst-range 0.0.0.0-9.255.255.255 -j ACCEPT`))
+								Expect(iptablesFilterRules()).NotTo(MatchRegexp(`-A asg-.+ -j REJECT --reject-with icmp-port-unreachable`))
 
 							})
 						})
@@ -724,12 +724,12 @@ var _ = Describe("VXLAN Policy Agent", func() {
 
 						It("cleans up the parent asg keeping the reject rule", func() {
 							Eventually(ip6tablesFilterRules, "4s", "1s").ShouldNot(MatchRegexp(`-A netout--some-handle -m state --state RELATED,ESTABLISHED -j ACCEPT`))
-							Expect(ip6tablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -p tcp -m state --state INVALID -j DROP`))
+							Expect(ip6tablesFilterRules()).NotTo(MatchRegexp(`-A netout--some-handle -p tcp -m state --state INVALID -j DROP`))
 							Expect(ip6tablesFilterRules()).To(MatchRegexp(`-A netout--some-handle -j asg-.+`))
-							Expect(ip6tablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -p ipv6-icmp -m iprange --dst-range 2000::-2999:: -m icmp6 --icmpv6-type 255/255 -j ACCEPT`))
-							Expect(ip6tablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -p ipv6-icmp -m iprange --dst-range 2001::-2001::ff -m icmp6 --icmpv6-type 0/0 -j ACCEPT`))
-							Expect(ip6tablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -m iprange --dst-range 2006::-2007:: -j ACCEPT`))
-							Expect(ip6tablesFilterRules()).ToNot(MatchRegexp(`-A netout--some-handle -m iprange --dst-range 2005::-2006:: -j ACCEPT`))
+							Expect(ip6tablesFilterRules()).NotTo(MatchRegexp(`-A netout--some-handle -p ipv6-icmp -m iprange --dst-range 2000::-2999:: -m icmp6 --icmpv6-type 255/255 -j ACCEPT`))
+							Expect(ip6tablesFilterRules()).NotTo(MatchRegexp(`-A netout--some-handle -p ipv6-icmp -m iprange --dst-range 2001::-2001::ff -m icmp6 --icmpv6-type 0/0 -j ACCEPT`))
+							Expect(ip6tablesFilterRules()).NotTo(MatchRegexp(`-A netout--some-handle -m iprange --dst-range 2006::-2007:: -j ACCEPT`))
+							Expect(ip6tablesFilterRules()).NotTo(MatchRegexp(`-A netout--some-handle -m iprange --dst-range 2005::-2006:: -j ACCEPT`))
 							Expect(ip6tablesFilterRules()).To(MatchRegexp(`-A netout--some-handle -j REJECT --reject-with icmp6-port-unreachable`))
 						})
 

--- a/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner_linux_test.go
+++ b/src/code.cloudfoundry.org/vxlan-policy-agent/planner/planner_linux_test.go
@@ -817,7 +817,7 @@ var _ = Describe("Planner", func() {
 			Context("when only one container was specified", func() {
 				It("only gets security groups for the specified container", func() {
 					_, err := policyPlanner.GetASGRulesAndChains("container-id-1")
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 					Expect(policyClient.GetSecurityGroupsForSpaceCallCount()).To(Equal(1))
 					Expect(policyClient.GetSecurityGroupsForSpaceArgsForCall(0)).To(ConsistOf("some-space-guid"))
 				})


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
    Fixes multiple bugs in vxlan-policy-agent that caused spurious errors
    when creating or cleaning up ASG iptables chains:
    
    - Handle Exists() errors in replaceChainRules: distinguish 'parent chain
      does not exist' from 'no jump rule' and return ParentChainNotReadyErr
      instead of silently proceeding to the first-time creation path
    - Skip containers with ParentChainNotReadyErr in SyncASGsForContainers
      instead of accumulating them as errors
    - Flush-and-reuse chain on 'chain already exists' in enforce() to
      self-heal after VPA restarts or partial failures
    - Fix CleanupOrphanedASGsChains to look up the correct map key
      (map is keyed by parent chain name, not ASG chain name)
    - Guard desiredChains against empty chain names from failed enforcement
    


Backward Compatibility
---------------
Breaking Change? no