### PR TITLE
fix: pin ifrit to v0.0.0-20260418191334-846868129986 (JIRA-1234)

### DIFF
--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -2,6 +2,9 @@ module code.cloudfoundry.org
 
 go 1.26.2
 
+// pin ifrit until https://github.com/tedsuo/ifrit/pull/48 is merged
+replace github.com/tedsuo/ifrit => github.com/tedsuo/ifrit v0.0.0-20260418191334-846868129986
+
 replace code.cloudfoundry.org/runtimeschema => code.cloudfoundry.org/runtimeschema v0.0.0-20180622181441-7dcd19348be6
 
 replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
@@ -33,7 +36,7 @@ require (
 	github.com/pivotal-cf-experimental/gomegamatchers v0.0.0-20180326192815-e36bfcc98c3a
 	github.com/pkg/errors v0.9.1
 	github.com/rubenv/sql-migrate v1.8.1
-	github.com/tedsuo/ifrit v0.0.0-20260813155221-94822c932811
+	github.com/tedsuo/ifrit v0.0.0-20260418191334-846868129986
 	github.com/tedsuo/rata v1.0.0
 	github.com/vishvananda/netlink v1.3.1
 	github.com/ziutek/utils v0.0.0-20190626152656-eb2a3b364d6c


### PR DESCRIPTION
## Summary

- Pins `github.com/tedsuo/ifrit` to `v0.0.0-20260418191334-846868129986` via a `replace` directive
- Prevents transitive upgrade to the newer pseudoversion while https://github.com/tedsuo/ifrit/pull/48 remains unmerged
- Matches the pattern already in place in `garden-runc-release`

Ticket: JIRA-1234

🤖 Generated with Claude Code