### PR TITLE
Disable checksum offloading on silk-vtep when tile setting is enabled

### DIFF
--- a/jobs/silk-daemon/templates/post-start.erb
+++ b/jobs/silk-daemon/templates/post-start.erb
@@ -6,5 +6,12 @@ source /var/vcap/packages/silk-ctl-utils/ctl_util.sh
 
 URL=127.0.0.1:<%= p("listen_port") %>
 TIMEOUT=20
-exit $(wait_for_server_to_become_healthy "${URL}" "${TIMEOUT}")
+wait_for_server_to_become_healthy "${URL}" "${TIMEOUT}"
+exit_code=$?
+
+<% if p('disable_checksum_offloading') %>
+/usr/sbin/ethtool -K silk-vtep tx-checksum-ip-generic off
+<% end %>
+
+exit $exit_code
 <% end %>

--- a/spec/silk-daemon/post_start_spec.rb
+++ b/spec/silk-daemon/post_start_spec.rb
@@ -1,0 +1,44 @@
+require 'rspec'
+require 'bosh/template/test'
+
+module Bosh::Template::Test
+  describe 'post-start.erb' do
+    describe 'template rendering' do
+      let(:release_path) { File.join(File.dirname(__FILE__), '../..') }
+      let(:release) { ReleaseDir.new(release_path) }
+      let(:job) { release.job('silk-daemon') }
+      let(:template) { job.template('bin/post-start') }
+
+      context 'when disable is false' do
+        context 'when disable_checksum_offloading is true' do
+          it 'disables tx-checksum-ip-generic on silk-vtep' do
+            rendered = template.render({'disable_checksum_offloading' => true})
+            expect(rendered).to include('ethtool -K silk-vtep tx-checksum-ip-generic off')
+          end
+        end
+
+        context 'when disable_checksum_offloading is false' do
+          it 'does not include an ethtool call for silk-vtep' do
+            rendered = template.render({'disable_checksum_offloading' => false})
+            expect(rendered).not_to include('ethtool -K silk-vtep')
+          end
+        end
+
+        context 'when disable_checksum_offloading is not set' do
+          it 'does not include an ethtool call for silk-vtep' do
+            rendered = template.render({})
+            expect(rendered).not_to include('ethtool -K silk-vtep')
+          end
+        end
+      end
+
+      context 'when disable is true' do
+        it 'renders an empty script body' do
+          rendered = template.render({'disable' => true})
+          expect(rendered).not_to include('ethtool')
+          expect(rendered).not_to include('wait_for_server')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The pre-start script only disabled tx-checksum-ip-generic on eth0, but silk-vtep is created by the daemon after pre-start runs. This caused corrupt inner TCP checksums on Geneve/VXLAN-encapsulated traffic, leading to silent packet drops and ~1s retransmission delays in C2C.

Backward Compatibility
---------------
Breaking Change? **No**
