### PR TITLE
Add mysql-8.4 support to create-docker-container.bash

### DIFF
--- a/scripts/create-docker-container.bash
+++ b/scripts/create-docker-container.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# @AI-Generated
+# Generated in whole or in part by Cursor with a mix of different LLM models (Auto select mode)
+# Description:
+# 2026-05-21: Add mysql-8.4 support (TNZ-99882)
 
 set -eu
 set -o pipefail
@@ -17,6 +21,9 @@ fi
 CONTAINER_NAME="$REPO_NAME-$DB-docker-container"
 if [[ "${DB}" == "mysql" ]] || [[ "${DB}" == "mysql-8.0" ]]; then
   IMAGE="cloudfoundry/tas-runtime-mysql-8.0"
+  DB="mysql"
+elif [[ "${DB}" == "mysql-8.4" ]]; then
+  IMAGE="cloudfoundry/tas-runtime-mysql-8.4"
   DB="mysql"
 elif [[ "${DB}" == "mysql-5.7" ]]; then
   IMAGE="cloudfoundry/tas-runtime-mysql-5.7"


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Adds a mysql-8.4 case using the docker.io/ prefix and ${TAG} suffix pattern, mapping to cloudfoundry/tas-runtime-mysql-8.4.

TNZ-99882
ai-assisted=yes

Backward Compatibility
---------------
Breaking Change? No