### PR TITLE
Retry netlink dump-interrupted errors in isRetryableError

### DIFF
--- a/src/code.cloudfoundry.org/lib/common/common.go
+++ b/src/code.cloudfoundry.org/lib/common/common.go
@@ -1,12 +1,15 @@
 package common
 
 import (
-	"code.cloudfoundry.org/lager/v3/lagerflags"
+	"errors"
 	"fmt"
-	"github.com/pkg/errors"
 	"math"
 	"net"
 	"time"
+
+	"code.cloudfoundry.org/lager/v3/lagerflags"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 type temporaryError interface {
@@ -52,12 +55,13 @@ func RetryWithBackoff[T any](interval int, maxRetries int, fn RetryableFunc[T]) 
 }
 
 func isRetryableError(err error) bool {
+	if errors.Is(err, netlink.ErrDumpInterrupted) || errors.Is(err, unix.EINTR) {
+		return true
+	}
 	var tempErr temporaryError
-
 	if errors.As(err, &tempErr) {
 		return tempErr.Temporary()
 	}
-
 	return false
 }
 

--- a/src/code.cloudfoundry.org/lib/common/common.go
+++ b/src/code.cloudfoundry.org/lib/common/common.go
@@ -1,15 +1,14 @@
 package common
 
 import (
-	"errors"
+	"code.cloudfoundry.org/lager/v3/lagerflags"
 	"fmt"
+	"github.com/pkg/errors"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 	"math"
 	"net"
 	"time"
-
-	"code.cloudfoundry.org/lager/v3/lagerflags"
-	"github.com/vishvananda/netlink"
-	"golang.org/x/sys/unix"
 )
 
 type temporaryError interface {

--- a/src/code.cloudfoundry.org/lib/interfacelookup/interface_name_lookup_test.go
+++ b/src/code.cloudfoundry.org/lib/interfacelookup/interface_name_lookup_test.go
@@ -116,6 +116,24 @@ var _ = Describe("InterfaceNameLookup", func() {
 					Expect(netlinkAdapter.LinkListCallCount()).To(Equal(4))
 				})
 			})
+
+			Context("and the error is netlink ErrDumpInterrupted (does not implement Temporary()) the first 3 tries", func() {
+				BeforeEach(func() {
+					netlinkAdapter.LinkListReturnsOnCall(0, nil, netlink.ErrDumpInterrupted)
+					netlinkAdapter.LinkListReturnsOnCall(1, nil, netlink.ErrDumpInterrupted)
+					netlinkAdapter.LinkListReturnsOnCall(2, nil, netlink.ErrDumpInterrupted)
+					netlinkAdapter.LinkListReturnsOnCall(3, []netlink.Link{
+						netlinkLinkEth0,
+						netlinkLinkEth1,
+					}, nil)
+				})
+
+				It("succeeds after 4 retries", func() {
+					_, err := interfaceNameLookup.GetNameFromIP("10.0.0.0")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(netlinkAdapter.LinkListCallCount()).To(Equal(4))
+				})
+			})
 		})
 
 		Context("when it fails to fetch the AddrList", func() {


### PR DESCRIPTION
> **Note:** This PR was authored with AI assistance (Claude Code).

## Problem

`vishvananda/netlink` v1.3.1 changed how dump-interrupted netlink responses are surfaced: instead of returning `unix.EINTR` directly, the library now returns a custom `ErrDumpInterrupted` sentinel that does **not** implement the `Temporary() bool` interface. The existing `isRetryableError` predicate in `lib/common` keyed off `Temporary()`, so it silently stopped retrying interrupted dumps after the version bump.

This broke retry coverage on the `InterfaceNameLookup` path (used by `cni-wrapper-plugin` and `vxlan-policy-agent`) without any test failures — the unit tests were injecting raw `unix.EINTR` (`unix.Errno`), which still implements `Temporary()`, masking the regression.

## Fix

- Update `isRetryableError` to check `errors.Is(err, netlink.ErrDumpInterrupted)` and `errors.Is(err, unix.EINTR)` before falling back to the `Temporary()` interface check.
- Add a regression test that injects the real `netlink.ErrDumpInterrupted` sentinel so the fix is locked in.

## Testing

Unit tests pass in the CI docker environment (`lib/common` 5/5, `lib/interfacelookup` 8/8 including the new test).