### PR TITLE
fix: explicit nil return in mainWithError to satisfy staticcheck SA4023

### DIFF
--- a/src/code.cloudfoundry.org/silk/cmd/silk-daemon/main.go
+++ b/src/code.cloudfoundry.org/silk/cmd/silk-daemon/main.go
@@ -229,7 +229,10 @@ func mainWithError() error {
 	monitor := ifrit.Invoke(sigmon.New(group))
 
 	err = <-monitor.Wait()
-	return err
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func acquireLease(logger lager.Logger, client *controller.Client, vtepConfigCreator *vtep.ConfigCreator, vtepFactory *vtep.Factory, cfg config.Config) (controller.Lease, error) {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
staticcheck 2026.2rc1 infers mainWithError never returns nil via inter-procedural analysis of the ifrit/grouper chain. Make the nil return explicit so the check passes.


Backward Compatibility
---------------
Breaking Change? No